### PR TITLE
libs.tech: klayout: Fix Metal density min/max values

### DIFF
--- a/ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_density_report.lym
+++ b/ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_density_report.lym
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <klayout-macro>
-	<description>Density Report</description>
+ <description>Density Report</description>
  <version>0.1</version>
  <category>misc</category>
  <prolog/>
@@ -137,23 +137,23 @@ puts "GatPoly %\t=\t#{tf_GatPoly}%\tMin = 35 \t Max = 55\n\n"
 
 # metal 1
 puts "Metal1 Area\t=\t#{area_metal1}um^2"
-puts "Metal1 %\t=\t#{tf_metal1}%\tMin = 25 \t Max = 75\n\n"
+puts "Metal1 %\t=\t#{tf_metal1}%\tMin = 35 \t Max = 60\n\n"
 
 # metal 2
 puts "Metal2 Area\t=\t#{area_metal2}um^2"
-puts "Metal2 %\t=\t#{tf_metal2}%\tMin = 25 \t Max = 75\n\n"
+puts "Metal2 %\t=\t#{tf_metal2}%\tMin = 35 \t Max = 60\n\n"
 
 # metal 3
 puts "Metal3 Area\t=\t#{area_metal3}um^2"
-puts "Metal3 %\t=\t#{tf_metal3}%\tMin = 25 \t Max = 75\n\n"
+puts "Metal3 %\t=\t#{tf_metal3}%\tMin = 35 \t Max = 60\n\n"
 
 # metal 4
 puts "Metal4 Area\t=\t#{area_metal4}um^2"
-puts "Metal4 %\t=\t#{tf_metal4}%\tMin = 25 \t Max = 75\n\n"
+puts "Metal4 %\t=\t#{tf_metal4}%\tMin = 35 \t Max = 60\n\n"
 
 # metal 5
 puts "Metal5 Area\t=\t#{area_metal5}um^2"
-puts "Metal5 %\t=\t#{tf_metal5}%\tMin = 25 \t Max = 75\n\n"
+puts "Metal5 %\t=\t#{tf_metal5}%\tMin = 35 \t Max = 60\n\n"
 
 # TopMetal 1
 puts "TopMetal1 Area\t=\t#{area_TopMetal1}um^2"


### PR DESCRIPTION
Global min./max. Metal(n) density values are 35% and 60%. The previous 25% and 75% are only valid for 800x800 chip areas.