### PR TITLE
Fix typo in gds2poly python scripts

### DIFF
--- a/ihp-sg13g2/libs.tech/openems/import_GDSII/gds2matlabpoly.py
+++ b/ihp-sg13g2/libs.tech/openems/import_GDSII/gds2matlabpoly.py
@@ -147,7 +147,7 @@ if len(sys.argv) >= 2:
               # update bounding box information
               if x<xmin: xmin=x
               if x>xmax: xmax=x
-              if y<xmin: ymin=y
+              if y<ymin: ymin=y
               if y>ymax: ymax=y
             
             # create polygon with vertics written before

--- a/ihp-sg13g2/libs.tech/openems/import_GDSII/gds2pythonpoly.py
+++ b/ihp-sg13g2/libs.tech/openems/import_GDSII/gds2pythonpoly.py
@@ -148,7 +148,7 @@ if len(sys.argv) >= 2:
               # update bounding box information
               if x<xmin: xmin=x
               if x>xmax: xmax=x
-              if y<xmin: ymin=y
+              if y<ymin: ymin=y
               if y>ymax: ymax=y
             
             # create polygon with vertics written before


### PR DESCRIPTION
Change "xmin" to "ymin" for correct bounding box calculation