### PR TITLE
Standard cells symbols update

### DIFF
--- a/ihp-sg13g2/libs.tech/ngspice/models/resistors_mod.lib
+++ b/ihp-sg13g2/libs.tech/ngspice/models/resistors_mod.lib
@@ -45,7 +45,7 @@ R1 1 2 R=r*res_rpara TC1=TC1 TC2=TC2
 +weff=w+0.01e-6
 +rzspec=4.5e-6
 R1 1 2 res_rsil L=leff W=weff m=m
-R2 2 3 R=res_rzspec TC1=3100e-6 TC2=0.3e-6
+R2 2 3 R=res_rzspec TC1=3100e-6 TC2=0.3e-6 m=m
 .ends rsil
 
 .subckt rhigh 1 3 
@@ -57,7 +57,7 @@ R2 2 3 R=res_rzspec TC1=3100e-6 TC2=0.3e-6
 +weff=w-0.04e-6
 +rzspec=80e-6
 R1 1 2 res_rhigh L=leff W=weff m=m
-R2 2 3 R=res_rzspec TC1=-2300e-6 TC2=2.1e-6
+R2 2 3 R=res_rzspec TC1=-2300e-6 TC2=2.1e-6 m=m
 .ends rhigh
 
 .subckt rppd 1 3 
@@ -69,5 +69,5 @@ R2 2 3 R=res_rzspec TC1=-2300e-6 TC2=2.1e-6
 +weff=w+0.006e-6
 +rzspec=35e-6
 R1 1 2 res_rppd L=leff W=weff m=m
-R2 2 3 R=res_rzspec TC1=-950e-6
+R2 2 3 R=res_rzspec TC1=-950e-6 m=m
 .ends rppd

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/IHP130_stdcells.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/IHP130_stdcells.sch
@@ -1,4 +1,4 @@
-v {xschem version=3.4.4 file_version=1.2
+v {xschem version=3.4.5 file_version=1.2
 }
 G {}
 K {}
@@ -6,40 +6,63 @@ V {}
 S {}
 E {}
 C {devices/title.sym} -90 0 0 0 {name=l1 author="IHP PDK Authors"}
-C {sg13g2_stdcells/sg13g2_a21o_1.sym} 330 -970 0 0 {name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ }
-C {sg13g2_stdcells/sg13g2_a21oi_1.sym} 330 -850 0 0 {name=x2 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ }
-C {sg13g2_stdcells/sg13g2_a221oi_1.sym} 330 -680 0 0 {name=x3 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ }
-C {sg13g2_stdcells/sg13g2_a22oi_1.sym} 330 -470 0 0 {name=x4 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ }
-C {sg13g2_stdcells/sg13g2_and2_1.sym} 70 -900 0 0 {name=x5 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ }
-C {sg13g2_stdcells/sg13g2_and3_1.sym} 70 -790 0 0 {name=x6 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ }
-C {sg13g2_stdcells/sg13g2_and4_1.sym} 80 -640 0 0 {name=x7 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ }
-C {sg13g2_stdcells/sg13g2_buf_1.sym} 540 -350 0 0 {name=x8 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ }
-C {sg13g2_stdcells/sg13g2_dfrbp_1.sym} 1190 -900 0 0 {name=x9 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ }
-C {sg13g2_stdcells/sg13g2_dlygate4sd2_1.sym} 550 -650 0 0 {name=x10 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ }
-C {sg13g2_stdcells/sg13g2_ebufn_2.sym} 550 -560 0 0 {name=x11 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ }
-C {sg13g2_stdcells/sg13g2_einvn_2.sym} 550 -460 0 0 {name=x12 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ }
-C {sg13g2_stdcells/sg13g2_inv_1.sym} 530 -280 0 0 {name=x13 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ }
-C {sg13g2_stdcells/sg13g2_mux2_1.sym} 560 -780 0 0 {name=x14 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ }
-C {sg13g2_stdcells/sg13g2_mux4_1.sym} 560 -1000 0 0 {name=x15 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ }
-C {sg13g2_stdcells/sg13g2_nand2_1.sym} 80 -350 0 0 {name=x16 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ }
-C {sg13g2_stdcells/sg13g2_nand2b_1.sym} 80 -230 0 0 {name=x17 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ }
-C {sg13g2_stdcells/sg13g2_nand3_1.sym} 80 -120 0 0 {name=x18 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ }
-C {sg13g2_stdcells/sg13g2_nand3b_1.sym} 70 -1000 0 0 {name=x19 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ }
-C {sg13g2_stdcells/sg13g2_nand4_1.sym} 80 -470 0 0 {name=x20 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ }
-C {sg13g2_stdcells/sg13g2_nor2_1.sym} -160 -890 0 0 {name=x21 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ }
-C {sg13g2_stdcells/sg13g2_nor2b_1.sym} -160 -790 0 0 {name=x22 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ }
-C {sg13g2_stdcells/sg13g2_nor3_1.sym} -150 -120 0 0 {name=x23 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ }
-C {sg13g2_stdcells/sg13g2_nor4_1.sym} -140 -420 0 0 {name=x24 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ }
-C {sg13g2_stdcells/sg13g2_o21ai_1.sym} 330 -280 0 0 {name=x25 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ }
-C {sg13g2_stdcells/sg13g2_or2_1.sym} -150 -560 0 0 {name=x26 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ }
-C {sg13g2_stdcells/sg13g2_or3_1.sym} -160 -670 0 0 {name=x27 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ }
-C {sg13g2_stdcells/sg13g2_or4_1.sym} -140 -270 0 0 {name=x28 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ }
-C {sg13g2_stdcells/sg13g2_sdfbbp_1.sym} 1190 -750 0 0 {name=x29 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ }
-C {sg13g2_stdcells/sg13g2_xor2_1.sym} -370 -610 0 0 {name=x30 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ }
-C {sg13g2_stdcells/sg13g2_xnor2_1.sym} -370 -480 0 0 {name=x31 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ }
-C {sg13g2_stdcells/sg13g2_dlhq_1.sym} 870 -840 0 0 {name=x32 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ }
-C {sg13g2_stdcells/sg13g2_dlhr_1.sym} 870 -580 0 0 {name=x33 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ }
-C {sg13g2_stdcells/sg13g2_dlhrq_1.sym} 870 -670 0 0 {name=x34 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ }
-C {sg13g2_stdcells/sg13g2_dlhr_1.sym} 870 -760 0 0 {name=x35 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ }
-C {sg13g2_stdcells/sg13g2_dllr_1.sym} 870 -410 0 0 {name=x36 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ }
-C {sg13g2_stdcells/sg13g2_dllrq_1.sym} 870 -490 0 0 {name=x37 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_xor2_1.sym} -300 -540 0 0 {name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_xnor2_1.sym} -300 -430 0 0 {name=x2 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_or4_2.sym} -120 -160 0 0 {name=x3 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_or4_1.sym} -120 -300 0 0 {name=x4 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_or3_2.sym} -120 -430 0 0 {name=x5 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_or3_1.sym} -120 -540 0 0 {name=x6 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_or2_2.sym} -120 -630 0 0 {name=x7 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_nor4_2.sym} 20 -160 0 0 {name=x8 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_nor4_1.sym} 20 -300 0 0 {name=x9 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_nor3_2.sym} 20 -430 0 0 {name=x10 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_nor3_1.sym} 20 -540 0 0 {name=x11 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_nor2b_2.sym} 20 -630 0 0 {name=x12 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_nor2b_1.sym} 20 -710 0 0 {name=x13 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_nor2_2.sym} 20 -790 0 0 {name=x14 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_nor2_1.sym} 20 -870 0 0 {name=x15 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_or2_1.sym} -120 -710 0 0 {name=x16 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_nand4_1.sym} 190 -260 0 0 {name=x17 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_nand3b_1.sym} 190 -390 0 0 {name=x18 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_nand3_1.sym} 190 -500 0 0 {name=x19 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_nand2b_2.sym} 190 -600 0 0 {name=x20 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_nand2b_1.sym} 190 -690 0 0 {name=x21 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_nand2_2.sym} 190 -780 0 0 {name=x22 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_nand2_1.sym} 190 -870 0 0 {name=x23 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_mux4_1.sym} 550 -160 0 0 {name=x24 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_mux2_2.sym} 550 -320 0 0 {name=x25 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_mux2_1.sym} 550 -430 0 0 {name=x26 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_inv_8.sym} 710 -180 0 0 {name=x27 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_inv_4.sym} 710 -260 0 0 {name=x29 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_inv_2.sym} 710 -340 0 0 {name=x30 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_inv_16.sym} 710 -90 0 0 {name=x31 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_inv_1.sym} 710 -420 0 0 {name=x32 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_einvn_2.sym} 890 -420 0 0 {name=x33 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_einvn_4.sym} 880 -320 0 0 {name=x34 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_einvn_8.sym} 890 -190 0 0 {name=x35 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_ebufn_8.sym} 1040 -190 0 0 {name=x36 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_ebufn_4.sym} 1030 -320 0 0 {name=x37 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_ebufn_2.sym} 1030 -420 0 0 {name=x38 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_dlygate4sd2_1.sym} 1180 -320 0 0 {name=x40 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_dlygate4sd1_1.sym} 1180 -420 0 0 {name=x41 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_dlygate4sd3_1.sym} 1190 -190 0 0 {name=x42 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_and4_2.sym} 360 -270 0 0 {name=x28 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_and4_1.sym} 360 -430 0 0 {name=x39 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_and3_2.sym} 360 -560 0 0 {name=x43 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_and3_1.sym} 360 -670 0 0 {name=x44 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_and2_2.sym} 360 -770 0 0 {name=x45 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_and2_1.sym} 360 -870 0 0 {name=x46 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_a22oi_1.sym} 780 -670 0 0 {name=x47 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_a21o_2.sym} 560 -1010 0 0 {name=x48 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_a21oi_1.sym} 560 -720 0 0 {name=x49 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_a221oi_1.sym} 780 -880 0 0 {name=x50 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_a21o_2.sym} 560 -870 0 0 {name=x51 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_a21oi_2.sym} 560 -590 0 0 {name=x52 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_dfrbp_1.sym} 1010 -970 0 0 {name=x53 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_dfrbp_2.sym} 1010 -860 0 0 {name=x54 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_dlhq_1.sym} 1010 -760 0 0 {name=x55 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_dlhr_1.sym} 1010 -650 0 0 {name=x56 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_dlhrq_1.sym} 1010 -560 0 0 {name=x57 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_dllr_1.sym} 1240 -970 0 0 {name=x58 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_dllrq_1.sym} 1240 -860 0 0 {name=x59 VDD=VDD VSS=VSS prefix=sg13g2_ }
+C {sg13g2_stdcells/sg13g2_sdfbbp_1.sym} 1240 -710 0 0 {name=x60 VDD=VDD VSS=VSS prefix=sg13g2_ }

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_a21o_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_a21o_1.sym
@@ -18,9 +18,9 @@ v {xschem version=3.1.0 file_version=1.0
 G {}
 K {type=primitive
 function3="0 1 & 2 |"
-format="@name @@A1 @@A2 @@B1 @VGND @VNB @VPB @VPWR @@X @prefix\\\\a21o_1"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A1 @@A2 @@B1 @VDD @VSS @@X @prefix\\\\a21o_1"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_a21o_2.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_a21o_2.sym
@@ -17,9 +17,9 @@ v {xschem version=3.1.0 file_version=1.0
 
 G {}
 K {type=primitive
-format="@name @@A1 @@A2 @@B1 @VGND @VNB @VPB @VPWR @@X @prefix\\\\a21o_2"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A1 @@A2 @@B1 @VDD @VSS @@X @prefix\\\\a21o_2"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_a21oi_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_a21oi_1.sym
@@ -18,9 +18,9 @@ v {xschem version=3.1.0 file_version=1.0
 G {}
 K {type=primitive
 function3="0 1 & 2 | ~"
-format="@name @@A1 @@A2 @@B1 @VGND @VNB @VPB @VPWR @@Y @prefix\\\\a21oi_1"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A1 @@A2 @@B1 @VDD @VSS @@Y @prefix\\\\a21oi_1"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_a21oi_2.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_a21oi_2.sym
@@ -17,9 +17,9 @@ v {xschem version=3.1.0 file_version=1.0
 
 G {}
 K {type=primitive
-format="@name @@A1 @@A2 @@B1 @VGND @VNB @VPB @VPWR @@Y @prefix\\\\a21oi_2"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A1 @@A2 @@B1 @VDD @VSS @@Y @prefix\\\\a21oi_2"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_a221oi_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_a221oi_1.sym
@@ -18,9 +18,9 @@ v {xschem version=3.1.0 file_version=1.0
 
 K {type=primitive
 function5="0 1 & 2 3 & 4 | | ~"
-format="@name @@A1 @@A2 @@B1 @@B2 @@C1 @VGND @VNB @VPB @VPWR @@Y @prefix\\\\a221oi_1"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A1 @@A2 @@B1 @@B2 @@C1 @VDD @VSS @@Y @prefix\\\\a221oi_1"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_a22oi_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_a22oi_1.sym
@@ -17,9 +17,9 @@ v {xschem version=3.1.0 file_version=1.0
 
 G {}
 K {type=primitive
-format="@name @@A1 @@A2 @@B1 @@B2 @VGND @VNB @VPB @VPWR @@Y @prefix\\\\a22oi_1"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A1 @@A2 @@B1 @@B2 @VDD @VSS @@Y @prefix\\\\a22oi_1"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_and2_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_and2_1.sym
@@ -18,9 +18,9 @@ v {xschem version=3.1.0 file_version=1.0
 G {}
 K {type=primitive
 function2="0 1 &"
-format="@name @@A @@B @VGND @VNB @VPB @VPWR @@X @prefix\\\\and2_1"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A @@B @VDD @VSS @@X @prefix\\\\and2_1"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true
 }

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_and2_2.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_and2_2.sym
@@ -17,9 +17,9 @@ v {xschem version=3.1.0 file_version=1.0
 
 G {}
 K {type=primitive
-format="@name @@A @@B @VGND @VNB @VPB @VPWR @@X @prefix\\\\and2_2"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A @@B @VDD @VSS @@X @prefix\\\\and2_2"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_and3_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_and3_1.sym
@@ -17,9 +17,9 @@ v {xschem version=3.1.0 file_version=1.0
 
 G {}
 K {type=primitive
-format="@name @@A @@B @@C @VGND @VNB @VPB @VPWR @@X @prefix\\\\and3_1"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A @@B @@C @VDD @VSS @@X @prefix\\\\and3_1"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true
 function3="0 1 2 & &"}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_and3_2.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_and3_2.sym
@@ -17,9 +17,9 @@ v {xschem version=3.1.0 file_version=1.0
 
 G {}
 K {type=primitive
-format="@name @@A @@B @@C @VGND @VNB @VPB @VPWR @@X @prefix\\\\and3_2"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A @@B @@C @VDD @VSS @@X @prefix\\\\and3_2"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_and4_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_and4_1.sym
@@ -18,9 +18,9 @@ v {xschem version=3.1.0 file_version=1.0
 G {}
 K {type=primitive
 function4="0 1 2 3 & & &"
-format="@name @@A @@B @@C @@D @VGND @VNB @VPB @VPWR @@X @prefix\\\\and4_1"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A @@B @@C @@D @VDD @VSS @@X @prefix\\\\and4_1"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_and4_2.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_and4_2.sym
@@ -17,9 +17,9 @@ v {xschem version=3.1.0 file_version=1.0
 
 G {}
 K {type=primitive
-format="@name @@A @@B @@C @@D @VGND @VNB @VPB @VPWR @@X @prefix\\\\and4_2"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A @@B @@C @@D @VDD @VSS @@X @prefix\\\\and4_2"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_buf_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_buf_1.sym
@@ -17,9 +17,9 @@ v {xschem version=3.1.0 file_version=1.0
 
 G {}
 K {type=primitive
-format="@name @@A @VGND @VNB @VPB @VPWR @@X @prefix\\\\buf_1"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A @VDD @VSS @@X @prefix\\\\buf_1"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_buf_16.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_buf_16.sym
@@ -17,9 +17,9 @@ v {xschem version=3.1.0 file_version=1.0
 
 G {}
 K {type=primitive
-format="@name @@A @VGND @VNB @VPB @VPWR @@X @prefix\\\\buf_16"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A @VDD @VSS @@X @prefix\\\\buf_16"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_buf_2.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_buf_2.sym
@@ -18,9 +18,9 @@ v {xschem version=3.1.0 file_version=1.0
 G {}
 K {function1="0"
 type=primitive
-format="@name @@A @VGND @VNB @VPB @VPWR @@X @prefix\\\\buf_2"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A @VDD @VSS @@X @prefix\\\\buf_2"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_buf_4.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_buf_4.sym
@@ -18,9 +18,9 @@ v {xschem version=3.1.0 file_version=1.0
 G {}
 K {type=primitive
 function1="0"
-format="@name @@A @VGND @VNB @VPB @VPWR @@X @prefix\\\\buf_4"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A @VDD @VSS @@X @prefix\\\\buf_4"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_buf_8.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_buf_8.sym
@@ -18,9 +18,9 @@ v {xschem version=3.1.0 file_version=1.0
 G {}
 K {type=primitive
 function1="0"
-format="@name @@A @VGND @VNB @VPB @VPWR @@X @prefix\\\\buf_8"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A @VDD @VSS @@X @prefix\\\\buf_8"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_decap_4.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_decap_4.sym
@@ -16,9 +16,9 @@ v {xschem version=3.1.0 file_version=1.0
 }
 
 K {type=primitive
-format="@name @VGND @VNB @VPB @VPWR @prefix\\\\decap_4"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @VDD @VSS @prefix\\\\decap_4"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 T {@symname} 0 -6 0 0 0.3 0.3 {hcenter=true}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_decap_8.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_decap_8.sym
@@ -16,9 +16,9 @@ v {xschem version=3.1.0 file_version=1.0
 }
 
 K {type=primitive
-format="@name @VGND @VNB @VPB @VPWR @prefix\\\\decap_8"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @VDD @VSS @prefix\\\\decap_8"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 T {@symname} 0 -6 0 0 0.3 0.3 {hcenter=true}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_dfrbp_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_dfrbp_1.sym
@@ -19,9 +19,9 @@ G {}
 K {type=primitive
 function3="1 0 2 & & 0 ~ 2 3 & & |"
 function4="3 ~"
-format="@name @@CLK @@D @@RESET_B @VGND @VNB @VPB @VPWR @@Q @@Q_N @prefix\\\\dfrbp_1"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@CLK @@D @@Q @@Q_N @@RESET_B @VDD @VSS @prefix\\\\dfrbp_1"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 }
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_dfrbp_2.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_dfrbp_2.sym
@@ -16,9 +16,9 @@ v {xschem version=3.1.0 file_version=1.0
 }
 
 K {type=primitive
-format="@name @@CLK @@D @@RESET_B @VGND @VNB @VPB @VPWR @@Q @@Q_N @prefix\\\\dfrbp_2"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@CLK @@D @@Q @@Q_N @@RESET_B @VDD @VSS @prefix\\\\dfrbp_2"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 }
 T {@symname} 0 -6 0 0 0.2 0.2 {hcenter=true}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_dlhq_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_dlhq_1.sym
@@ -18,9 +18,9 @@ v {xschem version=3.1.0 file_version=1.0
 G {}
 K {type=primitive
 function2="1 d ~ 2 & x 0 & |"
-format="@name @@CLK @@D @@RESET_B @VGND @VNB @VPB @VPWR @@Q @@Q_N @prefix\\\\dlhq_1"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@D @@GATE @@Q @VDD @VSS @prefix\\\\dlhq_1"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 }
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_dlhr_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_dlhr_1.sym
@@ -19,9 +19,9 @@ G {}
 K {type=primitive
 function3="1 d ~ 3 & x 0 & | 2 &"
 function4="3 ~"
-format="@name @@CLK @@D @@RESET_B @VGND @VNB @VPB @VPWR @@Q @@Q_N @prefix\\\\dlhr_1"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@D @@GATE @@Q @@Q_N @@@RESET_B VDD @VSS @prefix\\\\dlhr_1"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 }
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_dlhrq_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_dlhrq_1.sym
@@ -18,9 +18,9 @@ v {xschem version=3.1.0 file_version=1.0
 G {}
 K {type=primitive
 function3="1 d ~ 3 & x 0 & | 2 &"
-format="@name @@CLK @@D @@RESET_B @VGND @VNB @VPB @VPWR @@Q @@Q_N @prefix\\\\dlhrq_1"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@D @@GATE @@@Q @RESET_B @VDD @VSS @prefix\\\\dlhrq_1"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 }
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_dllr_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_dllr_1.sym
@@ -19,9 +19,9 @@ G {}
 K {type=primitive
 function3="1 d ~ 0 & x 3 & | 2 &"
 function4="3 ~"
-format="@name @@CLK @@D @@RESET_B @VGND @VNB @VPB @VPWR @@Q @@Q_N @prefix\\\\dllr_1"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@D @@GATE_N @@Q @@Q_N @@RESET_B @VDD @VSS @prefix\\\\dllr_1"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 }
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_dllrq_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_dllrq_1.sym
@@ -18,9 +18,9 @@ v {xschem version=3.1.0 file_version=1.0
 G {}
 K {type=primitive
 function3="1 d ~ 0 & x 3 & | 2 &"
-format="@name @@CLK @@D @@RESET_B @VGND @VNB @VPB @VPWR @@Q @@Q_N @prefix\\\\dllrq_1"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@D @@GATE_N @@Q @@RESET_B @VDD @VSS @prefix\\\\dllrq_1"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 }
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_dlygate4sd1_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_dlygate4sd1_1.sym
@@ -17,9 +17,9 @@ v {xschem version=3.1.0 file_version=1.0
 
 G {}
 K {type=primitive
-format="@name @@A @VGND @VNB @VPB @VPWR @@X @prefix\\\\dlygate4sd1_1"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A @VDD @VSS @@X @prefix\\\\dlygate4sd1_1"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_dlygate4sd2_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_dlygate4sd2_1.sym
@@ -17,9 +17,9 @@ v {xschem version=3.1.0 file_version=1.0
 
 G {}
 K {type=primitive
-format="@name @@A @VGND @VNB @VPB @VPWR @@X @prefix\\\\dlygate4sd2_1"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A @VDD @VSS @@X @prefix\\\\dlygate4sd2_1"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_dlygate4sd3_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_dlygate4sd3_1.sym
@@ -17,9 +17,9 @@ v {xschem version=3.1.0 file_version=1.0
 
 G {}
 K {type=primitive
-format="@name @@A @VGND @VNB @VPB @VPWR @@X @prefix\\\\dlygate4sd3_1"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A @VDD @VSS @@X @prefix\\\\dlygate4sd3_1"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_ebufn_2.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_ebufn_2.sym
@@ -18,9 +18,9 @@ v {xschem version=3.1.0 file_version=1.0
 G {}
 K {type=primitive
 function2="0 1 ~ &"
-format="@name @@A @@TE_B @VGND @VNB @VPB @VPWR @@Z @prefix\\\\ebufn_2"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A @@TE_B @VDD @VSS @@Z @prefix\\\\ebufn_2"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_ebufn_4.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_ebufn_4.sym
@@ -17,9 +17,9 @@ v {xschem version=3.1.0 file_version=1.0
 
 G {}
 K {type=primitive
-format="@name @@A @@TE_B @VGND @VNB @VPB @VPWR @@Z @prefix\\\\ebufn_4"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A @@TE_B @VDD @VSS @@Z @prefix\\\\ebufn_4"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_ebufn_8.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_ebufn_8.sym
@@ -17,9 +17,9 @@ v {xschem version=3.1.0 file_version=1.0
 
 G {}
 K {type=primitive
-format="@name @@A @@TE_B @VGND @VNB @VPB @VPWR @@Z @prefix\\\\ebufn_8"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A @@TE_B @VDD @VSS @@Z @prefix\\\\ebufn_8"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_einvn_2.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_einvn_2.sym
@@ -17,9 +17,9 @@ v {xschem version=3.1.0 file_version=1.0
 
 G {}
 K {type=primitive
-format="@name @@A @@TE_B @VGND @VNB @VPB @VPWR @@Z @prefix\\\\einvn_2"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A @@TE_B @VDD @VSS @@Z @prefix\\\\einvn_2"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_einvn_4.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_einvn_4.sym
@@ -17,9 +17,9 @@ v {xschem version=3.1.0 file_version=1.0
 
 G {}
 K {type=primitive
-format="@name @@A @@TE_B @VGND @VNB @VPB @VPWR @@Z @prefix\\\\einvn_4"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A @@TE_B @VDD @VSS @@Z @prefix\\\\einvn_4"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_einvn_8.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_einvn_8.sym
@@ -17,9 +17,9 @@ v {xschem version=3.1.0 file_version=1.0
 
 G {}
 K {type=primitive
-format="@name @@A @@TE_B @VGND @VNB @VPB @VPWR @@Z @prefix\\\\einvn_8"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A @@TE_B @VDD @VSS @@Z @prefix\\\\einvn_8"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_inv_16.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_inv_16.sym
@@ -17,9 +17,9 @@ v {xschem version=3.1.0 file_version=1.0
 
 G {}
 K {type=primitive
-format="@name @@A @VGND @VNB @VPB @VPWR @@Y @prefix\\\\inv_16"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A @VDD @VSS @@Y @prefix\\\\inv_16"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_inv_2.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_inv_2.sym
@@ -18,9 +18,9 @@ v {xschem version=3.1.0 file_version=1.0
 G {}
 K {type=primitive
 function1="0 ~"
-format="@name @@A @VGND @VNB @VPB @VPWR @@Y @prefix\\\\inv_2"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A @VDD @VSS @@Y @prefix\\\\inv_2"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_inv_4.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_inv_4.sym
@@ -17,9 +17,9 @@ v {xschem version=3.1.0 file_version=1.0
 
 G {}
 K {type=primitive
-format="@name @@A @VGND @VNB @VPB @VPWR @@Y @prefix\\\\inv_4"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A @VDD @VSS @@Y @prefix\\\\inv_4"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_inv_8.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_inv_8.sym
@@ -17,9 +17,9 @@ v {xschem version=3.1.0 file_version=1.0
 
 G {}
 K {type=primitive
-format="@name @@A @VGND @VNB @VPB @VPWR @@Y @prefix\\\\inv_8"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A @VDD @VSS @@Y @prefix\\\\inv_8"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_mux2_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_mux2_1.sym
@@ -18,9 +18,9 @@ v {xschem version=3.1.0 file_version=1.0
 G {}
 K {type=primitive
 function3="0 1 2 M"
-format="@name @@A0 @@A1 @@S @VGND @VNB @VPB @VPWR @@X @prefix\\\\mux2_1"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A0 @@A1 @@S @VDD @VSS @@X @prefix\\\\mux2_1"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_mux2_2.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_mux2_2.sym
@@ -18,9 +18,9 @@ v {xschem version=3.1.0 file_version=1.0
 G {}
 K {type=primitive
 function3="0 1 2 M"
-format="@name @@A0 @@A1 @@S @VGND @VNB @VPB @VPWR @@X @prefix\\\\mux2_2"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A0 @@A1 @@S @VDD @VSS @@X @prefix\\\\mux2_2"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_mux4_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_mux4_1.sym
@@ -18,9 +18,9 @@ v {xschem version=3.1.0 file_version=1.0
 G {}
 K {type=primitive
 function6="0 1 4 M 2 3 4 M 5 M"
-format="@name @@A0 @@A1 @@A2 @@A3 @@S0 @@S1 @VGND @VNB @VPB @VPWR @@X @prefix\\\\mux4_1"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A0 @@A1 @@A2 @@A3 @@S0 @@S1 @VDD @VSS @@X @prefix\\\\mux4_1"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nand2_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nand2_1.sym
@@ -18,9 +18,9 @@ v {xschem version=3.1.0 file_version=1.0
 G {}
 K {type=primitive
 function2="0 1 & ~"
-format="@name @@A @@B @VGND @VNB @VPB @VPWR @@Y @prefix\\\\nand2_1"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A @@B @VDD @VSS @@Y @prefix\\\\nand2_1"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true
 }

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nand2_2.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nand2_2.sym
@@ -18,9 +18,9 @@ v {xschem version=3.1.0 file_version=1.0
 G {}
 K {type=primitive
 function2="0 1 & ~"
-format="@name @@A @@B @VGND @VNB @VPB @VPWR @@Y @prefix\\\\nand2_2"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A @@B @VDD @VSS @@Y @prefix\\\\nand2_2"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nand2b_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nand2b_1.sym
@@ -17,9 +17,9 @@ v {xschem version=3.1.0 file_version=1.0
 
 G {}
 K {type=primitive
-format="@name @@A_N @@B @VGND @VNB @VPB @VPWR @@Y @prefix\\\\nand2b_1"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A_N @@B @VDD @VSS @@Y @prefix\\\\nand2b_1"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nand2b_2.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nand2b_2.sym
@@ -17,9 +17,9 @@ v {xschem version=3.1.0 file_version=1.0
 
 G {}
 K {type=primitive
-format="@name @@A_N @@B @VGND @VNB @VPB @VPWR @@Y @prefix\\\\nand2b_2"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A_N @@B @VDD @VSS @@Y @prefix\\\\nand2b_2"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nand3_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nand3_1.sym
@@ -18,9 +18,9 @@ v {xschem version=3.1.0 file_version=1.0
 G {}
 K {type=primitive
 function3="0 1 2 & & ~"
-format="@name @@A @@B @@C @VGND @VNB @VPB @VPWR @@Y @prefix\\\\nand3_1"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A @@B @@C @VDD @VSS @@Y @prefix\\\\nand3_1"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true
 }

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nand3b_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nand3b_1.sym
@@ -17,9 +17,9 @@ v {xschem version=3.1.0 file_version=1.0
 
 G {}
 K {type=primitive
-format="@name @@A_N @@B @@C @VGND @VNB @VPB @VPWR @@Y @prefix\\\\nand3b_1"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A_N @@B @@C @VDD @VSS @@Y @prefix\\\\nand3b_1"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nand4_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nand4_1.sym
@@ -18,9 +18,9 @@ v {xschem version=3.1.0 file_version=1.0
 G {}
 K {type=primitive
 function4="0 1 2 3 & & & ~"
-format="@name @@A @@B @@C @@D @VGND @VNB @VPB @VPWR @@Y @prefix\\\\nand4_1"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A @@B @@C @@D @VDD @VSS @@Y @prefix\\\\nand4_1"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nor2_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nor2_1.sym
@@ -18,9 +18,9 @@ v {xschem version=3.1.0 file_version=1.0
 G {}
 K {type=primitive
 function2="0 1 | ~"
-format="@name @@A @@B @VGND @VNB @VPB @VPWR @@Y @prefix\\\\nor2_1"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A @@B @VDD @VSS @@Y @prefix\\\\nor2_1"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nor2_2.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nor2_2.sym
@@ -18,9 +18,9 @@ v {xschem version=3.1.0 file_version=1.0
 G {}
 K {type=primitive
 function2="0 1 | ~"
-format="@name @@A @@B @VGND @VNB @VPB @VPWR @@Y @prefix\\\\nor2_2"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A @@B @VDD @VSS @@Y @prefix\\\\nor2_2"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nor2b_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nor2b_1.sym
@@ -18,9 +18,9 @@ v {xschem version=3.1.0 file_version=1.0
 G {}
 K {type=primitive
 function2="0 1 ~ | ~"
-format="@name @@A @@B_N @VGND @VNB @VPB @VPWR @@Y @prefix\\\\nor2b_1"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A @@B_N @VDD @VSS @@Y @prefix\\\\nor2b_1"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nor2b_2.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nor2b_2.sym
@@ -17,9 +17,9 @@ v {xschem version=3.1.0 file_version=1.0
 
 G {}
 K {type=primitive
-format="@name @@A @@B_N @VGND @VNB @VPB @VPWR @@Y @prefix\\\\nor2b_2"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A @@B_N @VDD @VSS @@Y @prefix\\\\nor2b_2"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nor3_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nor3_1.sym
@@ -18,9 +18,9 @@ v {xschem version=3.1.0 file_version=1.0
 G {}
 K {type=primitive
 function3="0 1 2 | | ~"
-format="@name @@A @@B @@C @VGND @VNB @VPB @VPWR @@Y @prefix\\\\nor3_1"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A @@B @@C @VDD @VSS @@Y @prefix\\\\nor3_1"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nor3_2.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nor3_2.sym
@@ -17,9 +17,9 @@ v {xschem version=3.1.0 file_version=1.0
 
 G {}
 K {type=primitive
-format="@name @@A @@B @@C @VGND @VNB @VPB @VPWR @@Y @prefix\\\\nor3_2"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A @@B @@C @VDD @VSS @@Y @prefix\\\\nor3_2"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nor4_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nor4_1.sym
@@ -17,9 +17,9 @@ v {xschem version=3.1.0 file_version=1.0
 
 G {}
 K {type=primitive
-format="@name @@A @@B @@C @@D @VGND @VNB @VPB @VPWR @@Y @prefix\\\\nor4_1"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A @@B @@C @@D @VDD @VSS @@Y @prefix\\\\nor4_1"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nor4_2.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nor4_2.sym
@@ -18,9 +18,9 @@ v {xschem version=3.1.0 file_version=1.0
 G {}
 K {type=primitive
 function4="0 1 2 3 | | | ~"
-format="@name @@A @@B @@C @@D @VGND @VNB @VPB @VPWR @@Y @prefix\\\\nor4_2"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A @@B @@C @@D @VDD @VSS @@Y @prefix\\\\nor4_2"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_o21ai_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_o21ai_1.sym
@@ -18,9 +18,9 @@ v {xschem version=3.1.0 file_version=1.0
 G {}
 K {type=primitive
 function3="0 1 | 2 & ~"
-format="@name @@A1 @@A2 @@B1 @VGND @VNB @VPB @VPWR @@Y @prefix\\\\o21ai_1"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A1 @@A2 @@B1 @VDD @VSS @@Y @prefix\\\\o21ai_1"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_or2_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_or2_1.sym
@@ -18,9 +18,9 @@ v {xschem version=3.1.0 file_version=1.0
 G {}
 K {type=primitive
 function2="0 1 |"
-format="@name @@A @@B @VGND @VNB @VPB @VPWR @@X @prefix\\\\or2_1"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A @@B @VDD @VSS @@X @prefix\\\\or2_1"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_or2_2.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_or2_2.sym
@@ -18,9 +18,9 @@ v {xschem version=3.1.0 file_version=1.0
 G {}
 K {type=primitive
 function2="0 1 |"
-format="@name @@A @@B @VGND @VNB @VPB @VPWR @@X @prefix\\\\or2_2"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A @@B @VDD @VSS @@X @prefix\\\\or2_2"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_or3_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_or3_1.sym
@@ -17,9 +17,9 @@ v {xschem version=3.1.0 file_version=1.0
 
 G {}
 K {type=primitive
-format="@name @@A @@B @@C @VGND @VNB @VPB @VPWR @@X @prefix\\\\or3_1"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A @@B @@C @VDD @VSS @@X @prefix\\\\or3_1"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true
 function3="0 1 2 | |"}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_or3_2.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_or3_2.sym
@@ -18,9 +18,9 @@ v {xschem version=3.1.0 file_version=1.0
 G {}
 K {type=primitive
 function3="0 1 2 | |"
-format="@name @@A @@B @@C @VGND @VNB @VPB @VPWR @@X @prefix\\\\or3_2"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A @@B @@C @VDD @VSS @@X @prefix\\\\or3_2"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_or4_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_or4_1.sym
@@ -18,9 +18,9 @@ v {xschem version=3.1.0 file_version=1.0
 G {}
 K {type=primitive
 function4="0 1 2 3 | | |"
-format="@name @@A @@B @@C @@D @VGND @VNB @VPB @VPWR @@X @prefix\\\\or4_1"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A @@B @@C @@D @VDD @VSS @@X @prefix\\\\or4_1"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_or4_2.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_or4_2.sym
@@ -18,9 +18,9 @@ v {xschem version=3.1.0 file_version=1.0
 G {}
 K {type=primitive
 function4="0 1 2 3 | | |"
-format="@name @@A @@B @@C @@D @VGND @VNB @VPB @VPWR @@X @prefix\\\\or4_2"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A @@B @@C @@D @VDD @VSS @@X @prefix\\\\or4_2"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_sdfbbp_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_sdfbbp_1.sym
@@ -17,9 +17,9 @@ v {xschem version=3.1.0 file_version=1.0
 
 G {}
 K {type=primitive
-format="@name @@CLK @@D @@RESET_B @@SCD @@SCE @@SET_B @VGND @VNB @VPB @VPWR @@Q @@Q_N @prefix\\\\sdfbbp_1"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@CLK @@D @@Q @@Q_N @@@RESET_B @@SCD @@SCE @@SET_B VDD @VSS @prefix\\\\sdfbbp_1"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 }
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_xnor2_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_xnor2_1.sym
@@ -17,9 +17,9 @@ v {xschem version=3.1.0 file_version=1.0
 
 G {}
 K {type=primitive
-format="@name @@A @@B @VGND @VNB @VPB @VPWR @@Y @prefix\\\\xnor2_1"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A @@B @VDD @VSS @@Y @prefix\\\\xnor2_1"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_xor2_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_xor2_1.sym
@@ -18,9 +18,9 @@ v {xschem version=3.1.0 file_version=1.0
 G {}
 K {type=primitive
 function2="0 1 ^"
-format="@name @@A @@B @VGND @VNB @VPB @VPWR @@X @prefix\\\\xor2_1"
-template="name=x1 VGND=VGND VNB=VNB VPB=VPB VPWR=VPWR prefix=sg13g2_ "
-extra="VGND VNB VPB VPWR prefix"
+format="@name @@A @@B @VDD @VSS @@X @prefix\\\\xor2_1"
+template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
+extra="VDD VSS prefix"
 verilogprefix=sg13g2_
 highlight=true
 }


### PR DESCRIPTION
1. This PR updates the standard cells symbols definition for xschem to be compatible with SPICE level netlist. 
All the ports are in alphabetical order. Power ports are defined as VDD and VSS. 

2. Minor change in `ngspice/models/resistors_mod.lib` where "m" parameter was assigned to the Rzspec. Now parallel multiplier downscales the value of the resistance correctly.
