### PR TITLE
Fixing paths and making PDK easier to install in Qucs-S

### DIFF
--- a/ihp-sg13g2/libs.tech/qucs/examples/README.txt
+++ b/ihp-sg13g2/libs.tech/qucs/examples/README.txt
@@ -1,0 +1,9 @@
+####################################################
+				IMPORTANT
+####################################################
+
+In order to use the SG13G3 PDK sample schematics, you must add the SG13G3 PDK library to the Qucs-S subcircuit search path:
+
+1) Go to File ->Application Settings ...
+2) Click on the "Locations" tab
+3) On the bottom, click on the "Add Path With Subfolders" button and select the SG13G3 PDK library folder (/home/<username>/.qucs/user_lib)

--- a/ihp-sg13g2/libs.tech/qucs/examples/ac_mim_cap.sch
+++ b/ihp-sg13g2/libs.tech/qucs/examples/ac_mim_cap.sch
@@ -16,7 +16,7 @@
 <Symbol>
 </Symbol>
 <Components>
-  <INCLSCR INCLSCR1 1 120 50 -60 16 0 0 ".LIB ../../.qucs/IHP-Open-PDK-main/ihp-sg13g2/libs.tech/ngspice/models/cornerRES.lib res_typ\n.LIB ../../.qucs/IHP-Open-PDK-main/ihp-sg13g2/libs.tech/ngspice/models/cornerCAP.lib cap_typ\n.control\n\n.endc" 1 "" 0 "" 0>
+  <INCLSCR INCLSCR1 1 120 50 -60 16 0 0 ".LIB ~/.qucs/IHP-Open-PDK-main/ihp-sg13g2/libs.tech/ngspice/models/cornerRES.lib res_typ\n.LIB ~/.qucs/IHP-Open-PDK-main/ihp-sg13g2/libs.tech/ngspice/models/cornerCAP.lib cap_typ\n.control\n\n.endc" 1 "" 0 "" 0>
   <.AC AC1 1 70 190 0 40 0 0 "log" 1 "100k" 1 "300 GHz" 1 "101" 1 "no" 0>
   <GND * 1 360 650 0 0 0 0>
   <Vac V1 1 70 570 18 -26 0 1 "1 V" 1 "1 kHz" 0 "0" 0 "0" 0 "0" 0 "0" 0>

--- a/ihp-sg13g2/libs.tech/qucs/examples/dc_diode_op.sch
+++ b/ihp-sg13g2/libs.tech/qucs/examples/dc_diode_op.sch
@@ -19,7 +19,7 @@
   <.SW SW1 1 90 280 0 68 0 0 "DC1" 1 "lin" 1 "V2" 1 "0" 1 "1" 1 "301" 1 "false" 0>
   <GND * 1 270 840 0 0 0 0>
   <IProbe Pr1 1 270 640 -37 -26 0 3>
-  <INCLSCR INCLSCR1 1 130 50 -60 16 0 0 ".INCLUDE ../../.qucs/IHP-Open-PDK-main/ihp-sg13g2/libs.tech/ngspice/models/diodes.lib\n.control\npre_osdi ../../.qucs/psp103_nqs.osdi\n.endc" 1 "" 0 "" 0>
+  <INCLSCR INCLSCR1 1 130 50 -60 16 0 0 ".INCLUDE ~/.qucs/IHP-Open-PDK-main/ihp-sg13g2/libs.tech/ngspice/models/diodes.lib\n.control\npre_osdi ~/.qucs/psp103_nqs.osdi\n.endc" 1 "" 0 "" 0>
   <.DC DC1 1 90 180 0 41 0 0 "26.85" 0 "0.001" 0 "1 pA" 0 "1 uV" 0 "no" 0 "150" 0 "no" 0 "none" 0 "CroutLU" 0>
   <GND * 1 120 840 0 0 0 0>
   <Vdc V2 1 120 750 18 -26 0 1 "1 V" 1>

--- a/ihp-sg13g2/libs.tech/qucs/examples/dc_diode_op.sch
+++ b/ihp-sg13g2/libs.tech/qucs/examples/dc_diode_op.sch
@@ -1,6 +1,6 @@
-<Qucs Schematic 24.2.0>
+<Qucs Schematic 24.2.1>
 <Properties>
-  <View=-86,-4,1624,1075,1.25348,0,181>
+  <View=-76,-4,1614,1003,0.920856,0,0>
   <Grid=10,10,1>
   <DataSet=dc_diode_op.dat>
   <DataDisplay=dc_diode_op.dpl>
@@ -41,9 +41,9 @@
   <270 590 470 590 "" 0 0 0 "">
 </Wires>
 <Diagrams>
-  <Rect 639 890 831 618 3 #c0c0c0 1 00 1 0 0.1 1 0 0 2e-06 2e-05 1 -1 0.2 1 315 0 225 1 0 0 "" "" "">
-	<"ngspice/i(pr1)" #0000ff 2 3 0 0 0>
-	<"ngspice/i(pr2)" #ff0000 2 3 0 0 0>
+  <Rect 639 890 831 618 3 #c0c0c0 1 00 1 -1 0.2 1 0 0 2e-06 2e-05 1 -1 0.2 1 315 0 225 1 0 0 "" "" "">
+	<"ngspice/sw1.i(pr1)" #0000ff 2 3 0 0 0>
+	<"ngspice/sw1.i(pr2)" #ff0000 2 3 0 0 0>
   </Rect>
 </Diagrams>
 <Paintings>

--- a/ihp-sg13g2/libs.tech/qucs/examples/dc_hbt_13g2.sch
+++ b/ihp-sg13g2/libs.tech/qucs/examples/dc_hbt_13g2.sch
@@ -1,6 +1,6 @@
-<Qucs Schematic 24.2.0>
+<Qucs Schematic 24.2.1>
 <Properties>
-  <View=-201,-94,2082,1128,0.651338,0,0>
+  <View=-147,16,1678,1026,0.852475,0,0>
   <Grid=10,10,1>
   <DataSet=dc_hbt_13g2.dat>
   <DataDisplay=dc_hbt_13g2.dpl>
@@ -43,8 +43,8 @@
   <170 900 170 960 "" 0 0 0 "">
 </Wires>
 <Diagrams>
-  <Rect 437 899 1062 769 3 #c0c0c0 1 00 1 0 0.1 1.5 1 -0.000277029 0.0002 0.00246701 1 -1 0.2 1 315 0 225 1 0 0 "" "" "">
-	<"ngspice/i(pr1)" #ff0000 0 3 0 0 0>
+  <Rect 437 899 1062 769 3 #c0c0c0 1 00 1 -1 0.1 1 1 -1 0.2 1 1 -1 0.2 1 315 0 225 1 0 0 "" "" "">
+	<"ngspice/sw1.i(pr1)" #ff0000 0 3 0 0 0>
   </Rect>
 </Diagrams>
 <Paintings>

--- a/ihp-sg13g2/libs.tech/qucs/examples/dc_hbt_13g2.sch
+++ b/ihp-sg13g2/libs.tech/qucs/examples/dc_hbt_13g2.sch
@@ -16,7 +16,7 @@
 <Symbol>
 </Symbol>
 <Components>
-  <INCLSCR INCLSCR1 1 160 70 -60 16 0 0 ".LIB ../../.qucs/IHP-Open-PDK-main/ihp-sg13g2/libs.tech/ngspice/models/cornerHBT.lib hbt_typ\n" 1 "" 0 "" 0>
+  <INCLSCR INCLSCR1 1 160 70 -60 16 0 0 ".LIB ~/.qucs/IHP-Open-PDK-main/ihp-sg13g2/libs.tech/ngspice/models/cornerHBT.lib hbt_typ\n" 1 "" 0 "" 0>
   <.DC DC1 1 40 160 0 46 0 0 "26.85" 0 "0.001" 0 "1 pA" 0 "1 uV" 0 "no" 0 "150" 0 "no" 0 "none" 0 "CroutLU" 0>
   <.SW SW1 1 50 250 0 77 0 0 "DC1" 1 "lin" 1 "V2" 1 "0" 1 "1.5" 1 "301" 1 "false" 0>
   <.SW SW2 1 50 470 0 77 0 0 "SW1" 1 "lin" 1 "I1" 1 "0" 1 "5u" 1 "10" 1 "false" 0>

--- a/ihp-sg13g2/libs.tech/qucs/examples/dc_hv_nmos.sch
+++ b/ihp-sg13g2/libs.tech/qucs/examples/dc_hv_nmos.sch
@@ -24,7 +24,7 @@
   <GND * 1 450 840 0 0 0 0>
   <Vdc V1 1 160 800 18 -26 0 1 "1 V" 1>
   <GND * 1 160 840 0 0 0 0>
-  <INCLSCR INCLSCR1 1 130 50 -60 16 0 0 ".LIB ../../.qucs/IHP-Open-PDK-main/ihp-sg13g2/libs.tech/ngspice/models/cornerMOShv.lib mos_tt\n.control\npre_osdi ../../.qucs/psp103_nqs.osdi\n.endc" 1 "" 0 "" 0>
+  <INCLSCR INCLSCR1 1 130 50 -60 16 0 0 ".LIB ~/.qucs/IHP-Open-PDK-main/ihp-sg13g2/libs.tech/ngspice/models/cornerMOShv.lib mos_tt\n.control\npre_osdi ~/.qucs/psp103_nqs.osdi\n.endc" 1 "" 0 "" 0>
   <.DC DC1 1 90 180 0 41 0 0 "26.85" 0 "0.001" 0 "1 pA" 0 "1 uV" 0 "no" 0 "150" 0 "no" 0 "none" 0 "CroutLU" 0>
   <.SW SW2 1 260 280 0 68 0 0 "SW1" 1 "lin" 1 "V1" 1 "0" 1 "0.9" 1 "10" 1 "false" 0>
   <Lib sg13_hv_nmos1 1 270 750 55 -121 0 0 "/home/herman/.qucs/user_lib/IHP_PDK_nonlinear_components" 0 "sg13_hv_nmos" 0 "1.0u" 1 "0.45u" 1 "1" 1 "1" 1 "0" 0 "0" 0 "0" 0 "0" 0 "0" 0 "0.346e-6" 0 "0.38e-6" 0 "0.15e-6" 0 "0" 0 "1" 0>

--- a/ihp-sg13g2/libs.tech/qucs/examples/dc_hv_pmos.sch
+++ b/ihp-sg13g2/libs.tech/qucs/examples/dc_hv_pmos.sch
@@ -26,7 +26,7 @@
   <Vdc V2 1 370 820 -61 -26 0 3 "1 V" 1>
   <Vdc V1 1 80 870 -61 -26 0 3 "1 V" 1>
   <IProbe Pr1 1 190 710 16 -26 0 1>
-  <INCLSCR INCLSCR1 1 130 50 -60 16 0 0 ".LIB ../../.qucs/IHP-Open-PDK-main/ihp-sg13g2/libs.tech/ngspice/models/cornerMOShv.lib mos_tt\n.control\npre_osdi ../../.qucs/psp103_nqs.osdi\n.endc" 1 "" 0 "" 0>
+  <INCLSCR INCLSCR1 1 130 50 -60 16 0 0 ".LIB ~/.qucs/IHP-Open-PDK-main/ihp-sg13g2/libs.tech/ngspice/models/cornerMOShv.lib mos_tt\n.control\npre_osdi ~/.qucs/psp103_nqs.osdi\n.endc" 1 "" 0 "" 0>
   <Lib sg13_hv_pmos1 1 190 820 45 -101 0 0 "/home/herman/.qucs/user_lib/IHP_PDK_nonlinear_components" 0 "sg13_hv_pmos" 0 "1.0u" 1 "0.45u" 1 "1" 0 "1" 1 "0" 0 "0" 0 "0" 0 "0" 0 "0" 0 "0.346e-6" 0 "0.38e-6" 0 "0.15e-6" 0 "0" 0 "1" 0>
 </Components>
 <Wires>

--- a/ihp-sg13g2/libs.tech/qucs/examples/dc_lv_nmos.sch
+++ b/ihp-sg13g2/libs.tech/qucs/examples/dc_lv_nmos.sch
@@ -24,7 +24,7 @@
   <GND * 1 450 840 0 0 0 0>
   <Vdc V1 1 160 800 18 -26 0 1 "1 V" 1>
   <GND * 1 160 840 0 0 0 0>
-  <INCLSCR INCLSCR1 1 130 50 -60 16 0 0 ".LIB ../../.qucs/IHP-Open-PDK-main/ihp-sg13g2/libs.tech/ngspice/models/cornerMOSlv.lib mos_tt\n.control\npre_osdi ../../.qucs/psp103_nqs.osdi\n.endc" 1 "" 0 "" 0>
+  <INCLSCR INCLSCR1 1 130 50 -60 16 0 0 ".LIB ~/.qucs/IHP-Open-PDK-main/ihp-sg13g2/libs.tech/ngspice/models/cornerMOSlv.lib mos_tt\n.control\npre_osdi ~/.qucs/psp103_nqs.osdi\n.endc" 1 "" 0 "" 0>
   <.DC DC1 1 90 180 0 41 0 0 "26.85" 0 "0.001" 0 "1 pA" 0 "1 uV" 0 "no" 0 "150" 0 "no" 0 "none" 0 "CroutLU" 0>
   <.SW SW2 1 260 280 0 68 0 0 "SW1" 1 "lin" 1 "V1" 1 "0" 1 "0.9" 1 "10" 1 "false" 0>
   <Lib sg13_lv_nmos1 1 270 750 55 -121 0 0 "/home/herman/.qucs/user_lib/IHP_PDK_nonlinear_components" 0 "sg13_lv_nmos" 0 "0.35u" 1 "0.34u" 1 "1" 1 "1" 1 "0" 0 "0" 0 "0" 0 "0" 0 "0" 0 "0.346e-6" 0 "0.38e-6" 0 "0.15e-6" 0 "0" 0 "1" 0>

--- a/ihp-sg13g2/libs.tech/qucs/examples/dc_lv_pmos.sch
+++ b/ihp-sg13g2/libs.tech/qucs/examples/dc_lv_pmos.sch
@@ -26,7 +26,7 @@
   <Vdc V2 1 370 820 -61 -26 0 3 "1 V" 1>
   <Vdc V1 1 80 870 -61 -26 0 3 "1 V" 1>
   <IProbe Pr1 1 190 710 16 -26 0 1>
-  <INCLSCR INCLSCR1 1 130 50 -60 16 0 0 ".LIB ../../.qucs/IHP-Open-PDK-main/ihp-sg13g2/libs.tech/ngspice/models/cornerMOSlv.lib mos_tt\n.control\npre_osdi ../../.qucs/psp103_nqs.osdi\n.endc" 1 "" 0 "" 0>
+  <INCLSCR INCLSCR1 1 130 50 -60 16 0 0 ".LIB ~/.qucs/IHP-Open-PDK-main/ihp-sg13g2/libs.tech/ngspice/models/cornerMOSlv.lib mos_tt\n.control\npre_osdi ~/.qucs/psp103_nqs.osdi\n.endc" 1 "" 0 "" 0>
   <Lib sg13_lv_pmos1 1 190 820 45 -101 0 0 "/home/herman/.qucs/user_lib/IHP_PDK_nonlinear_components" 0 "sg13_lv_pmos" 0 "0.35u" 1 "0.34u" 1 "1" 0 "1" 1 "0" 0 "0" 0 "0" 0 "0" 0 "0" 0 "0.346e-6" 0 "0.38e-6" 0 "0.15e-6" 0 "0" 0 "1" 0>
 </Components>
 <Wires>

--- a/ihp-sg13g2/libs.tech/qucs/examples/resistors.sch
+++ b/ihp-sg13g2/libs.tech/qucs/examples/resistors.sch
@@ -22,7 +22,7 @@
 </Symbol>
 <Components>
   <.SW SW1 1 90 280 0 68 0 0 "DC1" 1 "lin" 1 "V2" 1 "0" 1 "10" 1 "301" 1 "false" 0>
-  <INCLSCR INCLSCR1 1 130 50 -60 16 0 0 ".LIB ../../.qucs/IHP-Open-PDK-main/ihp-sg13g2/libs.tech/ngspice/models/cornerRES.lib res_wcs\n.control\nop\n.endc" 1 "" 0 "" 0>
+  <INCLSCR INCLSCR1 1 130 50 -60 16 0 0 ".LIB ~/.qucs/IHP-Open-PDK-main/ihp-sg13g2/libs.tech/ngspice/models/cornerRES.lib res_wcs\n.control\nop\n.endc" 1 "" 0 "" 0>
   <Vdc V2 1 110 800 18 -26 0 1 "1 V" 1>
   <GND * 1 250 950 0 0 0 0>
   <GND * 1 110 950 0 0 0 0>

--- a/ihp-sg13g2/libs.tech/qucs/install.py
+++ b/ihp-sg13g2/libs.tech/qucs/install.py
@@ -92,6 +92,12 @@ if __name__ == "__main__":
         
     copy_files(source_directory, destination_directory)
     print("Examples copied")
+    print("\n\n#############################################")
+    print("              IMPORTANT NOTE")
+    print("#############################################\n")
+    print("Before using the PDK example schematics, you must add the PDK library path to the Qucs-S search path list.\n")
+    print("Please read the instructions provided in " + destination_directory + "/README.txt\n")
+    print("#############################################\n\n")
 
     original_file = pdk_root
     symbolic_link = "/home/" + username + "/.qucs/IHP-Open-PDK-main"

--- a/ihp-sg13g2/libs.tech/qucs/install.py
+++ b/ihp-sg13g2/libs.tech/qucs/install.py
@@ -81,6 +81,17 @@ if __name__ == "__main__":
         print(f"Destination directory '{destination_directory}' created.")
     
     copy_files(source_directory, destination_directory)
+    
+    # Copy examples to "Qucs Home" (/home/<username>/.qucs/)
+    print("Copying examples into Qucs-S Home...")
+    source_directory=pdk_root + "/ihp-sg13g2/libs.tech/qucs/examples"
+    destination_directory = "/home/" + username + "/.qucs/IHP-Open-PDK-SG13G2-Examples_prj"
+    
+    if not os.path.exists(destination_directory):
+        os.makedirs(destination_directory)
+        
+    copy_files(source_directory, destination_directory)
+    print("Examples copied")
 
     original_file = pdk_root
     symbolic_link = "/home/" + username + "/.qucs/IHP-Open-PDK-main"

--- a/ihp-sg13g2/libs.tech/qucs/user_lib/IHP_PDK_basic_components.lib
+++ b/ihp-sg13g2/libs.tech/qucs/user_lib/IHP_PDK_basic_components.lib
@@ -64,7 +64,7 @@ mbrin72043@yahoo.co.uk, or brinsonm@staff.londonmet.ac.uk.
   </Model>
   <Spice>*
 .SUBCKT IHP_PDK_basic_components_rhigh  gnd P1 P2 w=1.0e-6 l=0.5e-6 m=1
-.INCLUDE ../../.qucs/IHP-Open-PDK-main/ihp-sg13g2/libs.tech/ngspice/models/resistors_parm.lib          
+.INCLUDE ~/.qucs/IHP-Open-PDK-main/ihp-sg13g2/libs.tech/ngspice/models/resistors_parm.lib          
 X1 P1 P2 rhigh w={w} l={l} m={m}
 .ENDS
   </Spice>
@@ -91,7 +91,7 @@ mbrin72043@yahoo.co.uk, or brinsonm@staff.londonmet.ac.uk.
   </Model>
   <Spice>*
 .SUBCKT IHP_PDK_basic_components_rppd  gnd P1 P2 w=1.0e-6 l=0.5e-6 m=1
-.INCLUDE ../../.qucs/IHP-Open-PDK-main/ihp-sg13g2/libs.tech/ngspice/models/resistors_parm.lib          
+.INCLUDE ~/.qucs/IHP-Open-PDK-main/ihp-sg13g2/libs.tech/ngspice/models/resistors_parm.lib          
 X1 P1 P2 rppd w={w} l={l} m={m}
 .ENDS
   </Spice>
@@ -118,7 +118,7 @@ mbrin72043@yahoo.co.uk, or brinsonm@staff.londonmet.ac.uk.
   </Model>
   <Spice>*
 .SUBCKT IHP_PDK_basic_components_rsil  gnd P1 P2 w=1.0e-6 l=0.5e-6 m=1
-.INCLUDE ../../.qucs/IHP-Open-PDK-main/ihp-sg13g2/libs.tech/ngspice/models/resistors_parm.lib          
+.INCLUDE ~/.qucs/IHP-Open-PDK-main/ihp-sg13g2/libs.tech/ngspice/models/resistors_parm.lib          
 X1 P1 P2 rsil w={w} l={l} m={m}
 .ENDS
   </Spice>

--- a/ihp-sg13g2/libs.tech/qucs/user_lib/IHP_PDK_nonlinear_components.lib
+++ b/ihp-sg13g2/libs.tech/qucs/user_lib/IHP_PDK_nonlinear_components.lib
@@ -69,7 +69,7 @@ mbrin72043@yahoo.co.uk, or m.brinson@londonmet.ac.uk.
   </Model>
   <Spice>*
 .SUBCKT IHP_PDK_nonlinear_components_sg13_lv_nmos  gnd d g s b w=0.35u l=0.34u ng=1 m=1 as=0 ad=0 pd=0 ps=0 trise=0 z1=0.346e-6 z2=0.38e-6 wmin=0.15e-6 rfmode=0 pre_layout=1 mlist=1
-.INCLUDE   ../../.qucs/IHP-Open-PDK-main/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moslv_parm.lib
+.INCLUDE   ~/.qucs/IHP-Open-PDK-main/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moslv_parm.lib
 X1 d g s b  sg13_lv_nmos w={w} l={l} ng={ng} m={m} as={as} ad={ad} pd={pd} 
 + ps={ps} trise={trise} z1={z1} z2={z2} wmin={wmin} rfmode={rfmode} pre_layout={pre_layout} 
 .ENDS
@@ -108,7 +108,7 @@ mbrin72043@yahoo.co.uk, or m.brinson@londonmet.ac.uk.
   </Model>
   <Spice>*
 .SUBCKT IHP_PDK_nonlinear_components_sg13_hv_nmos  gnd d g s b w=0.35u l=0.34u ng=1 m=1 as=0 ad=0 pd=0 ps=0 trise=0 z1=0.346e-6 z2=0.38e-6 wmin=0.15e-6 rfmode=0 pre_layout=1 mlist=1
-.INCLUDE   ../../.qucs/IHP-Open-PDK-main/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moshv_parm.lib
+.INCLUDE   ~/.qucs/IHP-Open-PDK-main/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moshv_parm.lib
 X1 d g s b  sg13_hv_nmos w={w} l={l} ng={ng} m={m} as={as} ad={ad} pd={pd} 
 + ps={ps} trise={trise} z1={z1} z2={z2} wmin={wmin} rfmode={rfmode} pre_layout={pre_layout} 
 .ENDS
@@ -147,7 +147,7 @@ mbrin72043@yahoo.co.uk, or m.brinson@londonmet.ac.uk.
   </Model>
   <Spice>*
 .SUBCKT IHP_PDK_nonlinear_components_sg13_lv_pmos  gnd d g s b w=0.35u l=0.34u ng=1 m=1 as=0 ad=0 pd=0 ps=0 trise=0 z1=0.346e-6 z2=0.38e-6 wmin=0.15e-6 rfmode=0 pre_layout=1 
-.INCLUDE   ../../.qucs/IHP-Open-PDK-main/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moslv_parm.lib
+.INCLUDE   ~/.qucs/IHP-Open-PDK-main/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moslv_parm.lib
 X1 d g s b  sg13_lv_pmos w={w} l={l} ng={ng} m={1} as={as} ad={ad} pd={pd} 
 + ps={ps} trise={trise} z1={z1} z2={z2} wmin={wmin} rfmode={rfmode} pre_layout={pre_layout}
 .ENDS
@@ -185,7 +185,7 @@ mbrin72043@yahoo.co.uk, or m.brinson@londonmet.ac.uk.
   </Model>
   <Spice>*
 .SUBCKT IHP_PDK_nonlinear_components_sg13_hv_pmos  gnd d g s b w=0.35u l=0.34u ng=1 m=1 as=0 ad=0 pd=0 ps=0 trise=0 z1=0.346e-6 z2=0.38e-6 wmin=0.15e-6 rfmode=0 pre_layout=1 
-.INCLUDE   ../../.qucs/IHP-Open-PDK-main/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moshv_parm.lib
+.INCLUDE   ~/.qucs/IHP-Open-PDK-main/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moshv_parm.lib
 X1 d g s b  sg13_hv_pmos w={w} l={l} ng={ng} m={m} as={as} ad={ad} pd={pd} 
 + ps={ps} trise={trise} z1={z1} z2={z2} wmin={wmin} rfmode={rfmode} pre_layout={pre_layout}
 .ENDS
@@ -223,7 +223,7 @@ mbrin72043@yahoo.co.uk, or m.brinson@londonmet.ac.uk.
   </Model>
   <Spice>*
 .SUBCKT IHP_PDK_nonlinear_components_npn13G2  gnd c b e bn t Nx=1  
-.INCLUDE   ../../.qucs/IHP-Open-PDK-main/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_hbt_mod.lib
+.INCLUDE   ~/.qucs/IHP-Open-PDK-main/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_hbt_mod.lib
 X1 c b e bn t  npn13G2 Nx={Nx} 
 .ENDS
   </Spice>
@@ -257,7 +257,7 @@ mbrin72043@yahoo.co.uk, or m.brinson@londonmet.ac.uk.
   </Model>
   <Spice>*
 .SUBCKT IHP_PDK_nonlinear_components_npn13G2l  gnd c b e bn t Nx=1 El=1 
-.INCLUDE   ../../.qucs/IHP-Open-PDK-main/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_hbt_mod.lib
+.INCLUDE   ~/.qucs/IHP-Open-PDK-main/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_hbt_mod.lib
 X1 c b e bn t  npn13G2l Nx={Nx} El={El} 
 .ENDS
   </Spice>
@@ -292,7 +292,7 @@ mbrin72043@yahoo.co.uk, or m.brinson@londonmet.ac.uk.
   </Model>
   <Spice>*
 .SUBCKT IHP_PDK_nonlinear_components_npn13G2v  gnd c b e bn t Nx=1  
-.INCLUDE   ../../.qucs/IHP-Open-PDK-main/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_hbt_mod.lib
+.INCLUDE   ~/.qucs/IHP-Open-PDK-main/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_hbt_mod.lib
 X1 c b e bn t  npn13G2v Nx={Nx} 
 .ENDS
   </Spice>


### PR DESCRIPTION
The aim of this pull request is to facilitate the setup of the PDK in Qucs-S. 
I installed the PDK and tested a few things, but it took me a while to get it up and running, so I think the following commits will be useful:

***
`Commit #1`: **Copy sample schematics to Qucs-S home directory**
 
This adds a copy of the sample schematics to the Qucs home directory. By default, that’s where the user has his projects
and I find it very convenient to have the examples there. In order to make these files recognisable by Qucs-S, there must be located inside a folder with a name ending in “_prj”. I have given it the name “IHP-Open-PDK-SG13G2-Examples_prj” as it is something meaningful to the user.

![image](https://github.com/IHP-GmbH/IHP-Open-PDK/assets/13180689/e2861685-857d-48ea-ae7b-3c051908ab5c)
![image](https://github.com/IHP-GmbH/IHP-Open-PDK/assets/13180689/db051fc5-eafd-4fad-b7a5-91e60c5f9dff)

***

`Commit #2`: **Inform the user to complete the PDK installation on the Qucs-S side**
 
This commit adds  information for the user on how to configure Qucs-S to work with the SG13G2 PDK. Qucs-S needs to know
where the libraries are located, so the user should should specify this manually. A new file inside the examples folder has been added with instructions on how to do it.

![image](https://github.com/IHP-GmbH/IHP-Open-PDK/assets/13180689/493cf9df-bd54-4145-980b-083f731973a3)
![image](https://github.com/IHP-GmbH/IHP-Open-PDK/assets/13180689/49cd4dcc-702a-4e7e-a318-00c33263c4b6)

***

`Commit #3`: **Refer the library paths to the linux user’s home folder**
 
This modifies the schematics and the libraries to refer them to the user home. Prior to this, the schematics and the library files
included relative jumps. This means that the simulation can't find the symbols and models in the default configuration.

![image](https://github.com/IHP-GmbH/IHP-Open-PDK/assets/13180689/db5b0d7c-e927-4ec2-ad71-82550a61f11a)

***

`Commit #4`: **Fix dc_diode_op.sch and dc_hbt_13g2.sch examples**
 
The commit is a fix for two schematics that have problems with the rectangular plot variables

