### PR TITLE
sg13g2_stdcell: lib: Fix typo in libraries

### DIFF
--- a/ihp-sg13g2/libs.ref/sg13g2_stdcell/lib/sg13g2_stdcell_fast_1p32V_m40C.lib
+++ b/ihp-sg13g2/libs.ref/sg13g2_stdcell/lib/sg13g2_stdcell_fast_1p32V_m40C.lib
@@ -27286,7 +27286,7 @@ library (sg13g2_stdcell_fast_1p32V_m40C) {
       clear_preset_var1 : "H";
       clear_preset_var2 : "L";
       clocked_on : "CLK";
-      next_state : "(SCE*SCD)+(SCE'*D)";
+      next_state : "(SCE*SCD)+(SCE*D)";
       preset : "SET_B'";
     }
     test_cell () {

--- a/ihp-sg13g2/libs.ref/sg13g2_stdcell/lib/sg13g2_stdcell_fast_1p65V_m40C.lib
+++ b/ihp-sg13g2/libs.ref/sg13g2_stdcell/lib/sg13g2_stdcell_fast_1p65V_m40C.lib
@@ -27286,7 +27286,7 @@ library (sg13g2_stdcell_fast_1p65V_m40C) {
       clear_preset_var1 : "H";
       clear_preset_var2 : "L";
       clocked_on : "CLK";
-      next_state : "(SCE*SCD)+(SCE'*D)";
+      next_state : "(SCE*SCD)+(SCE*D)";
       preset : "SET_B'";
     }
     test_cell () {

--- a/ihp-sg13g2/libs.ref/sg13g2_stdcell/lib/sg13g2_stdcell_slow_1p08V_125C.lib
+++ b/ihp-sg13g2/libs.ref/sg13g2_stdcell/lib/sg13g2_stdcell_slow_1p08V_125C.lib
@@ -27286,7 +27286,7 @@ library (sg13g2_stdcell_slow_1p08V_125C) {
       clear_preset_var1 : "H";
       clear_preset_var2 : "L";
       clocked_on : "CLK";
-      next_state : "(SCE*SCD)+(SCE'*D)";
+      next_state : "(SCE*SCD)+(SCE*D)";
       preset : "SET_B'";
     }
     test_cell () {

--- a/ihp-sg13g2/libs.ref/sg13g2_stdcell/lib/sg13g2_stdcell_slow_1p35V_125C.lib
+++ b/ihp-sg13g2/libs.ref/sg13g2_stdcell/lib/sg13g2_stdcell_slow_1p35V_125C.lib
@@ -27286,7 +27286,7 @@ library (sg13g2_stdcell_slow_1p35V_125C) {
       clear_preset_var1 : "H";
       clear_preset_var2 : "L";
       clocked_on : "CLK";
-      next_state : "(SCE*SCD)+(SCE'*D)";
+      next_state : "(SCE*SCD)+(SCE*D)";
       preset : "SET_B'";
     }
     test_cell () {

--- a/ihp-sg13g2/libs.ref/sg13g2_stdcell/lib/sg13g2_stdcell_typ_1p20V_25C.lib
+++ b/ihp-sg13g2/libs.ref/sg13g2_stdcell/lib/sg13g2_stdcell_typ_1p20V_25C.lib
@@ -27286,7 +27286,7 @@ library (sg13g2_stdcell_typ_1p20V_25C) {
       clear_preset_var1 : "H";
       clear_preset_var2 : "L";
       clocked_on : "CLK";
-      next_state : "(SCE*SCD)+(SCE'*D)";
+      next_state : "(SCE*SCD)+(SCE*D)";
       preset : "SET_B'";
     }
     test_cell () {

--- a/ihp-sg13g2/libs.ref/sg13g2_stdcell/lib/sg13g2_stdcell_typ_1p50V_25C.lib
+++ b/ihp-sg13g2/libs.ref/sg13g2_stdcell/lib/sg13g2_stdcell_typ_1p50V_25C.lib
@@ -27286,7 +27286,7 @@ library (sg13g2_stdcell_typ_1p50V_25C) {
       clear_preset_var1 : "H";
       clear_preset_var2 : "L";
       clocked_on : "CLK";
-      next_state : "(SCE*SCD)+(SCE'*D)";
+      next_state : "(SCE*SCD)+(SCE*D)";
       preset : "SET_B'";
     }
     test_cell () {


### PR DESCRIPTION
Flip-flop IQ in cell sg13g2_sdfbbp_1 included an apostrophe in the next_state statement. OpenROAD reported that as unsupported expression and skip it.

Removed the apostrophe in next_state.

Before:
  "(SCE*SCD)+(SCE'*D)"
Now:
  "(SCE*SCD)+(SCE*D)"