### PR TITLE
Qucs-S mosfets symbols and related examples updated to support m parameter 

### DIFF
--- a/ihp-sg13g2/libs.tech/qucs/examples/dc_hv_nmos.sch
+++ b/ihp-sg13g2/libs.tech/qucs/examples/dc_hv_nmos.sch
@@ -1,6 +1,6 @@
 <Qucs Schematic 24.2.0>
 <Properties>
-  <View=-105,-4,1642,932,0.851337,0,1>
+  <View=-27,-4,1565,985,0.944385,0,0>
   <Grid=10,10,1>
   <DataSet=dc_hv_nmos.dat>
   <DataDisplay=dc_hv_nmos.dpl>
@@ -27,7 +27,7 @@
   <INCLSCR INCLSCR1 1 130 50 -60 16 0 0 ".LIB ../../.qucs/IHP-Open-PDK-main/ihp-sg13g2/libs.tech/ngspice/models/cornerMOShv.lib mos_tt\n.control\npre_osdi ../../.qucs/psp103_nqs.osdi\n.endc" 1 "" 0 "" 0>
   <.DC DC1 1 90 180 0 41 0 0 "26.85" 0 "0.001" 0 "1 pA" 0 "1 uV" 0 "no" 0 "150" 0 "no" 0 "none" 0 "CroutLU" 0>
   <.SW SW2 1 260 280 0 68 0 0 "SW1" 1 "lin" 1 "V1" 1 "0" 1 "0.9" 1 "10" 1 "false" 0>
-  <Lib sg13_hv_nmos1 1 270 750 55 -121 0 0 "/home/herman/.qucs/user_lib/IHP_PDK_nonlinear_components" 0 "sg13_hv_nmos" 0 "1.0u" 1 "0.45u" 1 "1" 1 "1" 0 "0" 0 "0" 0 "0" 0 "0" 0 "0" 0 "0.346e-6" 0 "0.38e-6" 0 "0.15e-6" 0 "0" 0 "1" 0>
+  <Lib sg13_hv_nmos1 1 270 750 55 -121 0 0 "/home/herman/.qucs/user_lib/IHP_PDK_nonlinear_components" 0 "sg13_hv_nmos" 0 "1.0u" 1 "0.45u" 1 "1" 1 "1" 1 "0" 0 "0" 0 "0" 0 "0" 0 "0" 0 "0.346e-6" 0 "0.38e-6" 0 "0.15e-6" 0 "0" 0 "1" 0>
 </Components>
 <Wires>
   <270 810 270 840 "" 0 0 0 "">
@@ -43,8 +43,8 @@
   <160 830 160 840 "" 0 0 0 "">
 </Wires>
 <Diagrams>
-  <Rect 639 890 831 618 3 #c0c0c0 1 00 1 0 0.5 3 1 -2.29858e-05 0.0001 0.000252839 1 -1 1 1 315 0 225 1 0 0 "" "" "">
-	<"ngspice/i(pr1)" #0000ff 0 3 0 0 0>
+  <Rect 639 890 831 618 3 #c0c0c0 1 00 1 -1 0.2 1 1 -1 0.2 1 1 -1 0.2 1 315 0 225 1 0 0 "" "" "">
+	<"ngspice/sw1.i(pr1)" #ff0000 0 3 0 0 0>
   </Rect>
 </Diagrams>
 <Paintings>

--- a/ihp-sg13g2/libs.tech/qucs/examples/dc_hv_pmos.sch
+++ b/ihp-sg13g2/libs.tech/qucs/examples/dc_hv_pmos.sch
@@ -1,6 +1,6 @@
 <Qucs Schematic 24.2.0>
 <Properties>
-  <View=-186,0,1651,1077,0.809276,0,75>
+  <View=-85,-4,1583,976,0.90102,0,0>
   <Grid=10,10,1>
   <DataSet=dc_hv_pmos.dat>
   <DataDisplay=dc_hv_pmos.dpl>
@@ -27,7 +27,7 @@
   <Vdc V1 1 80 870 -61 -26 0 3 "1 V" 1>
   <IProbe Pr1 1 190 710 16 -26 0 1>
   <INCLSCR INCLSCR1 1 130 50 -60 16 0 0 ".LIB ../../.qucs/IHP-Open-PDK-main/ihp-sg13g2/libs.tech/ngspice/models/cornerMOShv.lib mos_tt\n.control\npre_osdi ../../.qucs/psp103_nqs.osdi\n.endc" 1 "" 0 "" 0>
-  <Lib sg13_hv_pmos1 1 190 820 45 -101 0 0 "/home/herman/.qucs/user_lib/IHP_PDK_nonlinear_components" 0 "sg13_hv_pmos" 0 "1.0u" 1 "0.45u" 1 "1" 0 "1" 0 "0" 0 "0" 0 "0" 0 "0" 0 "0" 0 "0.346e-6" 0 "0.38e-6" 0 "0.15e-6" 0 "0" 0 "1" 0>
+  <Lib sg13_hv_pmos1 1 190 820 45 -101 0 0 "/home/herman/.qucs/user_lib/IHP_PDK_nonlinear_components" 0 "sg13_hv_pmos" 0 "1.0u" 1 "0.45u" 1 "1" 0 "1" 1 "0" 0 "0" 0 "0" 0 "0" 0 "0" 0 "0.346e-6" 0 "0.38e-6" 0 "0.15e-6" 0 "0" 0 "1" 0>
 </Components>
 <Wires>
   <190 880 190 910 "" 0 0 0 "">
@@ -43,8 +43,8 @@
   <80 900 80 910 "" 0 0 0 "">
 </Wires>
 <Diagrams>
-  <Rect 492 870 986 577 3 #c0c0c0 1 00 1 0 0.2 3 1 -5e-06 5e-06 4.05672e-05 1 -1 0.2 1 315 0 225 1 0 0 "" "" "">
-	<"ngspice/i(pr1)" #0000ff 0 3 0 0 0>
+  <Rect 492 870 986 577 3 #c0c0c0 1 00 1 0 0.2 3 1 -5e-07 5e-07 4.34555e-06 1 -1 0.2 1 315 0 225 1 0 0 "" "" "">
+	<"ngspice/sw1.i(pr1)" #ff0000 0 3 0 0 0>
   </Rect>
 </Diagrams>
 <Paintings>

--- a/ihp-sg13g2/libs.tech/qucs/examples/dc_lv_nmos.sch
+++ b/ihp-sg13g2/libs.tech/qucs/examples/dc_lv_nmos.sch
@@ -1,6 +1,6 @@
 <Qucs Schematic 24.2.0>
 <Properties>
-  <View=-735,-396,3009,1608,0.703584,568,151>
+  <View=-6,-4,1543,906,0.97033,0,0>
   <Grid=10,10,1>
   <DataSet=dc_lv_nmos.dat>
   <DataDisplay=dc_lv_nmos.dpl>
@@ -24,10 +24,10 @@
   <GND * 1 450 840 0 0 0 0>
   <Vdc V1 1 160 800 18 -26 0 1 "1 V" 1>
   <GND * 1 160 840 0 0 0 0>
-  <Lib sg13_lv_nmos1 1 270 750 55 -121 0 0 "/home/herman/.qucs/user_lib/IHP_PDK_nonlinear_components" 0 "sg13_lv_nmos" 0 "1u" 1 "0.45u" 1 "1" 1 "1" 0 "0" 0 "0" 0 "0" 0 "0" 0 "0" 0 "0.346e-6" 0 "0.38e-6" 0 "0.15e-6" 0 "0" 0 "1" 0>
   <INCLSCR INCLSCR1 1 130 50 -60 16 0 0 ".LIB ../../.qucs/IHP-Open-PDK-main/ihp-sg13g2/libs.tech/ngspice/models/cornerMOSlv.lib mos_tt\n.control\npre_osdi ../../.qucs/psp103_nqs.osdi\n.endc" 1 "" 0 "" 0>
   <.DC DC1 1 90 180 0 41 0 0 "26.85" 0 "0.001" 0 "1 pA" 0 "1 uV" 0 "no" 0 "150" 0 "no" 0 "none" 0 "CroutLU" 0>
   <.SW SW2 1 260 280 0 68 0 0 "SW1" 1 "lin" 1 "V1" 1 "0" 1 "0.9" 1 "10" 1 "false" 0>
+  <Lib sg13_lv_nmos1 1 270 750 55 -121 0 0 "/home/herman/.qucs/user_lib/IHP_PDK_nonlinear_components" 0 "sg13_lv_nmos" 0 "0.35u" 1 "0.34u" 1 "1" 1 "1" 1 "0" 0 "0" 0 "0" 0 "0" 0 "0" 0 "0.346e-6" 0 "0.38e-6" 0 "0.15e-6" 0 "0" 0 "1" 0>
 </Components>
 <Wires>
   <270 810 270 840 "" 0 0 0 "">
@@ -43,8 +43,8 @@
   <160 830 160 840 "" 0 0 0 "">
 </Wires>
 <Diagrams>
-  <Rect 639 890 831 618 3 #c0c0c0 1 00 1 0 0.5 3 1 -2.29858e-05 0.0001 0.000252839 1 -1 1 1 315 0 225 1 0 0 "" "" "">
-	<"ngspice/i(pr1)" #0000ff 0 3 0 0 0>
+  <Rect 602 852 868 643 3 #c0c0c0 1 00 1 0 0.1 2 1 0 5e-05 0.000381884 1 -1 0.2 1 315 0 225 1 0 0 "" "" "">
+	<"ngspice/sw1.i(pr1)" #0000ff 0 3 0 0 0>
   </Rect>
 </Diagrams>
 <Paintings>

--- a/ihp-sg13g2/libs.tech/qucs/examples/dc_lv_pmos.sch
+++ b/ihp-sg13g2/libs.tech/qucs/examples/dc_lv_pmos.sch
@@ -1,6 +1,6 @@
 <Qucs Schematic 24.2.0>
 <Properties>
-  <View=-167,-4,1664,976,0.812245,0,0>
+  <View=-85,-4,1583,976,0.90102,0,0>
   <Grid=10,10,1>
   <DataSet=dc_lv_pmos.dat>
   <DataDisplay=dc_lv_pmos.dpl>
@@ -26,8 +26,8 @@
   <Vdc V2 1 370 820 -61 -26 0 3 "1 V" 1>
   <Vdc V1 1 80 870 -61 -26 0 3 "1 V" 1>
   <IProbe Pr1 1 190 710 16 -26 0 1>
-  <Lib sg13_lv_pmos1 1 190 820 45 -101 0 0 "/home/herman/.qucs/user_lib/IHP_PDK_nonlinear_components" 0 "sg13_lv_pmos" 0 "1u" 1 "0.34u" 1 "1" 0 "1" 0 "0" 0 "0" 0 "0" 0 "0" 0 "0" 0 "0.346e-6" 0 "0.38e-6" 0 "0.15e-6" 0 "0" 0 "1" 0>
   <INCLSCR INCLSCR1 1 130 50 -60 16 0 0 ".LIB ../../.qucs/IHP-Open-PDK-main/ihp-sg13g2/libs.tech/ngspice/models/cornerMOSlv.lib mos_tt\n.control\npre_osdi ../../.qucs/psp103_nqs.osdi\n.endc" 1 "" 0 "" 0>
+  <Lib sg13_lv_pmos1 1 190 820 45 -101 0 0 "/home/herman/.qucs/user_lib/IHP_PDK_nonlinear_components" 0 "sg13_lv_pmos" 0 "0.35u" 1 "0.34u" 1 "1" 0 "1" 1 "0" 0 "0" 0 "0" 0 "0" 0 "0" 0 "0.346e-6" 0 "0.38e-6" 0 "0.15e-6" 0 "0" 0 "1" 0>
 </Components>
 <Wires>
   <190 880 190 910 "" 0 0 0 "">
@@ -43,8 +43,8 @@
   <80 900 80 910 "" 0 0 0 "">
 </Wires>
 <Diagrams>
-  <Rect 492 870 986 577 3 #c0c0c0 1 00 1 0 0.2 3 1 -5e-06 5e-06 4.05672e-05 1 -1 0.2 1 315 0 225 1 0 0 "" "" "">
-	<"ngspice/i(pr1)" #0000ff 0 3 0 0 0>
+  <Rect 492 870 986 577 3 #c0c0c0 1 00 1 -1 0.1 1 1 -1 0.2 1 1 -1 0.2 1 315 0 225 1 0 0 "" "" "">
+	<"ngspice/sw1.i(pr1)" #0000ff 0 3 0 0 0>
   </Rect>
 </Diagrams>
 <Paintings>

--- a/ihp-sg13g2/libs.tech/qucs/examples/symbols.sch
+++ b/ihp-sg13g2/libs.tech/qucs/examples/symbols.sch
@@ -1,6 +1,6 @@
 <Qucs Schematic 24.2.0>
 <Properties>
-  <View=-154,-2,1677,999,1.17031,0,0>
+  <View=56,105,1360,872,1.15274,0,0>
   <Grid=10,10,1>
   <DataSet=symbols.dat>
   <DataDisplay=symbols.dpl>
@@ -22,16 +22,16 @@
   <Lib rppd1 1 730 360 -110 -196 0 0 "/home/herman/.qucs/user_lib/IHP_PDK_basic_components" 0 "rppd" 0 "1.0u" 1 "0.5u" 1 "1" 1>
   <Lib rsil1 1 710 190 50 -26 0 0 "/home/herman/.qucs/user_lib/IHP_PDK_basic_components" 0 "rsil" 0 "1.0u" 1 "0.5u" 1 "1" 1>
   <Lib dpantenna1 1 360 310 40 -16 0 0 "/home/herman/.qucs/user_lib/IHP_PDK_nonlinear_components" 0 "dpantenna" 0 "0.78u" 1 "0.78u" 1>
-  <Lib sg13_lv_nmos1 1 170 550 55 -121 0 0 "/home/herman/.qucs/user_lib/IHP_PDK_nonlinear_components" 0 "sg13_lv_nmos" 0 "0.35u" 1 "0.34u" 1 "1" 1 "1" 0 "0" 0 "0" 0 "0" 0 "0" 0 "0" 0 "0.346e-6" 0 "0.38e-6" 0 "0.15e-6" 0 "0" 0 "1" 0>
-  <Lib sg13_hv_nmos1 1 360 550 55 -121 0 0 "/home/herman/.qucs/user_lib/IHP_PDK_nonlinear_components" 0 "sg13_hv_nmos" 0 "1.0u" 1 "0.45u" 1 "1" 1 "1" 0 "0" 0 "0" 0 "0" 0 "0" 0 "0" 0 "0.346e-6" 0 "0.38e-6" 0 "0.15e-6" 0 "0" 0 "1" 0>
-  <Lib sg13_lv_pmos1 1 620 550 45 -101 0 0 "/home/herman/.qucs/user_lib/IHP_PDK_nonlinear_components" 0 "sg13_lv_pmos" 0 "0.35u" 1 "0.34u" 1 "1" 0 "1" 0 "0" 0 "0" 0 "0" 0 "0" 0 "0" 0 "0.346e-6" 0 "0.38e-6" 0 "0.15e-6" 0 "0" 0 "1" 0>
-  <Lib sg13_hv_pmos1 1 860 550 45 -101 0 0 "/home/herman/.qucs/user_lib/IHP_PDK_nonlinear_components" 0 "sg13_hv_pmos" 0 "1.0u" 1 "0.45u" 1 "1" 0 "1" 0 "0" 0 "0" 0 "0" 0 "0" 0 "0" 0 "0.346e-6" 0 "0.38e-6" 0 "0.15e-6" 0 "0" 0 "1" 0>
   <Lib npn13G1 1 170 710 10 64 0 0 "/home/herman/.qucs/user_lib/IHP_PDK_nonlinear_components" 0 "npn13G2" 0 "1" 1>
   <Lib npn13G2l1 1 330 710 10 64 0 0 "/home/herman/.qucs/user_lib/IHP_PDK_nonlinear_components" 0 "npn13G2l" 0 "1" 1 "1" 1>
   <Lib npn13G2v1 1 500 710 10 64 0 0 "/home/herman/.qucs/user_lib/IHP_PDK_nonlinear_components" 0 "npn13G2v" 0 "1" 1>
   <Lib cap_rfcmim1 1 1160 190 50 -16 0 0 "/home/herman/.qucs/user_lib/IHP_PDK_basic_components" 0 "cap_rfcmim" 0 "7.0u" 1 "7.0u" 1>
   <Lib cap_cmim1 1 980 190 30 -26 0 0 "/home/herman/.qucs/user_lib/IHP_PDK_basic_components" 0 "cap_cmim" 0 "7.0u" 1 "7u" 1>
   <Lib dantenna1 1 180 310 40 -16 0 0 "/home/herman/.qucs/user_lib/IHP_PDK_nonlinear_components" 0 "dantenna" 0 "0.78u" 1 "0.78u" 1>
+  <Lib sg13_lv_nmos1 1 170 510 55 -121 0 0 "/home/herman/.qucs/user_lib/IHP_PDK_nonlinear_components" 0 "sg13_lv_nmos" 0 "0.35u" 1 "0.34u" 1 "1" 1 "1" 1 "0" 0 "0" 0 "0" 0 "0" 0 "0" 0 "0.346e-6" 0 "0.38e-6" 0 "0.15e-6" 0 "0" 0 "1" 0>
+  <Lib sg13_hv_nmos1 1 410 510 55 -121 0 0 "/home/herman/.qucs/user_lib/IHP_PDK_nonlinear_components" 0 "sg13_hv_nmos" 0 "1.0u" 1 "0.45u" 1 "1" 1 "1" 1 "0" 0 "0" 0 "0" 0 "0" 0 "0" 0 "0.346e-6" 0 "0.38e-6" 0 "0.15e-6" 0 "0" 0 "1" 0>
+  <Lib sg13_lv_pmos1 1 650 510 45 -101 0 0 "/home/herman/.qucs/user_lib/IHP_PDK_nonlinear_components" 0 "sg13_lv_pmos" 0 "0.35u" 1 "0.34u" 1 "1" 0 "1" 1 "0" 0 "0" 0 "0" 0 "0" 0 "0" 0 "0.346e-6" 0 "0.38e-6" 0 "0.15e-6" 0 "0" 0 "1" 0>
+  <Lib sg13_hv_pmos1 1 860 510 45 -101 0 0 "/home/herman/.qucs/user_lib/IHP_PDK_nonlinear_components" 0 "sg13_hv_pmos" 0 "1.0u" 1 "0.45u" 1 "1" 0 "1" 1 "0" 0 "0" 0 "0" 0 "0" 0 "0" 0 "0.346e-6" 0 "0.38e-6" 0 "0.15e-6" 0 "0" 0 "1" 0>
 </Components>
 <Wires>
 </Wires>

--- a/ihp-sg13g2/libs.tech/qucs/user_lib/IHP_PDK_nonlinear_components.lib
+++ b/ihp-sg13g2/libs.tech/qucs/user_lib/IHP_PDK_nonlinear_components.lib
@@ -64,13 +64,13 @@ Author: Mike Brinson, Feb 2024
 mbrin72043@yahoo.co.uk, or m.brinson@londonmet.ac.uk.
   </Description>
   <Model>
-.Def:IHP_PDK_nonlinear_components_sg13_lv_nmos d g s b w="0.35u" l="0.34u" ng="1" mfact="1"as="0" ad="0" pd="0" ps="0" trise="0" z1="0.346e-6" z2="0.38e-6" wmin="0.15e-6" rfmode="0" pre_layout="1"
+.Def:IHP_PDK_nonlinear_components_sg13_lv_nmos d g s b w="0.35u" l="0.34u" ng="1" m="1" as="0" ad="0" pd="0" ps="0" trise="0" z1="0.346e-6" z2="0.38e-6" wmin="0.15e-6" rfmode="0" pre_layout="1"
 .Def:End
   </Model>
   <Spice>*
-.SUBCKT IHP_PDK_nonlinear_components_sg13_lv_nmos  gnd d g s b w=0.35u l=0.34u ng=1 mfact=1 as=0 ad=0 pd=0 ps=0 trise=0 z1=0.346e-6 z2=0.38e-6 wmin=0.15e-6 rfmode=0 pre_layout=1 mlist=1
+.SUBCKT IHP_PDK_nonlinear_components_sg13_lv_nmos  gnd d g s b w=0.35u l=0.34u ng=1 m=1 as=0 ad=0 pd=0 ps=0 trise=0 z1=0.346e-6 z2=0.38e-6 wmin=0.15e-6 rfmode=0 pre_layout=1 mlist=1
 .INCLUDE   ../../.qucs/IHP-Open-PDK-main/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moslv_parm.lib
-X1 d g s b  sg13_lv_nmos w={w} l={l} ng={ng} mfact=1 as={as} ad={ad} pd={pd} 
+X1 d g s b  sg13_lv_nmos w={w} l={l} ng={ng} m={m} as={as} ad={ad} pd={pd} 
 + ps={ps} trise={trise} z1={z1} z2={z2} wmin={wmin} rfmode={rfmode} pre_layout={pre_layout} 
 .ENDS
   </Spice>
@@ -92,7 +92,7 @@ X1 d g s b  sg13_lv_nmos w={w} l={l} ng={ng} mfact=1 as={as} ad={ad} pd={pd}
     <.PortSym -50 0 2 0>
     <Line -20 0 10 -10 #ff0000 3 1>
     <Line -10 10 -10 -10 #ff0000 3 1>
-    <.ID 55 -121 sg13_lv_nmos "1=w=0.35u==" "1=l=0.34u==" "1=ng=1==" "0=mfact=1==" "0=as=0==" "0=ad=0==" "0=pd=0==" "0=ps=0==" "0=trise=0==" "0=z1=0.346e-6==" "0=z2=0.38e-6==" "0=wmin=0.15e-6==" "0=rfmode=0==" "0=pre_layout=1==">
+    <.ID 55 -121 sg13_lv_nmos "1=w=0.35u==" "1=l=0.34u==" "1=ng=1==" "1=m=1==" "0=as=0==" "0=ad=0==" "0=pd=0==" "0=ps=0==" "0=trise=0==" "0=z1=0.346e-6==" "0=z2=0.38e-6==" "0=wmin=0.15e-6==" "0=rfmode=0==" "0=pre_layout=1==">
   </Symbol>
 </Component>
 
@@ -103,13 +103,13 @@ Author: Mike Brinson, Feb 2024
 mbrin72043@yahoo.co.uk, or m.brinson@londonmet.ac.uk.
   </Description>
   <Model>
-.Def:IHP_PDK_nonlinear_components_sg13_hv_nmos d g s b w="1.0u" l="0.45u" ng="1" mfact="1"as="0" ad="0" pd="0" ps="0" trise="0" z1="0.346e-6" z2="0.38e-6" wmin="0.15e-6" rfmode="0" pre_layout="1"
+.Def:IHP_PDK_nonlinear_components_sg13_hv_nmos d g s b w="1.0u" l="0.45u" ng="1" m="1" as="0" ad="0" pd="0" ps="0" trise="0" z1="0.346e-6" z2="0.38e-6" wmin="0.15e-6" rfmode="0" pre_layout="1"
 .Def:End
   </Model>
   <Spice>*
-.SUBCKT IHP_PDK_nonlinear_components_sg13_hv_nmos  gnd d g s b w=0.35u l=0.34u ng=1 mfact=1 as=0 ad=0 pd=0 ps=0 trise=0 z1=0.346e-6 z2=0.38e-6 wmin=0.15e-6 rfmode=0 pre_layout=1 mlist=1
+.SUBCKT IHP_PDK_nonlinear_components_sg13_hv_nmos  gnd d g s b w=0.35u l=0.34u ng=1 m=1 as=0 ad=0 pd=0 ps=0 trise=0 z1=0.346e-6 z2=0.38e-6 wmin=0.15e-6 rfmode=0 pre_layout=1 mlist=1
 .INCLUDE   ../../.qucs/IHP-Open-PDK-main/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moshv_parm.lib
-X1 d g s b  sg13_hv_nmos w={w} l={l} ng={ng} mfact=1 as={as} ad={ad} pd={pd} 
+X1 d g s b  sg13_hv_nmos w={w} l={l} ng={ng} m={m} as={as} ad={ad} pd={pd} 
 + ps={ps} trise={trise} z1={z1} z2={z2} wmin={wmin} rfmode={rfmode} pre_layout={pre_layout} 
 .ENDS
   </Spice>
@@ -131,7 +131,7 @@ X1 d g s b  sg13_hv_nmos w={w} l={l} ng={ng} mfact=1 as={as} ad={ad} pd={pd}
     <.PortSym -50 0 2 0>
     <Line -20 0 10 -10 #ff0000 3 1>
     <Line -10 10 -10 -10 #ff0000 3 1>
-    <.ID 55 -121 sg13_hv_nmos "1=w=1.0u==" "1=l=0.45u==" "1=ng=1==" "0=mfact=1==" "0=as=0==" "0=ad=0==" "0=pd=0==" "0=ps=0==" "0=trise=0==" "0=z1=0.346e-6==" "0=z2=0.38e-6==" "0=wmin=0.15e-6==" "0=rfmode=0==" "0=pre_layout=1==">
+    <.ID 55 -121 sg13_hv_nmos "1=w=1.0u==" "1=l=0.45u==" "1=ng=1==" "1=m=1==" "0=as=0==" "0=ad=0==" "0=pd=0==" "0=ps=0==" "0=trise=0==" "0=z1=0.346e-6==" "0=z2=0.38e-6==" "0=wmin=0.15e-6==" "0=rfmode=0==" "0=pre_layout=1==">
   </Symbol>
 </Component>
 
@@ -142,13 +142,13 @@ Author: Mike Brinson, Feb 2024
 mbrin72043@yahoo.co.uk, or m.brinson@londonmet.ac.uk.
   </Description>
   <Model>
-.Def:IHP_PDK_nonlinear_components_sg13_lv_pmos d g s b w="0.35u" l="0.34u" ng="1" as="0" ad="0" pd="0" ps="0" trise="0" z1="0.346e-6" z2="0.38e-6" wmin="0.15e-6" rfmode="0" pre_layout="1"
+.Def:IHP_PDK_nonlinear_components_sg13_lv_pmos d g s b w="0.35u" l="0.34u" ng="1" m="1" as="0" ad="0" pd="0" ps="0" trise="0" z1="0.346e-6" z2="0.38e-6" wmin="0.15e-6" rfmode="0" pre_layout="1"
 .Def:End
   </Model>
   <Spice>*
-.SUBCKT IHP_PDK_nonlinear_components_sg13_lv_pmos  gnd d g s b w=0.35u l=0.34u ng=1 mfact=1 as=0 ad=0 pd=0 ps=0 trise=0 z1=0.346e-6 z2=0.38e-6 wmin=0.15e-6 rfmode=0 pre_layout=1 
+.SUBCKT IHP_PDK_nonlinear_components_sg13_lv_pmos  gnd d g s b w=0.35u l=0.34u ng=1 m=1 as=0 ad=0 pd=0 ps=0 trise=0 z1=0.346e-6 z2=0.38e-6 wmin=0.15e-6 rfmode=0 pre_layout=1 
 .INCLUDE   ../../.qucs/IHP-Open-PDK-main/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moslv_parm.lib
-X1 d g s b  sg13_lv_pmos w={w} l={l} ng={ng} mfact=1 as={as} ad={ad} pd={pd} 
+X1 d g s b  sg13_lv_pmos w={w} l={l} ng={ng} m={1} as={as} ad={ad} pd={pd} 
 + ps={ps} trise={trise} z1={z1} z2={z2} wmin={wmin} rfmode={rfmode} pre_layout={pre_layout}
 .ENDS
   </Spice>
@@ -170,7 +170,7 @@ X1 d g s b  sg13_lv_pmos w={w} l={l} ng={ng} mfact=1 as={as} ad={ad} pd={pd}
     <.PortSym -50 0 2 0>
     <Line 0 0 -10 -10 #ff0000 3 1>
     <Line -10 10 10 -10 #ff0000 3 1>
-    <.ID 45 -101 sg13_lv_pmos "1=w=0.35u==" "1=l=0.34u==" "0=ng=1==" "0=mfact=1==" "0=as=0==" "0=ad=0==" "0=pd=0==" "0=ps=0==" "0=trise=0==" "0=z1=0.346e-6==" "0=z2=0.38e-6==" "0=wmin=0.15e-6==" "0=rfmode=0==" "0=pre_layout=1==">
+    <.ID 45 -101 sg13_lv_pmos "1=w=0.35u==" "1=l=0.34u==" "0=ng=1==" "1=m=1==" "0=as=0==" "0=ad=0==" "0=pd=0==" "0=ps=0==" "0=trise=0==" "0=z1=0.346e-6==" "0=z2=0.38e-6==" "0=wmin=0.15e-6==" "0=rfmode=0==" "0=pre_layout=1==">
 </Symbol>
 </Component>
 
@@ -180,13 +180,13 @@ Author: Mike Brinson, Feb 2024
 mbrin72043@yahoo.co.uk, or m.brinson@londonmet.ac.uk.
   </Description>
   <Model>
-.Def:IHP_PDK_nonlinear_components_sg13_hv_pmos d g s b w="1.0u" l="0.45u" ng="1" as="0" ad="0" pd="0" ps="0" trise="0" z1="0.346e-6" z2="0.38e-6" wmin="0.15e-6" rfmode="0" pre_layout="1"
+.Def:IHP_PDK_nonlinear_components_sg13_hv_pmos d g s b w="1.0u" l="0.45u" ng="1" m="1" as="0" ad="0" pd="0" ps="0" trise="0" z1="0.346e-6" z2="0.38e-6" wmin="0.15e-6" rfmode="0" pre_layout="1"
 .Def:End
   </Model>
   <Spice>*
-.SUBCKT IHP_PDK_nonlinear_components_sg13_hv_pmos  gnd d g s b w=0.35u l=0.34u ng=1 mfact=1 as=0 ad=0 pd=0 ps=0 trise=0 z1=0.346e-6 z2=0.38e-6 wmin=0.15e-6 rfmode=0 pre_layout=1 
+.SUBCKT IHP_PDK_nonlinear_components_sg13_hv_pmos  gnd d g s b w=0.35u l=0.34u ng=1 m=1 as=0 ad=0 pd=0 ps=0 trise=0 z1=0.346e-6 z2=0.38e-6 wmin=0.15e-6 rfmode=0 pre_layout=1 
 .INCLUDE   ../../.qucs/IHP-Open-PDK-main/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moshv_parm.lib
-X1 d g s b  sg13_hv_pmos w={w} l={l} ng={ng} mfact=1 as={as} ad={ad} pd={pd} 
+X1 d g s b  sg13_hv_pmos w={w} l={l} ng={ng} m={m} as={as} ad={ad} pd={pd} 
 + ps={ps} trise={trise} z1={z1} z2={z2} wmin={wmin} rfmode={rfmode} pre_layout={pre_layout}
 .ENDS
   </Spice>
@@ -208,7 +208,7 @@ X1 d g s b  sg13_hv_pmos w={w} l={l} ng={ng} mfact=1 as={as} ad={ad} pd={pd}
     <.PortSym -50 0 2 0>
     <Line 0 0 -10 -10 #ff0000 3 1>
     <Line -10 10 10 -10 #ff0000 3 1>
-    <.ID 45 -101 sg13_hv_pmos "1=w=1.0u==" "1=l=0.45u==" "0=ng=1==" "0=mfact=1==" "0=as=0==" "0=ad=0==" "0=pd=0==" "0=ps=0==" "0=trise=0==" "0=z1=0.346e-6==" "0=z2=0.38e-6==" "0=wmin=0.15e-6==" "0=rfmode=0==" "0=pre_layout=1==">
+    <.ID 45 -101 sg13_hv_pmos "1=w=1.0u==" "1=l=0.45u==" "0=ng=1==" "1=m=1==" "0=as=0==" "0=ad=0==" "0=pd=0==" "0=ps=0==" "0=trise=0==" "0=z1=0.346e-6==" "0=z2=0.38e-6==" "0=wmin=0.15e-6==" "0=rfmode=0==" "0=pre_layout=1==">
   </Symbol>
 </Component>
 


### PR DESCRIPTION
Changes in `ihp-sg13g2/libs.tech/qucs/user_lib/IHP_PDK_nonlinear_components.lib` which remove `mfact` and add `m` parameter support (parallel devices). Also respective example test cases in `ihp-sg13g2/libs.tech/qucs/examples/` were updated .