### PR TITLE
Use more specific lef class for antenna and filler cells

### DIFF
--- a/ihp-sg13g2/libs.ref/sg13g2_stdcell/lef/sg13g2_stdcell.lef
+++ b/ihp-sg13g2/libs.ref/sg13g2_stdcell/lef/sg13g2_stdcell.lef
@@ -1272,7 +1272,7 @@ MACRO sg13g2_and4_2
 END sg13g2_and4_2
 
 MACRO sg13g2_antennanp
-  CLASS CORE ;
+  CLASS CORE ANTENNACELL ;
   ORIGIN 0 0 ;
   FOREIGN sg13g2_antennanp 0 0 ;
   SIZE 1.44 BY 3.78 ;
@@ -3374,7 +3374,7 @@ MACRO sg13g2_einvn_8
 END sg13g2_einvn_8
 
 MACRO sg13g2_fill_1
-  CLASS CORE ;
+  CLASS CORE SPACER ;
   ORIGIN 0 0 ;
   FOREIGN sg13g2_fill_1 0 0 ;
   SIZE 0.48 BY 3.78 ;
@@ -3402,7 +3402,7 @@ MACRO sg13g2_fill_1
 END sg13g2_fill_1
 
 MACRO sg13g2_fill_2
-  CLASS CORE ;
+  CLASS CORE SPACER ;
   ORIGIN 0 0 ;
   FOREIGN sg13g2_fill_2 0 0 ;
   SIZE 0.96 BY 3.78 ;
@@ -3430,7 +3430,7 @@ MACRO sg13g2_fill_2
 END sg13g2_fill_2
 
 MACRO sg13g2_fill_4
-  CLASS CORE ;
+  CLASS CORE SPACER ;
   ORIGIN 0 0 ;
   FOREIGN sg13g2_fill_4 0 0 ;
   SIZE 1.92 BY 3.78 ;
@@ -3458,7 +3458,7 @@ MACRO sg13g2_fill_4
 END sg13g2_fill_4
 
 MACRO sg13g2_fill_8
-  CLASS CORE ;
+  CLASS CORE SPACER ;
   ORIGIN 0 0 ;
   FOREIGN sg13g2_fill_8 0 0 ;
   SIZE 3.84 BY 3.78 ;


### PR DESCRIPTION
OpenROAD-flow-scripts and potentially other open-source flows use the lef `CLASS`  of cells to find antenna cells and fillers. This pull request improves compatibility with OpenROAD-flow-scripts by allowing it to automatically find the PDK's antenna cell and fillers.