### PR TITLE
removed the mfact parameter and implemented m properly

### DIFF
--- a/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moshv_mod.lib
+++ b/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moshv_mod.lib
@@ -64,73 +64,18 @@
 *  
   
 .subckt sg13_hv_nmos d g s b  
-+ w=0.35u l=0.34u ng=1 mfact=1 as=0 ad=0 pd=0 ps=0 trise=0 z1=0.34e-6 z2=0.38e-6 wmin=0.15e-6 rfmode=0  pre_layout=1  
++ w=0.35u l=0.34u ng=1 m=1 as=0 ad=0 pd=0 ps=0 trise=0 z1=0.34e-6 z2=0.38e-6 wmin=0.15e-6 rfmode=0 pre_layout=1  
 * if as = 0, calculate value, else take it  
 * if as is given externally, no adjustment for ng is done! -> must be done in the extractor  
 * if ng>1 and as=0 (in schematic) recalculate!  
   
-* --- Warning limits if design parameters exceed the values of the measured   
-*     test structures from which the model was derived   
-*LowL  paramtest warnif = (l<0.449u)  message = "Instance parameter 'l' is too small. Validated range for length is [0.45um, 10um]."  
-*HigL  paramtest warnif = (l>10.1u)   message = "Instance parameter 'l' is too large. Validated range for length is [0.45um, 10um]."  
-*if (rfmode) {  
-    *LowW  paramtest warnif = (w/ng<2.499u) message = "Instance parameter 'w/ng' is too small. Validated range for width per finger and rfmode=1 is [1um, 10um]."  
-    *HigW  paramtest warnif = (w/ng>10.1u) message = "Instance parameter 'w/ng' is too large. Validated range for width per finger and rfmode=1 is [1um, 10um]."  
-*} else {  
-    *LowW  paramtest warnif = (w/ng<0.299u)   message = "Instance parameter 'w/ng' is too small. Validated range for width per finger is [0.30um, 10um]."  
-    *HigW  paramtest warnif = (w/ng>10.1u)    message = "Instance parameter 'w/ng' is too large. Validated range for width per finger is [0.30um, 10um]."  
-*}  
-  
-* include the model parameters
-           .include sg13g2_moshv_parm.lib
-
-.if (as <= 1e-50)  
-    .if (floor(floor(ng/2+0.501)*2+0.001) != ng)		  
-        Nsg13_hv_nmos d g s b sg13g2_hv_nmos_psp w='w/ng' l=l mult=ng   
-          + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)/ng'   
-          + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)/ng'  
-          + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)/ng'  
-          + pd='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)/ng'  
-          *+ dta=trise  
-          + ngcon=2   
-    .else
-        Nsg13_hv_nmos d g s b sg13g2_hv_nmos_psp w='w/ng' l=l mult=ng   
-          + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)/ng'  
-          + ad='max(w/ng,wmin)*z2/2'  
-          + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)/ng'  
-          + pd='max(w/ng,wmin)+z2'  
-          *+ dta=trise  
-          + ngcon=2   
-    .endif
-.else
-    Nsg13_hv_nmos d g s b sg13g2_hv_nmos_psp w='w/ng' l=l as='as/ng' ad='ad/ng' pd='pd/ng' ps='ps/ng' mult=ng   
-      *+ dta=trise  
-      + ngcon=2   
-.endif
-.ends
-  
-  
-.subckt sg13_hv_pmos d g s b   
-+ w=0.35u l=0.28u ng=1 mfact=1 as=0 ad=0 pd=0 ps=0 trise=0 z1=0.34e-6 z2=0.38e-6 wmin=0.15e-6 rfmode=0 pre_layout=1  
-  
-* --- Warning limits if design parameters exceed the values of the measured   
-*     test structures from which the model was derived   
-*LowL  paramtest warnif = (l<0.399u)  message = "Instance parameter 'l' is too small. Validated range for length is [0.4um, 10um]."  
-*HigL  paramtest warnif = (l>10.1u)   message = "Instance parameter 'l' is too large. Validated range for length is [0.4um, 10um]."  
-*if (rfmode) {  
-    *LowW  paramtest warnif = (w/ng<2.499u) message = "Instance parameter 'w/ng' is too small. Validated range for width per finger and rfmode=1 is [1um, 10um]."  
-    *HigW  paramtest warnif = (w/ng>10.1u) message = "Instance parameter 'w/ng' is too large. Validated range for width per finger and rfmode=1 is [1um, 10um]."  
-*} else {  
-    *LowW  paramtest warnif = (w/ng<0.299u)   message = "Instance parameter 'w/ng' is too small. Validated range for width per finger is [0.30um, 10um]."  
-    *HigW  paramtest warnif = (w/ng>10.1u)    message = "Instance parameter 'w/ng' is too large. Validated range for width per finger is [0.30um, 10um]."  
-*}  
   
 * include the model parameters
 .include sg13g2_moshv_parm.lib
 
 .if (as <= 1e-50)  
     .if (floor(floor(ng/2+0.501)*2+0.001) != ng)		  
-        Nsg13_hv_pmos d g s b sg13g2_hv_pmos_psp w='w/ng' l=l mult=ng  
+        Nsg13_hv_nmos d g s b sg13g2_hv_nmos_psp w='w/ng' l=l mult='ng*m'   
           + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)/ng'   
           + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)/ng'  
           + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)/ng'  
@@ -138,7 +83,7 @@
           + dta=trise  
           + ngcon=2   
     .else
-        Nsg13_hv_pmos d g s b sg13g2_hv_pmos_psp w='w/ng' l=l mult=ng   
+        Nsg13_hv_nmos d g s b sg13g2_hv_nmos_psp w='w/ng' l=l mult='ng*m'   
           + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)/ng'  
           + ad='max(w/ng,wmin)*z2/2'  
           + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)/ng'  
@@ -147,7 +92,37 @@
           + ngcon=2   
     .endif
 .else
-    Nsg13_hv_pmos d g s b sg13g2_hv_pmos_psp w=w/ng l=l as='as/ng' ad='ad/ng' pd='pd/ng' ps='ps/ng' mult=ng  
+    Nsg13_hv_nmos d g s b sg13g2_hv_nmos_psp w='w/ng' l=l as='as/ng' ad='ad/ng' pd='pd/ng' ps='ps/ng' mult='ng*m'   
+      + dta=trise  
+      + ngcon=2   
+.endif
+.ends
+  
+.subckt sg13_hv_pmos d g s b   
++ w=0.35u l=0.28u ng=1 m=1 as=0 ad=0 pd=0 ps=0 trise=0 z1=0.34e-6 z2=0.38e-6 wmin=0.15e-6 rfmode=0 pre_layout=1  
+  
+* include the model parameters
+.include sg13g2_moshv_parm.lib
+.if (as <= 1e-50)  
+    .if (floor(floor(ng/2+0.501)*2+0.001) != ng)		  
+        Nsg13_hv_pmos d g s b sg13g2_hv_pmos_psp w='w/ng' l=l mult='ng*m'  
+          + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)/ng'   
+          + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)/ng'  
+          + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)/ng'  
+          + pd='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)/ng'  
+          + dta=trise  
+          + ngcon=2   
+    .else
+        Nsg13_hv_pmos d g s b sg13g2_hv_pmos_psp w='w/ng' l=l mult='ng*m'   
+          + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)/ng'  
+          + ad='max(w/ng,wmin)*z2/2'  
+          + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)/ng'  
+          + pd='max(w/ng,wmin)+z2'  
+          + dta=trise  
+          + ngcon=2   
+    .endif
+.else
+    Nsg13_hv_pmos d g s b sg13g2_hv_pmos_psp w='w/ng' l=l as='as/ng' ad='ad/ng' pd='pd/ng' ps='ps/ng' mult='ng*m'  
       + dta=trise  
       + ngcon=2   
 .endif

--- a/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moshv_parm.lib
+++ b/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moshv_parm.lib
@@ -70,7 +70,7 @@
 + lvarl         = -0.09125                     lvarw         =  0.0                         lap           =  6.3866e-08                  
 + wvaro         =  0.0                         wvarl         =  0.0                         wvarw         =  0.0                         
 + wot           =  3e-08                       dlq           =  '5.2202e-08 -((1-pre_layout)*0.0 )+rfmode*(-2e-08 +(ng<3 ? 5.9558e-09 : 0) )' dwq           =  '3e-08 +rfmode*(7.1489e-08 )' 
-+ vfbo          = '-0.89839*(1+(sg13g2_hv_nmos_vfbo_mm-1)/sqrt(mfact*l*w*1e12))'            vfbl          =  0.15096                     vfbw          =  0.0017033                   
++ vfbo          = '-0.89839*(1+(sg13g2_hv_nmos_vfbo_mm-1)/sqrt(m*l*w*1e12))'            vfbl          =  0.15096                     vfbw          =  0.0017033                   
 + vfblw         =  0.019398                    stvfbo        =  0.0008739                   stvfbl        =  0.00014864                  
 + stvfbw        = -4.6174e-05                  stvfblw       = -2.445e-06                   st2vfbo       =  0.0                         
 + toxo          =  '7.4256e-09*sg13g2_hv_nmos_toxo'                                         epsroxo       =  3.9                         nsubo         =  1.8552e+23                  
@@ -220,7 +220,7 @@
 + lvarl         =  0.0                         lvarw         =  0.0                         lap           =  3.471e-08                   
 + wvaro         =  0.0                         wvarl         =  0.0                         wvarw         =  0.0                         
 + wot           =  0.0                         dlq           =  '3.537e-08 -((1-pre_layout)*1e-07 )+rfmode*(2.96e-09 +(ng<3 ? 4e-08 : 0) )' dwq           =  '3e-08 +rfmode*(2.67e-07 )'   
-+ vfbo          = '-1.0717*(1+(sg13g2_hv_pmos_vfbo_mm-1)/sqrt(mfact*l*w*1e12))'               vfbl          = -0.03                        vfbw          =  0.0                         
++ vfbo          = '-1.0717*(1+(sg13g2_hv_pmos_vfbo_mm-1)/sqrt(m*l*w*1e12))'               vfbl          = -0.03                        vfbw          =  0.0                         
 + vfblw         =  0.0                         stvfbo        =  0.00057379                  stvfbl        =  8.6794e-05                  
 + stvfbw        =  4.9309e-05                  stvfblw       = -3.6436e-05                  st2vfbo       =  0.0                         
 + toxo          =  '6.945e-09*sg13g2_hv_pmos_toxo'                                            epsroxo       =  3.9                         nsubo         =  4.2268e+23                  

--- a/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moslv_mod.lib
+++ b/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moslv_mod.lib
@@ -64,34 +64,19 @@
 *  
 *  
 
-* SEMIMOD TODO:
-* - DTA parameter not working?
-  
 .subckt sg13_lv_nmos d g s b  
-+ w=0.35u l=0.34u ng=1 mfact=1 as=0 ad=0 pd=0 ps=0 trise=0 z1=0.34e-6 z2=0.38e-6 wmin=0.15e-6 
-+ rfmode=0 pre_layout=1   
++ w=0.35u l=0.34u ng=1 m=1 as=0 ad=0 pd=0 ps=0 trise=0 z1=0.34e-6 z2=0.38e-6 wmin=0.15e-6 rfmode=0 pre_layout=1  
 * if as = 0, calculate value, else take it  
 * if as is given externally, no adjustment for ng is done! -> must be done in the extractor  
 * if ng>1 and as=0 (in schematic) recalculate!  
   
-* --- Warning limits if design parameters exceed the values of the measured   
-*     test structures from which the model was derived   
-*LowL  paramtest warnif = (l<0.129u)  message = "Instance parameter 'l' is too small. Validated range for length is [0.13um, 10um]."  
-*HigL  paramtest warnif = (l>10.1u)   message = "Instance parameter 'l' is too large. Validated range for length is [0.13um, 10um]."  
-*if (rfmode) {  
-*   LowW  paramtest warnif = (w/ng<0.99u)  message = "Instance parameter 'w/ng' is too small. Validated range for width per finger and rfmode=1 is [1um, 10um]."  
-*   HigW  paramtest warnif = (w/ng>10.1u)  message = "Instance parameter 'w/ng' is too large. Validated range for width per finger and rfmode=1 is [1um, 10um]."  
-*} else {  
-*   LowW  paramtest warnif = (w/ng<0.149u) message = "Instance parameter 'w/ng' is too small. Validated range for 'w' is [0.15um, 10um]."  
-*   HigW  paramtest warnif = (w/ng>10.1u)  message = "Instance parameter 'w/ng' is too large. Validated range for 'w' is [0.15um, 10um]."  
-*}  
-  
+
 * include the model parameters
 .include sg13g2_moslv_parm.lib
 
 .if (as <= 1e-50)  
     .if (floor(floor(ng/2+0.501)*2+0.001) != ng)		  
-        Nsg13_lv_nmos d g s b sg13g2_lv_nmos_psp w='w/ng' l=l mult=ng    
+        Nsg13_lv_nmos d g s b sg13g2_lv_nmos_psp w='w/ng' l=l mult='ng*m'   
           + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)/ng'   
           + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)/ng'  
           + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)/ng'  
@@ -99,7 +84,7 @@
           + dta=trise  
           + ngcon=2   
     .else
-        Nsg13_lv_nmos d g s b sg13g2_lv_nmos_psp w='w/ng' l=l mult=ng    
+        Nsg13_lv_nmos d g s b sg13g2_lv_nmos_psp w='w/ng' l=l mult='ng*m'   
           + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)/ng'  
           + ad='max(w/ng,wmin)*z2/2'  
           + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)/ng'  
@@ -108,32 +93,20 @@
           + ngcon=2   
     .endif
 .else
-    Nsg13_lv_nmos d g s b sg13g2_lv_nmos_psp w='w/ng' l=l as='as/ng' ad='ad/ng' pd='pd/ng' ps='ps/ng' mult=ng      
+    Nsg13_lv_nmos d g s b sg13g2_lv_nmos_psp w='w/ng' l=l as='as/ng' ad='ad/ng' pd='pd/ng' ps='ps/ng' mult='ng*m'   
       + dta=trise  
       + ngcon=2   
 .endif
 .ends
   
 .subckt sg13_lv_pmos d g s b   
-+ w=0.35u l=0.28u ng=1 mfact=1 as=0 ad=0 pd=0 ps=0 trise=0 z1=0.34e-6 z2=0.38e-6 wmin=0.15e-6 
-+ rfmode=0  pre_layout=1  
++ w=0.35u l=0.28u ng=1 m=1 as=0 ad=0 pd=0 ps=0 trise=0 z1=0.34e-6 z2=0.38e-6 wmin=0.15e-6 rfmode=0 pre_layout=1  
   
-* --- Warning limits if design parameters exceed the values of the measured   
-*     test structures from which the model was derived   
-*LowL  paramtest warnif = (l<0.129u)  message = "Instance parameter 'l' is too small. Validated range for length is [0.13um, 10um]."  
-*HigL  paramtest warnif = (l>10.1u)   message = "Instance parameter 'l' is too large. Validated range for length is [0.13um, 10um]."  
-*if (rfmode) {  
-*   LowW  paramtest warnif = (w/ng<4.9u)   message = "Instance parameter 'w/ng' is too small. Validated range for width per finger and rfmode=1 is [2.5um, 10um]."  
-*   HigW  paramtest warnif = (w/ng>10.1u)  message = "Instance parameter 'w/ng' is too large. Validated range for width per finger and rfmode=1 is [2.5um, 10um]."  
-*} else {  
-*   LowW  paramtest warnif = (w/ng<0.149u) message = "Instance parameter 'w/ng' is too small. Validated range for 'w' is [0.15um, 10um]."  
-*   HigW  paramtest warnif = (w/ng>10.1u)  message = "Instance parameter 'w/ng' is too large. Validated range for 'w' is [0.15um, 10um]."  
-*}  
 
 .include sg13g2_moslv_parm.lib
 .if (as <= 1e-50)  
     .if (floor(floor(ng/2+0.501)*2+0.001) != ng)		  
-        Nsg13_lv_pmos d g s b sg13g2_lv_pmos_psp w='w/ng' l=l mult=ng   
+        Nsg13_lv_pmos d g s b sg13g2_lv_pmos_psp w='w/ng' l=l mult='ng*m'  
           + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)/ng'   
           + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)/ng'  
           + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)/ng'  
@@ -141,7 +114,7 @@
           + dta=trise  
           + ngcon=2   
     .else
-        Nsg13_lv_pmos d g s b sg13g2_lv_pmos_psp w='w/ng' l=l mult=ng   
+        Nsg13_lv_pmos d g s b sg13g2_lv_pmos_psp w='w/ng' l=l mult='ng*m'   
           + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)/ng'  
           + ad='max(w/ng,wmin)*z2/2'  
           + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)/ng'  
@@ -150,9 +123,8 @@
           + ngcon=2   
     .endif
 .else
-    Nsg13_lv_pmos d g s b sg13g2_lv_pmos_psp w='w/ng' l=l as='as/ng' ad='ad/ng' pd='pd/ng' ps='ps/ng' mult=ng   
+    Nsg13_lv_pmos d g s b sg13g2_lv_pmos_psp w='w/ng' l=l as='as/ng' ad='ad/ng' pd='pd/ng' ps='ps/ng' mult='ng*m'  
       + dta=trise  
       + ngcon=2   
 .endif
 .ends
-  

--- a/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moslv_parm.lib
+++ b/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moslv_parm.lib
@@ -69,7 +69,7 @@
 + lvarl         =  0.0                         lvarw         =  0.0                         lap           =  2.9423e-08                  
 + wvaro         =  0.0                         wvarl         =  0.0                         wvarw         =  0.0                         
 + wot           = -1e-08                       dlq           = '-1.3721e-08 -((1-pre_layout)*2e-08 )+rfmode*(-1.5368e-08 +(ng<3 ? 4e-08 : 0) )' dwq           = '-1e-08 +rfmode*(4.8062e-07 )' 
-+ vfbo          = '-0.94312*(1+(sg13g2_lv_nmos_vfbo_mm-1)/sqrt(mfact*l*w*1e12)) '             vfbl          =  0.013965                    vfbw          = -0.027122                    
++ vfbo          = '-0.94312*(1+(sg13g2_lv_nmos_vfbo_mm-1)/sqrt(m*l*w*1e12)) '             vfbl          =  0.013965                    vfbw          = -0.027122                    
 + vfblw         =  0.0044814                   stvfbo        =  0.00068785                  stvfbl        =  2.8624e-05                  
 + stvfbw        = -1.8689e-05                  stvfblw       =  5.1435e-07                  st2vfbo       =  0.0                         
 + toxo          =  '2.2404e-09*sg13g2_lv_nmos_toxo'                                           epsroxo       =  3.9                         nsubo         =  1.0483e+23                  
@@ -219,7 +219,7 @@
 + lvarl         = -0.03438                     lvarw         =  0.0                         lap           =  2.5254e-08                  
 + wvaro         =  0.0                         wvarl         =  0.0                         wvarw         =  0.0                         
 + wot           =  1.5e-08                     dlq           = '-9.5922e-08 -((1-pre_layout)*3e-08 )+rfmode*(-2e-08 +(ng<3 ? 3.3917e-08 : 0) )' dwq           =  '1.5e-08 +rfmode*(4.7599e-07 )'                                            
-+ vfbo          = '-0.88703*(1+(sg13g2_lv_pmos_vfbo_mm-1)/sqrt(mfact*l*w*1e12))'              vfbl          =  0.0089886                   vfbw          =  0.0071805                   
++ vfbo          = '-0.88703*(1+(sg13g2_lv_pmos_vfbo_mm-1)/sqrt(m*l*w*1e12))'              vfbl          =  0.0089886                   vfbw          =  0.0071805                   
 + vfblw         =  0.004075                    stvfbo        =  0.00075111                  stvfbl        =  2.4487e-06                  
 + stvfbw        =  6.217e-06                   stvfblw       =  2.2668e-07                  st2vfbo       =  0.0                         
 + toxo          =  '1.9704e-09*sg13g2_lv_pmos_toxo'                                           epsroxo       =  3.9                         nsubo         =  4.6011e+23                  


### PR DESCRIPTION
Fixes #25 

As mentioned in the discussion, this fix is not ideal, but it seems this is how the original spectre SG13G2 model extractors did it. One main open question is the parameter `m`, which is used in the scaling of the PSP model parameter `vfbo`.

This can not be verified at the moment since in the current available measurements there are no multi-finger device measurements present.
