### PR TITLE
Allow running KLayout DRC script without GUI

### DIFF
--- a/ihp-sg13g2/libs.tech/klayout/tech/drc/sg13g2.lydrc
+++ b/ihp-sg13g2/libs.tech/klayout/tech/drc/sg13g2.lydrc
@@ -31,11 +31,13 @@
  <dsl-interpreter-name>drc-dsl-xml</dsl-interpreter-name>
  <text>application = RBA::Application.instance
 main_window = application.main_window
-curr_layout_view = main_window.current_view()
-unless curr_layout_view
-    layout_path = RBA::FileDialog::ask_open_file_name("Chose your layout file.", ".", "GDSII files (*.GDS *.gds *.GDS.gz *.gds.gz *.GDS2 *.gds2 *.GDS2.gz *.gds2.gz);; All files (*)")
-    main_window.load_layout(layout_path, 1)
+if main_window
     curr_layout_view = main_window.current_view()
+    unless curr_layout_view
+        layout_path = RBA::FileDialog::ask_open_file_name("Chose your layout file.", ".", "GDSII files (*.GDS *.gds *.GDS.gz *.gds.gz *.GDS2 *.gds2 *.GDS2.gz *.gds2.gz);; All files (*)")
+        main_window.load_layout(layout_path, 1)
+        curr_layout_view = main_window.current_view()
+    end
 end
 active_layout = RBA::CellView::active.layout
 active_cellname = RBA::CellView::active.cell_name


### PR DESCRIPTION
This is a very small change to check whether `main_window` is valid before trying to get the current view. This allows the script to be run in batch mode (`klayout -zz -r sg13g2.lydrc <design>.gds`) without GUI. This is useful to run the DRC check in a script (for example as part of OpenROAD-flow-scripts) or on a remote server.