### PR TITLE
Several changes for better compatibility between PDKs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.spice
 *.csv
 *.osdi
+.DS_Store

--- a/AUTHORS
+++ b/AUTHORS
@@ -19,5 +19,4 @@ Steffen Reith
 Thorsten Knoll
 Tim Henkes
 Volker Muehlhaus
-
-
+Harald Pretl

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/IHP_testcases.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/IHP_testcases.sch
@@ -34,7 +34,7 @@ T {S-param} 1440 -710 0 0 0.8 0.8 {}
 C {devices/title.sym} 160 -30 0 0 {name=l5 author="Copyright 2023 IHP PDK Authors"}
 C {devices/launcher.sym} 90 -780 0 0 {name=h1
 descr="IHP-Open-PDK"
-url="https://github.com/KHermanUBB/IHP-Open-PDK/tree/main"}
+url="https://github.com/IHP-GmbH/IHP-Open-PDK/tree/main"}
 C {sg13g2_tests/dc_lv_nmos.sym} 180 -630 0 0 {name=x5}
 C {sg13g2_tests/dc_hv_nmos.sym} 180 -600 0 0 {name=x6}
 C {sg13g2_tests/dc_lv_pmos.sym} 180 -570 0 0 {name=x7}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/ac_lv_nmosrf.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/ac_lv_nmosrf.sch
@@ -105,14 +105,14 @@ C {devices/code_shown.sym} 1190 -310 0 0 {name=NGSPICE only_toplevel=true
 value="
 .param temp=27
 .control
-pre_osdi ./psp103_nqs.osdi
+* pre_osdi ./psp103_nqs.osdi
 save all 
 ac dec 1001 10meg 10000meg 
 let vd1 = abs(Vout1)
 let vd2 = abs(Vout2)
 meas ac Vout_1_5GHz find vd1 at=5000meg
 meas ac Vout_2_5GHz find vd2 at=5000meg
-write ../raw/ac_lv_nmosrf.raw
+write ac_lv_nmosrf.raw
 .endc
 "}
 C {devices/gnd.sym} 160 50 0 0 {name=l1 lab=GND}
@@ -124,7 +124,7 @@ C {devices/gnd.sym} 210 50 0 0 {name=l4 lab=GND}
 C {devices/title.sym} -130 260 0 0 {name=l5 author="Copyright 2023 IHP PDK Authors"}
 C {devices/launcher.sym} -210 -300 0 0 {name=h5
 descr="load waves Ctrl + left click" 
-tclcommand="xschem raw_read $netlist_dir/../raw/ac_lv_nmosrf.raw ac"}
+tclcommand="xschem raw_read $netlist_dir/ac_lv_nmosrf.raw ac"}
 C {sg13g2_pr/sg13_lv_rf_nmos.sym} 140 -40 2 1 {name=M1
 L=0.35u
 W=1.0u

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/ac_mim_cap.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/ac_mim_cap.sch
@@ -73,7 +73,7 @@ let mag=abs(out)
 meas ac freq_at when mag = 0.707
 let C = 1/(2*PI*freq_at*1e+5)
 print C
-write ../raw/ac_mim_cap.raw 
+write ac_mim_cap.raw 
 .endc
 " }
 C {devices/title.sym} 160 -30 0 0 {name=l1 author="Copyright 2023 IHP PDK Authors"}
@@ -95,5 +95,5 @@ C {devices/lab_pin.sym} 690 -390 1 0 {name=p2 sig_type=std_logic lab=out}
 C {sg13g2_pr/cap_cmim.sym} 530 -380 1 0 {name=C1 model=cap_cmim W=7.0e-6 L=7.0e-6 MF=1 spiceprefix=X}
 C {devices/launcher.sym} 200 -740 0 0 {name=h5
 descr="load waves" 
-tclcommand="xschem raw_read $netlist_dir/../raw/ac_mim_cap.raw ac"
+tclcommand="xschem raw_read $netlist_dir/ac_mim_cap.raw ac"
 }

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_diode_op.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_diode_op.sch
@@ -26,13 +26,13 @@ unitx=1
 logx=0
 logy=0
 color="7 8"
-node="i(vmdp)
-i(vmda)"}
+node="i(Vmdp)
+i(Vmda)"}
 N -500 20 -500 40 {
 lab=GND}
 N -500 -100 -500 -40 {
 lab=#net1}
-N -500 -100 -380 -100 {
+N -500 -100 -350 -100 {
 lab=#net1}
 N -350 40 -350 50 {
 lab=GND}
@@ -45,8 +45,6 @@ lab=#net1}
 N -170 -30 -170 -20 {
 lab=#net3}
 N -170 -100 -170 -90 {
-lab=#net1}
-N -380 -100 -350 -100 {
 lab=#net1}
 N -350 -100 -170 -100 {
 lab=#net1}
@@ -65,8 +63,8 @@ op
 print I(Vmda) I(Vmdp) 
 reset 
 dc V1 -12 1 1m
-write ../raw/dc_diode_op.raw
-wrdata ../csv/dc_diode.csv I(Vmda) I(Vmdp)
+write dc_diode_op.raw
+wrdata dc_diode.csv I(Vmda) I(Vmdp)
 .endc
 "}
 C {sg13g2_pr/dantenna.sym} -350 10 2 0 {name=XD1
@@ -77,7 +75,7 @@ w=780n
 C {devices/title.sym} -360 130 0 0 {name=l5 author="Copyright 2023 IHP PDK Authors"}
 C {devices/launcher.sym} -470 -260 0 0 {name=h5
 descr="Load IV curve" 
-tclcommand="xschem raw_read $netlist_dir/../raw/dc_diode_op.raw dc"
+tclcommand="xschem raw_read $netlist_dir/dc_diode_op.raw dc"
 }
 C {devices/gnd.sym} -170 50 0 0 {name=l3 lab=GND}
 C {sg13g2_pr/dpantenna.sym} -170 10 2 0 {name=XD2

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_diode_temp.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_diode_temp.sch
@@ -31,9 +31,7 @@ N -500 40 -500 60 {
 lab=GND}
 N -500 -80 -500 -20 {
 lab=Vd}
-N -500 -80 -380 -80 {
-lab=Vd}
-N -320 -80 -220 -80 {
+N -500 -80 -220 -80 {
 lab=Vd}
 N -220 -80 -220 -40 {
 lab=Vd}
@@ -41,23 +39,17 @@ N -220 20 -220 60 {
 lab=GND}
 N -220 -80 -200 -80 {
 lab=Vd}
-N -380 -80 -320 -80 {
-lab=Vd}
 N -70 40 -70 60 {
 lab=GND}
 N -70 -80 -70 -20 {
 lab=Vdp}
-N -70 -80 50 -80 {
-lab=Vdp}
-N 110 -80 210 -80 {
+N -70 -80 210 -80 {
 lab=Vdp}
 N 210 -80 210 -40 {
 lab=Vdp}
 N 210 20 210 60 {
 lab=GND}
 N 210 -80 230 -80 {
-lab=Vdp}
-N 50 -80 110 -80 {
 lab=Vdp}
 C {devices/gnd.sym} -220 60 0 0 {name=l1 lab=GND}
 C {devices/gnd.sym} -500 60 0 0 {name=l2 lab=GND}
@@ -75,8 +67,8 @@ op
 print Vd 
 reset 
 dc temp -40 125 1
-write ../raw/dc_diode_temp.raw
-wrdata ../csv/dc_diode_temp.csv Vd Vdp
+write dc_diode_temp.raw
+wrdata dc_diode_temp.csv Vd Vdp
 
 .endc
 "}
@@ -90,7 +82,7 @@ C {devices/isource.sym} -500 10 2 0 {name=I0 value=200n}
 C {devices/title.sym} -360 130 0 0 {name=l5 author="Copyright 2023 IHP PDK Authors"}
 C {devices/launcher.sym} -450 -220 0 0 {name=h5
 descr="Load IV curve" 
-tclcommand="xschem raw_read $netlist_dir/../raw/dc_diode_temp.raw dc"
+tclcommand="xschem raw_read $netlist_dir/dc_diode_temp.raw dc"
 }
 C {devices/gnd.sym} 210 60 0 0 {name=l3 lab=GND}
 C {devices/gnd.sym} -70 60 0 0 {name=l4 lab=GND}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_hbt_13g2.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_hbt_13g2.sch
@@ -23,7 +23,7 @@ unitx=1
 logx=0
 logy=0
 color=4
-node=i(vc)
+node=i(Vc)
 y1=-5.5e-05
 rainbow=0}
 T {Nx - number of emitters} -210 110 0 0 0.2 0.2 {}
@@ -47,11 +47,7 @@ N -170 -80 -140 -80 {
 lab=#net2}
 N -80 -80 -40 -80 {
 lab=#net3}
-N -220 -10 -210 -10 {
-lab=#net1}
-N -300 -10 -280 -10 {
-lab=#net1}
-N -280 -10 -220 -10 {
+N -300 -10 -210 -10 {
 lab=#net1}
 C {devices/code_shown.sym} -310 180 0 0 {name=MODEL only_toplevel=true
 format="tcleval( @value )"
@@ -67,7 +63,7 @@ op
 print I(Vc)
 reset 
 dc Vce 0 2 0.01 I0 0 5u 0.1u
-write ../raw/test_npn_13G2.raw
+write test_npn_13G2.raw
 .endc
 "}
 C {devices/gnd.sym} -170 80 0 0 {name=l1 lab=GND}
@@ -78,7 +74,7 @@ C {devices/gnd.sym} -120 80 0 0 {name=l4 lab=GND}
 C {devices/title.sym} -130 260 0 0 {name=l5 author="Copyright 2023 IHP PDK Authors"}
 C {devices/launcher.sym} 70 -70 0 0 {name=h5
 descr="load waves" 
-tclcommand="xschem raw_read $netlist_dir/../raw/test_npn_13G2.raw dc"
+tclcommand="xschem raw_read $netlist_dir/test_npn_13G2.raw dc"
 }
 C {sg13g2_pr/npn13G2.sym} -190 -10 0 0 {name=Q1
 model=npn13G2

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_hv_nmos.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_hv_nmos.sch
@@ -59,13 +59,13 @@ C {devices/code_shown.sym} 310 -30 0 0 {name=NGSPICE only_toplevel=true
 value="
 .param temp=27
 .control
-pre_osdi ./psp103_nqs.osdi
+* pre_osdi ./psp103_nqs.osdi
 save all 
 op
 print all
 reset 
 dc Vds 0 3 0.01 Vgs 0. 0.9 0.1
-write ../raw/dc_hv_nmos.raw
+write dc_hv_nmos.raw
 .endc
 "}
 C {devices/gnd.sym} 20 90 0 0 {name=l1 lab=GND}
@@ -77,7 +77,7 @@ C {devices/gnd.sym} 70 90 0 0 {name=l4 lab=GND}
 C {devices/title.sym} -130 260 0 0 {name=l5 author="Copyright 2023 IHP PDK Authors"}
 C {devices/launcher.sym} -200 -160 0 0 {name=h5
 descr="load waves Ctrl + left click" 
-tclcommand="xschem raw_read $netlist_dir/../raw/dc_hv_nmos.raw dc"
+tclcommand="xschem raw_read $netlist_dir/dc_hv_nmos.raw dc"
 }
 C {sg13g2_pr/sg13_hv_nmos.sym} 0 0 2 1 {name=M1
 L=0.45u

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_hv_pmos.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_hv_pmos.sch
@@ -63,13 +63,13 @@ C {devices/code_shown.sym} 290 -10 0 0 {name=NGSPICE only_toplevel=true
 value="
 .param temp=27
 .control
-pre_osdi ./psp103_nqs.osdi
+* pre_osdi ./psp103_nqs.osdi
 save all 
 op
 print I(Vd)
 reset 
 dc Vds 0 -2 -0.01 Vgs -0.45 -1.1 -0.05
-write ../raw/dc_hv_pmos.raw
+write dc_hv_pmos.raw
 *plot all
 .endc
 "}
@@ -82,7 +82,7 @@ C {devices/gnd.sym} 70 90 0 0 {name=l4 lab=GND}
 C {devices/title.sym} -130 260 0 0 {name=l5 author="Copyright 2023 IHP PDK Authors"}
 C {devices/launcher.sym} -230 -150 0 0 {name=h5
 descr="load waves" 
-tclcommand="xschem raw_read $netlist_dir/../raw/dc_hv_pmos.raw dc"
+tclcommand="xschem raw_read $netlist_dir/dc_hv_pmos.raw dc"
 }
 C {sg13g2_pr/sg13_hv_pmos.sym} 0 0 2 1 {name=M1
 L=0.45u

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_logic_not.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_logic_not.sch
@@ -29,54 +29,46 @@ node="gain
 out"}
 N -290 100 -290 120 {
 lab=GND}
-N -290 30 -290 40 {
-lab=in}
 N 20 60 20 120 {
 lab=GND}
 N 280 60 280 120 {
 lab=GND}
-N 280 -40 280 0 {
-lab=#net1}
-N -30 30 -20 30 {
-lab=in}
-N 70 30 70 60 {
+N 70 30 70 120 {
 lab=GND}
 N 20 30 70 30 {
 lab=GND}
-N 70 -90 70 -70 {
-lab=#net1}
 N 20 -70 70 -70 {
 lab=#net1}
-N 20 -40 20 0 {
+N 20 -20 20 0 {
 lab=out}
 N 20 -170 20 -100 {
 lab=#net1}
-N 20 -170 280 -170 {
+N 70 -170 280 -170 {
 lab=#net1}
-N 280 -170 280 -40 {
+N 280 -170 280 0 {
 lab=#net1}
-N 70 -170 70 -150 {
+N 70 -170 70 -70 {
 lab=#net1}
-N -50 30 -30 30 {
+N -50 30 -20 30 {
 lab=in}
-N -50 -70 -50 30 {
+N -50 -20 -50 30 {
 lab=in}
 N -50 -70 -20 -70 {
 lab=in}
-N -290 -20 -290 30 {
+N -290 -20 -290 40 {
 lab=in}
-N -290 -20 -230 -20 {
+N -290 -20 -50 -20 {
 lab=in}
 N 20 -20 150 -20 {
 lab=out}
 N -310 -20 -290 -20 {
 lab=in}
-N -230 -20 -50 -20 {
-lab=in}
-N 70 60 70 120 {
-lab=GND}
-N 70 -150 70 -90 {
+N 20 -170 70 -170 {
 lab=#net1}
+N 20 -40 20 -20 {
+lab=out}
+N -50 -70 -50 -20 {
+lab=in}
 C {devices/code_shown.sym} -300 170 0 0 {name=MODEL only_toplevel=true
 format="tcleval( @value )"
 value="
@@ -87,11 +79,11 @@ C {devices/code_shown.sym} -360 -260 0 0 {name=NGSPICE only_toplevel=true
 value="
 .param temp=27
 .control
-pre_osdi ./psp103_nqs.osdi
+* pre_osdi ./psp103_nqs.osdi
 save all 
 dc Vin 0 1.8 1m
 let gain = -deriv(V(out))/10
-write ../raw/dc_logic_not.raw
+write dc_logic_not.raw
 .endc
 "}
 C {devices/gnd.sym} 20 120 0 0 {name=l1 lab=GND}
@@ -103,7 +95,7 @@ C {devices/gnd.sym} 70 120 0 0 {name=l4 lab=GND}
 C {devices/title.sym} -130 260 0 0 {name=l5 author="Copyright 2023 IHP PDK Authors"}
 C {devices/launcher.sym} 420 180 0 0 {name=h5
 descr="load waves Ctrl + left click" 
-tclcommand="xschem raw_read $netlist_dir/../raw/dc_logic_not.raw dc"
+tclcommand="xschem raw_read $netlist_dir/dc_logic_not.raw dc"
 }
 C {sg13g2_pr/sg13_lv_nmos.sym} 0 30 2 1 {name=M1
 L=0.45u

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_lv_nmos.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_lv_nmos.sch
@@ -58,12 +58,12 @@ C {devices/code_shown.sym} -300 -320 0 0 {name=NGSPICE only_toplevel=true
 value="
 .param temp=27
 .control
-pre_osdi ./psp103_nqs.osdi
+* pre_osdi ./psp103_nqs.osdi
 save all 
 op
 *reset 
 dc Vds 0 3 0.01 Vgs 0. 0.9 0.1
-write ../raw/dc_lv_nmos.raw
+write dc_lv_nmos.raw
 .endc
 "}
 C {devices/gnd.sym} 20 90 0 0 {name=l1 lab=GND}
@@ -75,7 +75,7 @@ C {devices/gnd.sym} 70 90 0 0 {name=l4 lab=GND}
 C {devices/title.sym} -130 260 0 0 {name=l5 author="Copyright 2023 IHP PDK Authors"}
 C {devices/launcher.sym} 310 90 0 0 {name=h5
 descr="load waves Ctrl + left click" 
-tclcommand="xschem raw_read $netlist_dir/../raw/dc_lv_nmos.raw dc"
+tclcommand="xschem raw_read $netlist_dir/dc_lv_nmos.raw dc"
 }
 C {sg13g2_pr/sg13_lv_nmos.sym} 0 0 2 1 {name=M1
 L=0.45u

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_lv_pmos.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_lv_pmos.sch
@@ -67,13 +67,13 @@ C {devices/code_shown.sym} 290 -10 0 0 {name=NGSPICE only_toplevel=true
 value="
 .param temp=27
 .control
-pre_osdi ./psp103_nqs.osdi
+* pre_osdi ./psp103_nqs.osdi
 save all 
 op
 print I(Vd)
 *reset 
 dc Vds 0 -2 -0.01 Vgs -0.45 -1.1 -0.05
-write ../raw/dc_lv_pmos.raw
+write dc_lv_pmos.raw
 *plot all
 .endc
 "}
@@ -86,7 +86,7 @@ C {devices/gnd.sym} 70 90 0 0 {name=l4 lab=GND}
 C {devices/title.sym} -130 260 0 0 {name=l5 author="Copyright 2023 IHP PDK Authors"}
 C {devices/launcher.sym} -230 -150 0 0 {name=h5
 descr="load waves" 
-tclcommand="xschem raw_read $netlist_dir/../raw/dc_lv_pmos.raw dc"
+tclcommand="xschem raw_read $netlist_dir/dc_lv_pmos.raw dc"
 }
 C {sg13g2_pr/sg13_lv_pmos.sym} 0 0 2 1 {name=M1
 L=0.45u

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_mos_cs_temp.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_mos_cs_temp.sch
@@ -125,11 +125,11 @@ value="
 .savecurrents
 .param temp=27
 .control
-pre_osdi ./psp103_nqs.osdi
+* pre_osdi ./psp103_nqs.osdi
 save all 
 dc temp -40 125 1
-write ../raw/mos_temp.raw
-wrdata ../csv/mos_temp.csv Vgs1 Vgs2 Vgs3 Vgs4
+write mos_temp.raw
+wrdata mos_temp.csv Vgs1 Vgs2 Vgs3 Vgs4
 .endc
 "}
 C {devices/gnd.sym} -20 140 0 0 {name=l1 lab=GND}
@@ -137,7 +137,7 @@ C {devices/gnd.sym} 80 140 0 0 {name=l4 lab=GND}
 C {devices/title.sym} -130 260 0 0 {name=l5 author="Copyright 2023 IHP PDK Authors"}
 C {devices/launcher.sym} -210 -250 0 0 {name=h5
 descr="load waves Ctrl + left click" 
-tclcommand="xschem raw_read $netlist_dir/../raw/mos_temp.raw dc"
+tclcommand="xschem raw_read $netlist_dir/mos_temp.raw dc"
 }
 C {sg13g2_pr/sg13_lv_nmos.sym} -40 50 2 1 {name=M1
 L=1.0u

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_mos_temp.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_mos_temp.sch
@@ -125,11 +125,11 @@ value="
 .savecurrents
 .param temp=27
 .control
-pre_osdi ./psp103_nqs.osdi
+* pre_osdi ./psp103_nqs.osdi
 save all 
 dc temp -40 125 1
-write ../raw/mos_temp.raw
-wrdata ../csv/mos_temp.csv I(Vm1) I(Vm2) I(Vm3) I(Vm4)
+write mos_temp.raw
+wrdata mos_temp.csv I(Vm1) I(Vm2) I(Vm3) I(Vm4)
 .endc
 "}
 C {devices/gnd.sym} -20 200 0 0 {name=l1 lab=GND}
@@ -141,7 +141,7 @@ C {devices/gnd.sym} 30 200 0 0 {name=l4 lab=GND}
 C {devices/title.sym} -130 260 0 0 {name=l5 author="Copyright 2023 IHP PDK Authors"}
 C {devices/launcher.sym} -220 -150 0 0 {name=h5
 descr="load waves Ctrl + left click" 
-tclcommand="xschem raw_read $netlist_dir/../raw/mos_temp.raw dc"
+tclcommand="xschem raw_read $netlist_dir/mos_temp.raw dc"
 }
 C {sg13g2_pr/sg13_lv_nmos.sym} -40 110 2 1 {name=M1
 L=0.35u

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_ntap1.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_ntap1.sch
@@ -27,25 +27,25 @@ logy=0
 y1=0
 rainbow=0
 color=4
-node=i(vr)}
+node=i(Vmeas)}
 T {Here GND is for simulation purpose. The actuall connection goes to NWELL} -150 110 0 0 0.2 0.2 {}
-N -180 40 -180 100 {
+N -180 90 -180 100 {
 lab=GND}
 N -180 -60 -180 -20 {
 lab=#net1}
 N 0 -60 0 -20 {
 lab=Vcc}
-N -180 -60 -150 -60 {
+N -180 -60 -100 -60 {
 lab=#net1}
 N -40 -60 0 -60 {
 lab=Vcc}
 N 0 -60 50 -60 {
 lab=Vcc}
-N -150 -60 -100 -60 {
-lab=#net1}
 N 0 40 0 90 {
 lab=GND}
 N -180 90 0 90 {
+lab=GND}
+N -180 40 -180 90 {
 lab=GND}
 C {devices/code_shown.sym} -200 160 0 0 {name=MODEL only_toplevel=true
 format="tcleval( @value )"
@@ -61,7 +61,7 @@ op
 print Vcc/I(Vr)
 reset 
 dc Vres 0 3 0.01 
-write ../raw/dc_ntap1.raw
+write dc_ntap1.raw
 .endc
 "}
 C {devices/gnd.sym} -180 100 0 0 {name=l1 lab=GND}
@@ -69,7 +69,7 @@ C {devices/vsource.sym} 0 10 0 0 {name=Vres value=1.5}
 C {devices/title.sym} -130 260 0 0 {name=l5 author="Copyright 2023 IHP PDK Authors"}
 C {devices/launcher.sym} -40 -200 0 0 {name=h5
 descr="load waves" 
-tclcommand="xschem raw_read $netlist_dir/../raw/dc_ntap1.raw dc"
+tclcommand="xschem raw_read $netlist_dir/dc_ntap1.raw dc"
 }
 C {devices/lab_pin.sym} 50 -60 2 0 {name=p1 sig_type=std_logic lab=Vcc}
 C {sg13g2_pr/ntap1.sym} -180 10 0 0 {name=R1

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_ptap1.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_ptap1.sch
@@ -29,23 +29,23 @@ rainbow=0
 color=4
 node=i(vr)}
 T {Here GND is only for simulation purpose. The actuall connection is to substrate.} -150 100 0 0 0.2 0.2 {}
-N -180 40 -180 100 {
+N -180 80 -180 100 {
 lab=GND}
 N -180 -60 -180 -20 {
 lab=#net1}
 N 0 -60 0 -20 {
 lab=Vcc}
-N -180 -60 -150 -60 {
+N -180 -60 -100 -60 {
 lab=#net1}
 N -40 -60 0 -60 {
 lab=Vcc}
 N 0 -60 50 -60 {
 lab=Vcc}
-N -150 -60 -100 -60 {
-lab=#net1}
 N -180 80 0 80 {
 lab=GND}
 N 0 40 0 80 {
+lab=GND}
+N -180 40 -180 80 {
 lab=GND}
 C {devices/code_shown.sym} -210 160 0 0 {name=MODEL only_toplevel=true
 format="tcleval( @value )"
@@ -61,7 +61,7 @@ op
 print Vcc/I(Vr)
 reset 
 dc Vres 0 3 0.01 
-write ../raw/dc_ptap1.raw
+write dc_ptap1.raw
 .endc
 "}
 C {devices/gnd.sym} -180 100 0 0 {name=l1 lab=GND}
@@ -69,7 +69,7 @@ C {devices/vsource.sym} 0 10 0 0 {name=Vres value=1.5}
 C {devices/title.sym} -100 240 0 0 {name=l5 author="Copyright 2023 IHP PDK Authors"}
 C {devices/launcher.sym} -120 -200 0 0 {name=h5
 descr="load waves" 
-tclcommand="xschem raw_read $netlist_dir/../raw/dc_ptap1.raw dc"
+tclcommand="xschem raw_read $netlist_dir/dc_ptap1.raw dc"
 }
 C {devices/lab_pin.sym} 50 -60 2 0 {name=p1 sig_type=std_logic lab=Vcc}
 C {sg13g2_pr/ptap1.sym} -180 10 0 0 {name=R1

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_res_temp.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_res_temp.sch
@@ -32,9 +32,7 @@ i(vppd)
 i(vsil)"}
 N -140 30 -140 90 {
 lab=GND}
-N -140 -70 -140 -30 {
-lab=Vcc}
-N -140 -110 -140 -70 {
+N -140 -110 -140 -30 {
 lab=Vcc}
 N -140 -110 90 -110 {
 lab=Vcc}
@@ -79,8 +77,8 @@ echo High poly resisotr value:
 print Vcc/I(Vrh)
 reset 
 dc temp -40 125 1 
-write ../raw/dc_res_temp.raw
-wrdata ../csv/dc_res_temp.csv I(Vsil) I(Vppd) I(Vrh)
+write dc_res_temp.raw
+wrdata dc_res_temp.csv I(Vsil) I(Vppd) I(Vrh)
 .endc
 "}
 C {devices/gnd.sym} 90 90 0 0 {name=l1 lab=GND}
@@ -89,7 +87,7 @@ C {devices/gnd.sym} -140 90 0 0 {name=l3 lab=GND}
 C {devices/title.sym} -130 260 0 0 {name=l5 author="Copyright 2023 IHP PDK Authors"}
 C {devices/launcher.sym} -70 -170 0 0 {name=h5
 descr="load waves" 
-tclcommand="xschem raw_read $netlist_dir/../raw/dc_res_temp.raw dc"
+tclcommand="xschem raw_read $netlist_dir/dc_res_temp.raw dc"
 }
 C {devices/lab_pin.sym} -140 -60 2 0 {name=p1 sig_type=std_logic lab=Vcc}
 C {devices/ammeter.sym} 90 -40 0 0 {name=Vsil}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/mc_hbt_13g2.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/mc_hbt_13g2.sch
@@ -26,11 +26,7 @@ N -70 -110 -40 -110 {
 lab=#net2}
 N 20 -110 60 -110 {
 lab=#net3}
-N -120 -40 -110 -40 {
-lab=#net1}
-N -200 -40 -180 -40 {
-lab=#net1}
-N -180 -40 -120 -40 {
+N -200 -40 -110 -40 {
 lab=#net1}
 C {devices/code_shown.sym} -200 160 0 0 {name=MODEL only_toplevel=true
 format="tcleval( @value )"
@@ -67,8 +63,8 @@ let run=run+1
 end
 ***************** LOOP *********************
 
-wrdata ../csv/mc_hbt_op.csv \{$scratch\}.Ic
-write ../raw/mc_hbt_op.raw
+wrdata mc_hbt_op.csv \{$scratch\}.Ic
+write mc_hbt_op.raw
 echo
 print \{$scratch\}.Ic
 

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/mc_hbt_13g2_ac.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/mc_hbt_13g2_ac.sch
@@ -26,17 +26,15 @@ N 60 -170 90 -170 {
 lab=Vc}
 N 150 -170 190 -170 {
 lab=#net2}
-N 10 -100 20 -100 {
-lab=Vb}
-N -200 -100 -180 -100 {
+N -200 -100 -130 -100 {
 lab=#net1}
 N 40 -170 60 -170 {
 lab=Vc}
-N -180 -100 -130 -100 {
-lab=#net1}
-N -70 -100 10 -100 {
+N -20 -100 20 -100 {
 lab=Vb}
 N -20 -130 -20 -100 {
+lab=Vb}
+N -70 -100 -20 -100 {
 lab=Vb}
 C {devices/code_shown.sym} -200 160 0 0 {name=MODEL only_toplevel=true
 format="tcleval( @value )"
@@ -52,7 +50,7 @@ value="
 .control 
 let mc_runs = 1000
 let run = 0
-shell rm ../csv/mc_hbt_3dB.csv
+shell rm mc_hbt_3dB.csv
 ***************** LOOP *********************
 dowhile run < mc_runs
 reset
@@ -62,7 +60,7 @@ ac dec 10 10k 1000meg
 meas ac vnom_at FIND Vc AT=100k 
 let v3db = vnom_at*0.707
 meas ac freq_3dB when Vc=v3db
-print freq_3dB >> ../csv/mc_hbt_3dB.csv
+print freq_3dB >> mc_hbt_3dB.csv
 let run=run+1 
 end
 ***************** LOOP *********************

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/mc_hv_nmos_cs_loop.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/mc_hv_nmos_cs_loop.sch
@@ -39,7 +39,7 @@ value="
 .param temp=27
 
 .control
-pre_osdi ./psp103_nqs.osdi
+* pre_osdi ./psp103_nqs.osdi
 
 let mc_runs = 1000
 let run = 0
@@ -64,8 +64,8 @@ let run=run+1
 end
 ***************** LOOP *********************
 
-wrdata ../csv/sg13_hv_nmos_cs.csv \{$scratch\}.vg
-write ../raw/sg13_hv_nmos_cs.raw
+wrdata sg13_hv_nmos_cs.csv \{$scratch\}.vg
+write sg13_hv_nmos_cs.raw
 echo
 print \{$scratch\}.vg
 

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/mc_hv_pmos_cs_loop.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/mc_hv_pmos_cs_loop.sch
@@ -38,7 +38,7 @@ value="
 .param temp=27
 
 .control
-pre_osdi ./psp103_nqs.osdi
+* pre_osdi ./psp103_nqs.osdi
 
 let mc_runs = 1000
 let run = 0
@@ -63,8 +63,8 @@ let run=run+1
 end
 ***************** LOOP *********************
 
-wrdata ../csv/sg13_hv_pmos_cs.csv \{$scratch\}.vg
-write ../raw/sg13_hv_pmos_cs.raw
+wrdata sg13_hv_pmos_cs.csv \{$scratch\}.vg
+write sg13_hv_pmos_cs.raw
 echo
 print \{$scratch\}.vg
 

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/mc_lv_nmos_cs_loop.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/mc_lv_nmos_cs_loop.sch
@@ -37,7 +37,7 @@ value="
 .param temp=27
 
 .control
-pre_osdi ./psp103_nqs.osdi
+* pre_osdi ./psp103_nqs.osdi
 
 let mc_runs = 1000
 let run = 0
@@ -62,8 +62,8 @@ let run=run+1
 end
 ***************** LOOP *********************
 
-wrdata ../csv/sg13_lv_nmos_cs.csv \{$scratch\}.vg
-write ../raw/sg13_lv_nmos_cs.raw
+wrdata sg13_lv_nmos_cs.csv \{$scratch\}.vg
+write sg13_lv_nmos_cs.raw
 echo
 print \{$scratch\}.vg
 

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/mc_lv_pmos_cs_loop.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/mc_lv_pmos_cs_loop.sch
@@ -38,7 +38,7 @@ value="
 .param temp=27
 
 .control
-pre_osdi ./psp103_nqs.osdi
+* pre_osdi ./psp103_nqs.osdi
 
 let mc_runs = 1000
 let run = 0
@@ -63,8 +63,8 @@ let run=run+1
 end
 ***************** LOOP *********************
 
-wrdata ../csv/sg13_lv_pmos_cs.csv \{$scratch\}.vg
-write ../raw/sg13_lv_pmos_cs.raw
+wrdata sg13_lv_pmos_cs.csv \{$scratch\}.vg
+write sg13_lv_pmos_cs.raw
 echo
 print \{$scratch\}.vg
 

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/mc_mim_cap_ac.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/mc_mim_cap_ac.sch
@@ -44,7 +44,7 @@ value="
 .control 
 let mc_runs = 1000
 let run = 0
-shell rm ../csv/mc_cmim.csv
+shell rm mc_cmim.csv
 ***************** LOOP *********************
 dowhile run < mc_runs
 reset
@@ -54,7 +54,7 @@ ac dec 1000 1e6 100e9
 let mag=abs(out)
 meas ac freq_at when mag = 0.707
 let C = 1/(2*PI*freq_at*1e+5)
-print C >> ../csv/mc_cmim.csv
+print C >> mc_cmim.csv
 let run=run+1 
 end
 ***************** LOOP *********************

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/mc_res_op.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/mc_res_op.sch
@@ -10,9 +10,7 @@ res_typ when mc_ok = 0
 res_typ_stat when mc_ok = 0} 360 -430 0 0 0.3 0.3 {}
 N 380 40 380 100 {
 lab=GND}
-N 380 -60 380 -20 {
-lab=Vcc}
-N 380 -100 380 -60 {
+N 380 -100 380 -20 {
 lab=Vcc}
 N 380 -100 610 -100 {
 lab=Vcc}
@@ -75,8 +73,8 @@ let run=run+1
 end
 ***************** LOOP *********************
 
-wrdata ../csv/mc_res_op.csv \{$scratch\}.rsilval \{$scratch\}.rppdval \{$scratch\}.rhighval
-write ../raw/mc_res_op.raw
+wrdata mc_res_op.csv \{$scratch\}.rsilval \{$scratch\}.rppdval \{$scratch\}.rhighval
+write mc_res_op.raw
 echo
 print \{$scratch\}.rsilval
 print \{$scratch\}.rppdval

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/sp_mim_cap.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/sp_mim_cap.sch
@@ -94,15 +94,13 @@ N 690 -390 690 -380 {
 lab=out}
 N 370 -400 370 -380 {
 lab=in}
-N 150 -380 370 -380 {
-lab=in}
 N 690 -380 830 -380 {
 lab=out}
 N 370 -380 500 -380 {
 lab=in}
 N 560 -380 690 -380 {
 lab=out}
-N 80 -380 150 -380 {
+N 80 -380 370 -380 {
 lab=in}
 C {devices/code_shown.sym} 50 -660 0 0 {name=NGSPICE
 only_toplevel=true
@@ -112,7 +110,7 @@ save all
 sp lin 500 1e9 100e9 0
 let Cseries = 1e+15/(2*PI*frequency*imag(1/Y_2_1))
 let Rseries = -real(1/Y_2_1)
-write ../raw/sp_mim_cap.raw
+write sp_mim_cap.raw
 .endc
 " }
 C {devices/title.sym} 160 -30 0 0 {name=l1 author="Copyright 2023 IHP PDK Authors"}
@@ -141,6 +139,6 @@ C {devices/lab_pin.sym} 370 -400 1 0 {name=p1 sig_type=std_logic lab=in}
 C {devices/lab_pin.sym} 690 -390 1 0 {name=p2 sig_type=std_logic lab=out}
 C {devices/launcher.sym} 900 -650 0 0 {name=h5
 descr="load waves" 
-tclcommand="xschem raw_read $netlist_dir/../raw/sp_mim_cap.raw ac"
+tclcommand="xschem raw_read $netlist_dir/sp_mim_cap.raw ac"
 }
 C {sg13g2_pr/cap_cmim.sym} 530 -380 1 0 {name=C1 model=cap_cmim W=7.0e-6 L=7.0e-6 MF=1 spiceprefix=X}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/sp_parasitic_cap.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/sp_parasitic_cap.sch
@@ -94,15 +94,13 @@ N 690 -390 690 -380 {
 lab=out}
 N 370 -400 370 -380 {
 lab=in}
-N 150 -380 370 -380 {
-lab=in}
 N 690 -380 830 -380 {
 lab=out}
 N 370 -380 500 -380 {
 lab=in}
 N 560 -380 690 -380 {
 lab=out}
-N 80 -380 150 -380 {
+N 80 -380 370 -380 {
 lab=in}
 C {devices/code_shown.sym} 50 -660 0 0 {name=NGSPICE
 only_toplevel=true
@@ -112,7 +110,7 @@ save all
 sp lin 500 1e9 100e9 0
 let Cseries = 1e+15/(2*PI*frequency*imag(1/Y_2_1))
 let Rseries = -real(1/Y_2_1)
-write ../raw/sp_mim_cap.raw
+write sp_mim_cap.raw
 .endc
 " }
 C {devices/title.sym} 160 -30 0 0 {name=l1 author="Copyright 2023 IHP PDK Authors"}
@@ -141,6 +139,6 @@ C {devices/lab_pin.sym} 370 -400 1 0 {name=p1 sig_type=std_logic lab=in}
 C {devices/lab_pin.sym} 690 -390 1 0 {name=p2 sig_type=std_logic lab=out}
 C {devices/launcher.sym} 900 -650 0 0 {name=h5
 descr="load waves" 
-tclcommand="xschem raw_read $netlist_dir/../raw/sp_mim_cap.raw ac"
+tclcommand="xschem raw_read $netlist_dir/sp_mim_cap.raw ac"
 }
 C {sg13g2_pr/cap_cpara.sym} 530 -380 1 0 {name=C1 model=cparasitic C=20f  spiceprefix=X}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/sp_rfmim_cap.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/sp_rfmim_cap.sch
@@ -116,15 +116,13 @@ N 690 -390 690 -380 {
 lab=out}
 N 370 -400 370 -380 {
 lab=in}
-N 150 -380 370 -380 {
-lab=in}
 N 690 -380 830 -380 {
 lab=out}
 N 370 -380 500 -380 {
 lab=in}
 N 560 -380 690 -380 {
 lab=out}
-N 80 -380 150 -380 {
+N 80 -380 370 -380 {
 lab=in}
 N 530 -350 530 -230 {
 lab=GND}
@@ -137,7 +135,7 @@ sp lin 500 1e9 200e9 0
 let Cseries = 1e+15/(2*PI*frequency*imag(1/Y_2_1))
 let Rseries = -real(1/Y_2_1)
 let s21=vdb(s_2_1)
-write ../raw/sp_rfmim_cap.raw
+write sp_rfmim_cap.raw
 .endc
 " }
 C {devices/title.sym} 160 -30 0 0 {name=l1 author="Copyright 2023 IHP PDK Authors"}
@@ -166,7 +164,7 @@ C {devices/lab_pin.sym} 370 -400 1 0 {name=p1 sig_type=std_logic lab=in}
 C {devices/lab_pin.sym} 690 -390 1 0 {name=p2 sig_type=std_logic lab=out}
 C {devices/launcher.sym} 900 -650 0 0 {name=h5
 descr="load waves" 
-tclcommand="xschem raw_read $netlist_dir/../raw/sp_rfmim_cap.raw ac"
+tclcommand="xschem raw_read $netlist_dir/sp_rfmim_cap.raw ac"
 }
 C {devices/gnd.sym} 530 -230 0 0 {name=l2 lab=GND}
 C {sg13g2_pr/cap_rfcmim.sym} 530 -380 3 0 {name=C1 model=cap_rfcmim W=7.0e-6 L=7.0e-6 wfeed=5.0e-6 spiceprefix=X}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/tran_logic_nand.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/tran_logic_nand.sch
@@ -69,51 +69,41 @@ logy=0
 color=7}
 N 100 70 100 130 {
 lab=GND}
-N 410 -50 410 10 {
+N 410 -50 410 130 {
 lab=GND}
-N 410 -150 410 -110 {
-lab=#net1}
-N 150 40 150 70 {
+N 150 40 150 130 {
 lab=GND}
 N 100 40 150 40 {
 lab=GND}
-N 0 -210 0 -190 {
-lab=#net1}
 N -50 -190 0 -190 {
 lab=#net1}
 N -50 -290 -50 -220 {
 lab=#net1}
-N 410 -280 410 -150 {
-lab=#net1}
-N 0 -290 0 -270 {
+N 0 -290 0 -190 {
 lab=#net1}
 N -190 40 -170 40 {
 lab=A}
-N 230 -210 230 -190 {
-lab=#net1}
 N 180 -190 230 -190 {
 lab=#net1}
 N 180 -290 180 -220 {
 lab=#net1}
-N 230 -290 230 -270 {
+N 230 -290 230 -190 {
 lab=#net1}
 N 100 -40 200 -40 {
 lab=GND}
-N 200 -40 200 -30 {
-lab=GND}
-N 200 30 200 40 {
+N 200 -40 200 40 {
 lab=GND}
 N 100 -10 100 10 {
 lab=#net2}
 N -50 -160 -50 -140 {
 lab=out}
-N 0 -140 180 -140 {
+N 100 -140 180 -140 {
 lab=out}
 N 180 -160 180 -140 {
 lab=out}
-N 100 -140 100 -70 {
+N 100 -90 100 -70 {
 lab=out}
-N -50 -140 0 -140 {
+N -50 -140 100 -140 {
 lab=out}
 N 60 -190 140 -190 {
 lab=B}
@@ -123,8 +113,6 @@ N -90 40 60 40 {
 lab=A}
 N -90 -190 -90 40 {
 lab=A}
-N -170 -40 60 -40 {
-lab=B}
 N -170 40 -90 40 {
 lab=A}
 N -170 120 -170 130 {
@@ -137,24 +125,22 @@ N -270 40 -270 50 {
 lab=GND}
 N -270 -40 -270 -20 {
 lab=B}
-N -270 -40 -170 -40 {
+N -270 -40 60 -40 {
 lab=B}
-N -50 -290 410 -290 {
+N 230 -290 410 -290 {
 lab=#net1}
-N 410 -290 410 -280 {
+N 410 -290 410 -110 {
 lab=#net1}
-N 410 10 410 130 {
-lab=GND}
 N 100 -90 240 -90 {
 lab=out}
-N 150 70 150 130 {
-lab=GND}
-N 200 -30 200 30 {
-lab=GND}
-N 0 -270 -0 -210 {
+N -50 -290 0 -290 {
 lab=#net1}
-N 230 -270 230 -210 {
+N 0 -290 180 -290 {
 lab=#net1}
+N 180 -290 230 -290 {
+lab=#net1}
+N 100 -140 100 -90 {
+lab=out}
 C {devices/code_shown.sym} -290 190 0 0 {name=MODEL only_toplevel=true
 format="tcleval( @value )"
 value="
@@ -164,11 +150,11 @@ C {devices/code_shown.sym} -330 -530 0 0 {name=NGSPICE only_toplevel=true
 value="
 .param temp=27
 .control
-pre_osdi ./psp103_nqs.osdi
+* pre_osdi ./psp103_nqs.osdi
 save all 
 tran 50p 20n
 *meas tran tdelay TRIG v(in) VAL=0.9 FALL=1 TARG v(out) VAL=0.9 RISE=1
-write ../raw/tran_logic_nand.raw
+write tran_logic_nand.raw
 .endc
 "}
 C {devices/gnd.sym} 100 130 0 0 {name=l1 lab=GND}
@@ -180,7 +166,7 @@ C {devices/gnd.sym} 150 130 0 0 {name=l4 lab=GND}
 C {devices/title.sym} -130 260 0 0 {name=l5 author="Copyright 2023 IHP PDK Authors"}
 C {devices/launcher.sym} -270 -610 0 0 {name=h5
 descr="load waves Ctrl + left click" 
-tclcommand="xschem raw_read $netlist_dir/../raw/tran_logic_nand.raw tran"
+tclcommand="xschem raw_read $netlist_dir/tran_logic_nand.raw tran"
 }
 C {sg13g2_pr/sg13_lv_nmos.sym} 80 40 2 1 {name=M1
 L=0.45u

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/tran_logic_not.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/tran_logic_not.sch
@@ -28,54 +28,46 @@ node="out
 in"}
 N -440 90 -440 110 {
 lab=GND}
-N -440 20 -440 30 {
-lab=in}
 N -160 50 -160 110 {
 lab=GND}
 N 100 50 100 110 {
 lab=GND}
-N 100 -50 100 -10 {
-lab=#net1}
-N -210 20 -200 20 {
-lab=in}
-N -110 20 -110 50 {
+N -110 20 -110 110 {
 lab=GND}
 N -160 20 -110 20 {
 lab=GND}
-N -110 -100 -110 -80 {
-lab=#net1}
 N -160 -80 -110 -80 {
 lab=#net1}
-N -160 -50 -160 -10 {
+N -160 -30 -160 -10 {
 lab=out}
 N -160 -180 -160 -110 {
 lab=#net1}
-N -160 -180 100 -180 {
+N -110 -180 100 -180 {
 lab=#net1}
-N 100 -180 100 -50 {
+N 100 -180 100 -10 {
 lab=#net1}
-N -110 -180 -110 -160 {
+N -110 -180 -110 -80 {
 lab=#net1}
-N -230 20 -210 20 {
+N -230 20 -200 20 {
 lab=in}
-N -230 -80 -230 20 {
+N -230 -30 -230 20 {
 lab=in}
 N -230 -80 -200 -80 {
 lab=in}
-N -440 -30 -440 20 {
-lab=in}
-N -290 -30 -230 -30 {
+N -440 -30 -440 30 {
 lab=in}
 N -160 -30 -30 -30 {
 lab=out}
 N -460 -30 -440 -30 {
 lab=in}
-N -440 -30 -290 -30 {
+N -440 -30 -230 -30 {
 lab=in}
-N -110 50 -110 110 {
-lab=GND}
-N -110 -160 -110 -100 {
+N -160 -180 -110 -180 {
 lab=#net1}
+N -230 -80 -230 -30 {
+lab=in}
+N -160 -50 -160 -30 {
+lab=out}
 C {devices/code_shown.sym} -290 190 0 0 {name=MODEL only_toplevel=true
 format="tcleval( @value )"
 value="
@@ -86,11 +78,11 @@ C {devices/code_shown.sym} 160 -70 0 0 {name=NGSPICE only_toplevel=true
 value="
 .param temp=27
 .control
-pre_osdi ./psp103_nqs.osdi
+* pre_osdi ./psp103_nqs.osdi
 save all 
 tran 50p 20n
 meas tran tdelay TRIG v(in) VAL=0.9 FALL=1 TARG v(out) VAL=0.9 RISE=1
-write ../raw/tran_logic_not.raw
+write tran_logic_not.raw
 .endc
 "}
 C {devices/gnd.sym} -160 110 0 0 {name=l1 lab=GND}
@@ -102,7 +94,7 @@ C {devices/gnd.sym} -110 110 0 0 {name=l4 lab=GND}
 C {devices/title.sym} -130 260 0 0 {name=l5 author="Copyright 2023 IHP PDK Authors"}
 C {devices/launcher.sym} 230 -170 0 0 {name=h5
 descr="load waves Ctrl + left click" 
-tclcommand="xschem raw_read $netlist_dir/../raw/tran_logic_not.raw tran"
+tclcommand="xschem raw_read $netlist_dir/tran_logic_not.raw tran"
 }
 C {sg13g2_pr/sg13_lv_nmos.sym} -180 20 2 1 {name=M1
 L=0.45u

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/tran_mim_cap.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/tran_mim_cap.sch
@@ -60,7 +60,7 @@ value="
 .control
 save all
 tran 10n 6u
-write ../raw/test_mim_cap.raw
+write test_mim_cap.raw
 .endc
 " }
 C {devices/title.sym} 160 -30 0 0 {name=l1 author="Copyright 2023 IHP PDK Authors"}
@@ -99,6 +99,6 @@ value="
 "}
 C {devices/launcher.sym} 780 -450 0 0 {name=h5
 descr="load waves" 
-tclcommand="xschem raw_read $netlist_dir/../raw/test_mim_cap.raw tran"
+tclcommand="xschem raw_read $netlist_dir/test_mim_cap.raw tran"
 }
 C {sg13g2_pr/cap_cmim.sym} 40 -220 0 0 {name=C2 model=cap_cmim W=7.0e-6 L=7.0e-6 MF=1 spiceprefix=X}

--- a/ihp-sg13g2/libs.tech/xschem/xschemrc
+++ b/ihp-sg13g2/libs.tech/xschem/xschemrc
@@ -15,23 +15,22 @@
 #### XSCHEM SYSTEM-WIDE DESIGN LIBRARY PATHS: XSCHEM_LIBRARY_PATH
 ###########################################################################
 #### If unset xschem starts with XSCHEM_LIBRARY_PATH set to the default, typically:
-# /home/schippes/.xschem/xschem_library
-# /home/schippes/share/xschem/xschem_library/devices
-# /home/schippes/share/doc/xschem/examples
-# /home/schippes/share/doc/xschem/ngspice
-# /home/schippes/share/doc/xschem/logic
-# /home/schippes/share/doc/xschem/xschem_simulator
-# /home/schippes/share/doc/xschem/binto7seg
-# /home/schippes/share/doc/xschem/pcb
-# /home/schippes/share/doc/xschem/rom8k
+# ${HOME}/.xschem/xschem_library
+# <install_root>/share/xschem/xschem_library/devices
+# <install_root>/share/doc/xschem/examples
+# <install_root>/share/doc/xschem/ngspice
+# <install_root>/share/doc/xschem/logic
+# <install_root>/share/doc/xschem/xschem_simulator
+# <install_root>/share/doc/xschem/binto7seg
+# <install_root>/share/doc/xschem/pcb
+# <install_root>/share/doc/xschem/rom8k
 
 #### Flush any previous definition
 set XSCHEM_LIBRARY_PATH {}
 #### include devices/*.sym
 append XSCHEM_LIBRARY_PATH ${XSCHEM_SHAREDIR}/xschem_library
 #### include skywater libraries. Here i use [pwd]. This works if i start xschem from here.
-append XSCHEM_LIBRARY_PATH :$env(PWD)
-# append XSCHEM_LIBRARY_PATH :/mnt/sda7/home/schippes/pdks/sky130A/libs.tech/xschem
+append XSCHEM_LIBRARY_PATH :[file dirname [info script]]
 #### add ~/.xschem/xschem_library (USER_CONF_DIR is normally ~/.xschem)
 append XSCHEM_LIBRARY_PATH :$USER_CONF_DIR/xschem_library 
 
@@ -42,50 +41,19 @@ append XSCHEM_LIBRARY_PATH :$USER_CONF_DIR/xschem_library
 #### color can be an ordinary name (grey, brown, blue) or a hex code {#77aaff}
 #### hex code must be enclosed in braces
 array unset dircolor
-set dircolor(xschem_examples$) blue
-#set dircolor(xschem_180MCU_PDK$) blue
+set dircolor(sg13g2_pr$) blue
+set dircolor(sg13g2_tests$) blue
 set dircolor(xschem_library$) red
 set dircolor(devices$) red
 
 ###########################################################################
-#### WINDOW TO OPEN ON STARTUP: XSCHEM_START_WINDOW
-###########################################################################
-#### Start without a design if no filename given on command line:
-#### To avoid absolute paths, use a path that is relative to one of the
-#### XSCHEM_LIBRARY_PATH directories. Default: empty
-set XSCHEM_START_WINDOW {sg13g2_tests/IHP_testcases.sch}
-
-###########################################################################
-#### IHP130 PDK SPECIFIC VARIABLES
-###########################################################################
-
-## check if env var PDK_ROOT exists, and use it for building open_pdks paths
-if { [info exists env(PDK_ROOT)] && $env(PDK_ROOT) ne {} } {
-  ## found variable, set tcl PDK_ROOT var
-  if {![file isdir $env(PDK_ROOT)]} {
-    puts stderr "Warning: PDK_ROOT environment variable is set but path not found on the system."
-  }
-  set PDK_ROOT $env(PDK_ROOT)
-} else {
-  ## not existing or empty. 
-  puts stderr "Warning: PDK_ROOT env. var. not found or empty, trying to find a pdk install"
-  if {[file isdir [pwd]/..]} {
-    set PDK_ROOT [file normalize [pwd]/../..]
-  } else {
-    puts stderr {No pdk installation found, set PDK_ROOT env. var. and restart xschem}
-  }
-}
-###########################################################################
 #### DIRECTORY WHERE SIMULATIONS, NETLIST AND SIMULATOR OUTPUTS ARE PLACED
 ###########################################################################
 #### If unset $USER_CONF_DIR/simulations is assumed (normally ~/.xschem/simulations) 
-# set netlist_dir $env(HOME)/.xschem/simulations
-
-if {[info exists PDK_ROOT]} {
-  set netlist_dir ${PDK_ROOT}/libs.tech/xschem/sg13g2_tests/simulation
-  puts stderr "pdk installation: using $PDK_ROOT"
-  puts stderr "netlist_dir: $netlist_dir"
-}
+set netlist_dir $env(PWD)/simulations
+#### if this is set to '1' netlists and simulations will go into a simulation/ folder
+#### inside the directory containing the top level schematic. Default: not set (0)
+# set local_netlist_dir 1
 
 ###########################################################################
 #### NETLIST AND HIERARCHICAL PRINT EXCLUDE PATTERNS
@@ -102,6 +70,10 @@ if {[info exists PDK_ROOT]} {
 #### variable controls hierarchical print
 #### default value: empty
 # set noprint_libs {}
+#### nolist_libs is a list with same rules as for xschem_libs. This
+#### variable controls cell listing in procedure list_hierarchy.
+#### default value: empty
+# set nolist_libs {}
 
 ###########################################################################
 #### CHANGE DEFAULT [] WITH SOME OTHER CHARACTERS FOR BUSSED SIGNALS 
@@ -122,13 +94,18 @@ if {[info exists PDK_ROOT]} {
 # set hspice_netlist 1
 # set verilog_2001 1
 
-#### to use a fixed line with set change_lw to 0 and set some value to line_width
+#### to use a fixed line width set change_lw to 0 and set some value to line_width
 #### these are the defaults
 # set line_width 0
 # set change_lw 1
 
 #### allow color postscript and svg exports. Default: 1, enable color
 # set color_ps 1
+
+#### set paper size: name, height, width. Sizes in 1/72 of an inch (typographical points)
+#### default: {a4 842 595}
+# set ps_paper_size {a4 842 595}
+# set ps_paper_size {letter 792 612}
 
 #### initial size of xschem window you can specify also position with (wxh+x+y)
 #### this is the default:
@@ -138,6 +115,10 @@ if {[info exists PDK_ROOT]} {
 #### allowing to move away by zooming / unzooming with mouse wheel
 #### default setting: 0
 # set unzoom_nodrift 0
+
+#### if set to 1 full zoom will center the drawing instead of anhoring to lower
+#### left corner. Default: 0
+set zoom_full_center 1
 
 #### if set to 1 allow to place multiple components with same name.
 #### Warning: this is normally not allowed in any simulation netlist.
@@ -155,11 +136,14 @@ if {[info exists PDK_ROOT]} {
 #### if set to 1 automatically join/trim wires while editing
 #### this may slow down on rally big designs. Can be disabled via menu 
 #### default: 0
-# set autotrim_wires 0
+set autotrim_wires 1
 
 #### set widget scaling (mainly for font display), this is useful on 4K displays
 #### default: unset (tk uses its default) > 1.0 ==> bigger 
 # set tk_scaling 1.7
+
+#### use the tclreadline package if available , Default: 1 (enabled).
+# set use_tclreadline 1
 
 #### disable some symbol layers. Default: none, all layers are visible.
 # set enable_layer(5) 0 ;# example to disable pin red boxes
@@ -167,17 +151,45 @@ if {[info exists PDK_ROOT]} {
 #### enable to scale grid point size as done with lines at close zoom, default: 0
 # set big_grid_points 0
 
+#### enable grouping contiguous bits of bus slices in net->pin instance
+#### assignments for verilog netlists. Default: disabled (0)
+# set verilog_bitblast 0
+
+#### allow searching the full search path for schematics associated to symbols
+#### instead of looking only in symbol directory. Default: disabled (0).
+# set search_schematic 0
+
+#### focus the schematic window if mouse goes over it, even if a dialog box
+#### is displayed, without needing to click.
+#### This allows to move/zoom/pan the schematic while editing attributes.
+#### Clicking in the schematic window usually closes the dialog box or starts
+#### editing a new component if clicking on a new component.
+#### default: enabled (1)
+# set autofocus_mainwindow 1
+
+#### set component browser always above drawing canvas.
+#### default: enabled (1)
+# set component_browser_on_top 0
+
+#### set graph line with multiplier with respect to xschem actual line width
+#### default: 2.0
+# set graph_linewidth_mult 2.0
+
 ###########################################################################
 #### EXPORT FORMAT TRANSLATORS, PNG AND PDF
 ###########################################################################
 #### command to translate xpm to png; (assumes command takes source 
 #### and dest file as arguments, example: gm convert plot.xpm plot.png)
 #### default: {gm convert}
+#### Windows ghostscript uses gswin64c
+# set to_png {gswin64c -sDEVICE=png16m -o}
 # set to_png {gm convert}
 
 #### command to translate ps to pdf; (assumes command takes source
 #### and dest file as arguments, example: ps2pdf plot.ps plot.pdf)
 #### default: ps2pdf
+#### Windows ghostscript uses gswin64c
+# set to_pdf {gswin64c -sDEVICE=pdfwrite -o}
 # set to_pdf ps2pdf
 set to_pdf {ps2pdf -dAutoRotatePages=/None}
 
@@ -198,8 +210,8 @@ set to_pdf {ps2pdf -dAutoRotatePages=/None}
 ###########################################################################
 #### Warning: changing these values will likely break compatibility
 #### with existing symbol libraries. Defaults: grid 20, snap 10.
-# set grid 20
-# set snap 10
+# set cadgrid 20
+# set cadsnap 10
 
 ###########################################################################
 #### CUSTOM COLORS  MAY BE DEFINED HERE
@@ -247,12 +259,12 @@ set to_pdf {ps2pdf -dAutoRotatePages=/None}
 #### KEYBINDINGS
 ###########################################################################
 #### General format for specifying a replacement for a keybind
-#### Replace Ctrl-d with Escape (so you wont kill the program)
-# set replace_key(Control-d) Escape
+#### Replace Ctrl-q with Escape (so you wont kill the program)
+# set replace_key(Control-q) Escape
 
 #### swap w and W keybinds; Always specify Shift for capital letters
-# set replace_key(Shift-W) w
-# set replace_key(w) Shift-W
+# set replace_key(Shift-W) Key-w
+# set replace_key(Key-w) Shift-W
 
 ###########################################################################
 #### TERMINAL
@@ -282,12 +294,10 @@ set to_pdf {ps2pdf -dAutoRotatePages=/None}
 # set show_infowindow 0
 
 ###########################################################################
-#### CONFIGURE COMPUTER FARM JOB REDIRECTORS FOR SIMULATIONS
+#### ALWAYS SHOW ERC INFO WINDOW AFTER NETLIST
 ###########################################################################
-#### RTDA NC
-# set computerfarm {nc run -Il}
-#### LSF BSUB
-# set computerfarm {bsub -Is}
+#### default: 0 
+# set show_infowindow_after_netlist 0
 
 ###########################################################################
 #### TCP CONNECTION WITH GAW
@@ -306,14 +316,23 @@ set to_pdf {ps2pdf -dAutoRotatePages=/None}
 #### BESPICE WAVE SOCKET CONNECTION
 ###########################################################################
 #### set bespice wave listening port; default: not enabled
-set bespice_listen_port 2022
+# set bespice_listen_port 2022
 
 ###########################################################################
 #### TCL FILES TO LOAD AT STARTUP
 ###########################################################################
 #### list of tcl files to preload.
-# lappend tcl_files ${XSCHEM_SHAREDIR}/change_index.tcl
+set tcl_files {}
 lappend tcl_files ${XSCHEM_SHAREDIR}/ngspice_backannotate.tcl
+# lappend tcl_files ${XSCHEM_SHAREDIR}/change_index.tcl
+# lappend tcl_files ....
+
+###########################################################################
+#### WEB URL DOWNLOAD HELPER APPLICATION
+###########################################################################
+#### used to download files from web: default: {curl -f -s -O -J}
+# set download_url_helper {curl -f -s -O -J}
+# set download_url_helper {wget -N --quiet --content-disposition}
 
 ###########################################################################
 #### XSCHEM TOOLBAR
@@ -329,10 +348,85 @@ set toolbar_visible 1
 # or tab is open.
 set tabbed_interface 1
 
+###########################################################################
+#### CASE INSENSITIVE SYMBOL LOOKUP
+###########################################################################
+## this option might be useful on filesystems that are case insensitive and
+## on designs ported from windows where case of file names does not matter.
+## if this option is set symbol lookup will be case insensitive,
+## so a symbol reference 'AMPLI.SYM' will match with 'ampli.sym' or
+## Amply.sym on disk. File system must be case insensitive for this to work,
+## like FAT32 or NTFS.
+## Do not set this option if you don't know what you are doing.
+## Default: not enabled (0)
+# set case_insensitive 1
+
+###########################################################################
+#### HIDE GRAPHS IF NO SPICE DATA LOADED
+###########################################################################
+## if enabled graphs will be hidden if no data is loaded.
+## default: not enabled (0)
+# set hide_empty_graphs 0
+
+###########################################################################
+#### SHOW HIDDEN TEXTS
+###########################################################################
+## This option shows text objects even if they have attribute 'hide=true' set
+## default: 0 (not set) 
+# set show_hidden_texts 1
+
+###########################################################################
+#### LIVE BACKANNOTATION OF DATA AT CURSOR 2 (B) POSITION
+###########################################################################
+## if enabled will backannotate values in schematic at cursor 'b' position
+## in graph. Default: not enabled (0)
+set live_cursor2_backannotate 1
+
+###########################################################################
+#### IHP PDK SPECIFIC VARIABLES
+###########################################################################
+
+## check if env var PDK_ROOT exists, and use it for building open_pdks paths
+if { [info exists env(PDK_ROOT)] && $env(PDK_ROOT) ne {} } {
+  ## found variable, set tcl PDK_ROOT var
+  if {![file isdir $env(PDK_ROOT)]} {
+    puts stderr "Warning: PDK_ROOT environment variable is set but path not found on the system."
+  }
+  set PDK_ROOT $env(PDK_ROOT)
+} else {
+  ## not existing or empty. 
+  puts stderr "Warning: PDK_ROOT env. var. not found or empty, trying to find an open_pdks install"
+  if {[file isdir /usr/share/pdk]} {set PDK_ROOT /usr/share/pdk
+  } elseif {[file isdir /usr/local/share/pdk]} {set PDK_ROOT /usr/local/share/pdk
+  } elseif {[file isdir $env(HOME)/share/pdk]} {set PDK_ROOT $env(HOME)/share/pdk
+  } else {
+    puts stderr {No open_pdks installation found, set PDK_ROOT env. var. and restart xschem}
+  }
+}
 
 if {[info exists PDK_ROOT]} {
-  set SG13G2_MODELS ${PDK_ROOT}/libs.tech/ngspice/models
-  set SG13G2_MODELS_XYCE ${PDK_ROOT}/libs.tech/xyce/models
+  ## get process variant
+  if {[info exists env(PDK)]} {
+    set PDK $env(PDK)
+  } else {
+    set PDK ihp-sg13g2
+  }
+  set SG13G2_MODELS ${PDK_ROOT}/${PDK}/libs.tech/ngspice/models
+  set SG13G2_MODELS_XYCE ${PDK_ROOT}/${PDK}/libs.tech/xyce/models
   puts stderr "SG13G2_MODELS: $SG13G2_MODELS"
   puts stderr "SG13G2_MODELS_XYCE: $SG13G2_MODELS_XYCE"
+  #puts stderr "SKYWATER_STDCELLS: $SG13G2_STDCELLS"
+}
+
+
+# open_pdks specific:
+# Set variables after ${PDK_ROOT} is known
+# This overrides some of the variables set above.
+
+set XSCHEM_START_WINDOW ${PDK_ROOT}/${PDK}/libs.tech/xschem/sg13g2_tests/IHP_testcases.sch
+append XSCHEM_LIBRARY_PATH :${PDK_ROOT}/${PDK}/libs.tech/xschem
+
+# allow a user-specific path add-on (https://github.com/iic-jku/iic-osic-tools/issues/7)
+if { [info exists ::env(XSCHEM_USER_LIBRARY_PATH) ] } {
+    append XSCHEM_LIBRARY_PATH :$env(XSCHEM_USER_LIBRARY_PATH)
 }


### PR DESCRIPTION
1) Add `.DS_Store` to `.gitignore` (for macOS users)
2) Adapt `xschemrc` for better compatibility between PDKs.
3) Adapt provided examples for read-only PDK and pre-installed OSDI.