### PR TITLE
Nofill areas in sealring

### DIFF
--- a/ihp-sg13g2/libs.tech/klayout/python/sg13g2_pycell_lib/ihp/geometry.py
+++ b/ihp-sg13g2/libs.tech/klayout/python/sg13g2_pycell_lib/ihp/geometry.py
@@ -1146,14 +1146,14 @@ def DrawFillers(self, layer, xl, yl, xh, yh, ws, hs, dx, dy, dir, offset, retlis
 #***********************************************************************************************************************
 # generateCorner
 #***********************************************************************************************************************
-def generateCorner(self, corner_startx, corner_starty, corner_width, corner_length, corner_steps, corner_end, offset, layer):
+def generateCorner(self, corner_startx, corner_starty, corner_width, corner_length, corner_steps, corner_end, offset, layer, data_type='drawing'):
     item_list = list()
-    for cnt in range(corner_steps) :
-        rect = dbCreateRect(self, Layer(layer, 'drawing'), Box(corner_startx - corner_width * (cnt + 1), corner_starty + offset + (corner_length - corner_width) * cnt,
+    for cnt in range(corner_steps):
+        rect = dbCreateRect(self, Layer(layer, data_type), Box(corner_startx - corner_width * (cnt + 1), corner_starty + offset + (corner_length - corner_width) * cnt,
                                                                    corner_startx - corner_width * cnt, corner_starty+corner_length + offset  + (corner_length-corner_width) * cnt))
         cons(item_list, rect)
 
-    rect = dbCreateRect(self, Layer(layer, 'drawing'), Box(corner_startx - corner_width * (corner_steps + 1), corner_starty + offset  + (corner_length - corner_width) * corner_steps,
+    rect = dbCreateRect(self, Layer(layer, data_type), Box(corner_startx - corner_width * (corner_steps + 1), corner_starty + offset  + (corner_length - corner_width) * corner_steps,
                                                                corner_startx - corner_width * corner_steps, corner_end))
     cons(item_list, rect)
 
@@ -1162,9 +1162,9 @@ def generateCorner(self, corner_startx, corner_starty, corner_width, corner_leng
 #***********************************************************************************************************************
 # combineLayerAndDelete
 #***********************************************************************************************************************
-def combineLayerAndDelete(self, item_list, groupId, layer):
+def combineLayerAndDelete(self, item_list, groupId, layer, data_type='drawing'):
 
-    shapes = dbLayerOrList(Layer(layer, 'drawing'), item_list)
+    shapes = dbLayerOrList(Layer(layer, data_type), item_list)
 
     size = len(shapes.getComps())
     for i in range(size) :

--- a/ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_density_report.lym
+++ b/ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_density_report.lym
@@ -20,8 +20,7 @@
 ###################### Layer assignment #######################
 
 # total area limited by prBoundary
-# HACK: use 235/4 since we currently have no prBoundary (189/0) drawn
-prBoundary = input("235/4")
+prBoundary = input("189/0")
 
 
 # Activ


### PR DESCRIPTION
this changes adds nofill areas to Activ, GatPoly, M1-5 and TM1-2. These areas are not super nicely drawn but at least the area around Passiv in the sealring is now marked as nofill.

Additionally, sealring includes not a prBoundary.drawing rect around the entire chip.
