### PR TITLE
Update path to standard symbols

### DIFF
--- a/ihp-sg13g2/libs.tech/xschem/xschemrc
+++ b/ihp-sg13g2/libs.tech/xschem/xschemrc
@@ -29,6 +29,7 @@
 set XSCHEM_LIBRARY_PATH {}
 #### include devices/*.sym
 append XSCHEM_LIBRARY_PATH :${XSCHEM_SHAREDIR}/xschem_library/devices
+append XSCHEM_LIBRARY_PATH :${XSCHEM_SHAREDIR}/xschem_library
 #### include skywater libraries. Here i use [pwd]. This works if i start xschem from here.
 append XSCHEM_LIBRARY_PATH :[file dirname [info script]]
 #### add ~/.xschem/xschem_library (USER_CONF_DIR is normally ~/.xschem)

--- a/ihp-sg13g2/libs.tech/xschem/xschemrc
+++ b/ihp-sg13g2/libs.tech/xschem/xschemrc
@@ -28,7 +28,7 @@
 #### Flush any previous definition
 set XSCHEM_LIBRARY_PATH {}
 #### include devices/*.sym
-append XSCHEM_LIBRARY_PATH ${XSCHEM_SHAREDIR}/xschem_library
+append XSCHEM_LIBRARY_PATH :${XSCHEM_SHAREDIR}/xschem_library/devices
 #### include skywater libraries. Here i use [pwd]. This works if i start xschem from here.
 append XSCHEM_LIBRARY_PATH :[file dirname [info script]]
 #### add ~/.xschem/xschem_library (USER_CONF_DIR is normally ~/.xschem)


### PR DESCRIPTION
Hello! I would like to propose a change to the `xschemrc` file.

Currently, the standard symbols are added via `append XSCHEM_LIBRARY_PATH ${XSCHEM_SHAREDIR}/xschem_library`.
This works, but is not the full path to the standard symbols, consequently the symbols have `devices/` in their symbol references. This has no advantages and is not compatible with the default xschem setup. This prevents, for example, the sharing of simple testbenches without correcting the paths.

A fix has already been made for Sky130 and submitted to gf180mcu:

- https://github.com/StefanSchippers/xschem_sky130/commit/0597d6cd26ad460d3f4d689f9e6a11f33dc262ff
- https://github.com/efabless/globalfoundries-pdk-libs-gf180mcu_fd_pr/pull/48

Here, the full path to the standard symbols was added before the existing one, so that the references of newly placed symbols will only consist of the symbols name. Previously created schematics will still work since the symbols references are resolved using the second path.

The only (cosmetic) downside is that xschem will show both paths when choosing a symbol.

Since the IHP PDK is not yet widely used, it may make sense to replace the previous path with the full path (this PR). Of course, older schematics would need to be fixed then. Another option would be to add both paths for a transitional period and then remove the second one after a while.

Please let me know what you prefer.
