### PR TITLE
Add filler macros and script

### DIFF
--- a/ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_filler_ActGatP.lym
+++ b/ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_filler_ActGatP.lym
@@ -1,0 +1,232 @@
+<?xml version="1.0" encoding="utf-8"?>
+<klayout-macro>
+ <description>Fill Activ/GatPoly</description>
+ <version>0.1</version>
+ <category>filler</category>
+ <prolog/>
+ <epilog/>
+ <doc/>
+ <autorun>false</autorun>
+ <autorun-early>false</autorun-early>
+ <priority>0</priority>
+ <shortcut/>
+ <show-in-menu>true</show-in-menu>
+ <group-name>filler</group-name>
+ <menu-path>sg13g2_menu&gt;end("SG13G2 PDK").end</menu-path>
+ <interpreter>dsl</interpreter>
+ <dsl-interpreter-name>drc-dsl-xml</dsl-interpreter-name>
+ <text>
+  # Automatic filler generation script for Active/GatPoly
+  Activ = source.input("1/0")
+  Activ_pin = source.input("1/2")
+  Activ_mask = source.input("1/20")
+  Activ_filler = source.input("1/22")
+  Activ_nofill = source.input("1/23")
+  BiWind = source.input("3/0")
+  GatPoly = source.input("5/0")
+  GatPoly_pin = source.input("5/2")
+  GatPoly_filler = source.input("5/22")
+  GatPoly_nofill = source.input("5/23")
+  Cont = source.input("6/0")
+  nSD = source.input("7/0")
+  nSD_block = source.input("7/21")
+  Metal1 = source.input("8/0")
+  Metal1_pin = source.input("8/2")
+  Metal1_filler = source.input("8/22")
+  Metal1_nofill = source.input("8/23")
+  Metal1_slit = source.input("8/24")
+  Passiv = source.input("9/0")
+  Metal2 = source.input("10/0")
+  Metal2_pin = source.input("10/2")
+  Metal2_filler = source.input("10/22")
+  Metal2_nofill = source.input("10/23")
+  Metal2_slit = source.input("10/24")
+  BasPoly = source.input("13/0")
+  pSD = source.input("14/0")
+  DigiBnd = source.input("16/0")
+  Via1 = source.input("19/0")
+  RES = source.input("24/0")
+  SRAM = source.input("25/0")
+  TRANS = source.input("26/0")
+  IND = source.input("27/0")
+  SalBlock = source.input("28/0")
+  Via2 = source.input("29/0")
+  Metal3 = source.input("30/0")
+  Metal3_pin = source.input("30/2")
+  Metal3_filler = source.input("30/22")
+  Metal3_nofill = source.input("30/23")
+  Metal3_slit = source.input("30/24")
+  NWell = source.input("31/0")
+  NWell_pin = source.input("31/2")
+  nBuLay = source.input("32/0")
+  nBuLay_block = source.input("32/21")
+  EmWind = source.input("33/0")
+  DeepCo = source.input("35/0")
+  MIM = source.input("36/0")
+  EdgeSeal = source.input("39/0")
+  dfpad = source.input("41/0")
+  dfpad_pillar = source.input("41/35")
+  dfpad_sbump = source.input("41/36")
+  ThickGateOx = source.input("44/0")
+  PWell = source.input("46/0")
+  PWell_block = source.input("46/21")
+  Via3 = source.input("49/0")
+  Metal4 = source.input("50/0")
+  Metal4_pin = source.input("50/2")
+  Metal4_filler = source.input("50/22")
+  Metal4_nofill = source.input("50/23")
+  Metal4_slit = source.input("50/24")
+  EmPoly = source.input("55/0")
+  DigiSub = source.input("60/0")
+  TEXT_0 = source.labels("63/0")
+  Via4 = source.input("66/0")
+  Metal5 = source.input("67/0")
+  Metal5_pin = source.input("67/2")
+  Metal5_filler = source.input("67/22")
+  Metal5_nofill = source.input("67/23")
+  Metal5_slit = source.input("67/24")
+  Polimide = source.input("98/0")
+  Recog = source.input("99/0")
+  Recog_esd = source.input("99/30")
+  Recog_diode = source.input("99/31")
+  Recog_tsv = source.input("99/32")
+  EXTBlock = source.input("111/0")
+  TopVia1 = source.input("125/0")
+  TopMetal1 = source.input("126/0")
+  TopMetal1_pin = source.input("126/2")
+  TopMetal1_filler = source.input("126/22")
+  TopMetal1_nofill = source.input("126/23")
+  TopMetal1_slit = source.input("126/24")
+  PolyRes = source.input("128/0")
+  Vmim = source.input("129/0")
+  TopVia2 = source.input("133/0")
+  TopMetal2 = source.input("134/0")
+  TopMetal2_pin = source.input("134/2")
+  TopMetal2_filler = source.input("134/22")
+  TopMetal2_nofill = source.input("134/23")
+  TopMetal2_slit = source.input("134/24")
+  ColWind = source.input("139/0")
+  RFMEM = source.input("147/0")
+  DeepVia = source.input("152/0")
+  LBE = source.input("157/0")
+  NoMetFiller = source.input("160/0")
+
+  # Fill exclusion area
+
+  cellframe1 = EdgeSeal.holes
+
+  ##########################################################################
+  # CREATE DUMMY FILL PATTERNS FOR ALL LEVELS
+  ##########################################################################
+
+  # Active fill pattern
+  act_fill = fill_pattern("Act_FILL_CELL")
+  width = 3.4
+  length = 3.4
+  spacing_h = width + 1.6
+  spacing_v = length + 1.6
+  offset_h = 0
+  offset_v = 2.5
+  act_fill.shape(1, 22, box(0, 0, width, length))
+
+  # GatPoly fill pattern
+  gp_fill = fill_pattern("GatP_FILL_CELL")
+  gp_width = 5
+  gp_length = 1.4
+  gp_spacing_h = gp_width + 5
+  gp_spacing_v = gp_length + 1.1
+  gp_offset_h = 5
+  gp_offset_v = 0
+  gp_fill.shape(5, 22, box(0, 0, gp_width, gp_length))
+
+  act_fill.origin(-0.8, 0)
+  act_fill.dim(5, 3.4)
+
+  gp_fill.origin(0, -1)
+  gp_fill.dim(5, 3.4)
+
+  ##########################################################################
+  # CREATE Activ FILLER
+  ##########################################################################
+
+  extent_all_layers = source.extent
+  Activ_cpy=Activ.dup
+  Poly_cpy=GatPoly.dup
+  Cnt_cpy=Cont.dup
+  TRANS_cpy=TRANS.dup
+  NWell_cpy=NWell.dup
+
+  sep=1.1                                     ### AFil.c
+  Poly_cpy.size(sep,sep, "square_limit")
+  Cnt_cpy.size(sep,sep, "square_limit")
+  AFil_c = Poly_cpy | Cnt_cpy
+
+  sep=0.42                                    ### AFil.c1
+  Activ_cpy.size(sep,sep, "square_limit")
+  AFil_c1 = Activ_cpy
+
+  sep=1.0                                     ### AFil.e
+  TRANS_cpy.size(sep, sep, "square_limit")
+  AFil_e = TRANS_cpy
+
+  sep=1.0                                     ### AFil.d
+  NWell_cpy2 = NWell_cpy
+  NWell_cpy.size(sep, sep, "square_limit")
+  NWell_cpy2.size(-sep, -sep, "square_limit")
+  AFil_d = NWell_cpy - NWell_cpy2
+
+  exclLayAct = AFil_c | AFil_c1 | AFil_e | AFil_d
+
+  ##########################################################################
+  # CREATE GatPoly FILLER
+  ##########################################################################
+
+  Activ_gp_cpy=Activ.dup
+  Poly_filler_cpy=GatPoly_filler.dup
+  Poly_gp_cpy=GatPoly.dup
+  Cnt_gp_cpy=Cont.dup
+  TRANS_gp_cpy=TRANS.dup
+  NWell_gp_cpy=NWell.dup
+  pSD_cpy = pSD.dup
+  nSD_block_cpy = nSD_block.dup
+  SalBlock_cpy = SalBlock.dup
+
+  sep=0.8                                     ###GFil.c
+  Poly_filler_cpy.size(sep, sep, "square_limit")
+  GFil_c = Poly_filler_cpy
+
+  sep=1.1                                     ###GFil.d
+  Activ_gp_cpy.size(sep, sep, "square_limit")
+  Poly_gp_cpy.size(sep, sep, "square_limit")
+  Cnt_gp_cpy.size(sep, sep, "square_limit")
+  pSD_cpy.size(sep, sep, "square_limit")
+  nSD_block_cpy.size(sep, sep, "square_limit")
+  SalBlock_cpy.size(sep, sep, "square_limit")
+  GFil_d = Activ_gp_cpy | Poly_gp_cpy | Cnt_gp_cpy | pSD_cpy | nSD_block_cpy | SalBlock_cpy
+
+  sep=1.1                                     ###GFil.f
+  TRANS_gp_cpy.size(sep, sep, "square_limit")
+  GFil_f = TRANS_gp_cpy
+
+  sep=1.1                                     ###GFil.e
+  NWell_gp_cpy2 = NWell_gp_cpy
+  NWell_gp_cpy.size(sep, sep, "square_limit")
+  NWell_gp_cpy2.size(-sep, -sep, "square_limit")
+  GFil_e = NWell_gp_cpy - NWell_gp_cpy2
+
+  exclLayGatP = GFil_c | GFil_d | GFil_f | GFil_e
+
+  ActoutGatP = exclLayGatP - exclLayAct
+  GatPoutAct = exclLayAct - exclLayGatP
+
+
+  # perform fill
+  #vstep=spacing_v
+  #hstep=spacing_h
+
+  org_x = 2000.0
+  org_y = org_x
+  (cellframe1-exclLayAct-exclLayGatP).fill(act_fill, hstep(spacing_h, offset_v), vstep(offset_h, spacing_v))
+  (cellframe1-exclLayGatP-exclLayAct).fill(gp_fill, hstep(gp_spacing_h, gp_offset_v), vstep(gp_offset_h, gp_spacing_v))
+</text>
+</klayout-macro>

--- a/ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_filler_ActGatP.lym
+++ b/ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_filler_ActGatP.lym
@@ -155,6 +155,7 @@
   Cnt_cpy=Cont.dup
   TRANS_cpy=TRANS.dup
   NWell_cpy=NWell.dup
+  NWell_cpy2=NWell.dup
 
   sep=1.1                                     ### AFil.c
   Poly_cpy.size(sep,sep, "square_limit")
@@ -170,7 +171,6 @@
   AFil_e = TRANS_cpy
 
   sep=1.0                                     ### AFil.d
-  NWell_cpy2 = NWell_cpy
   NWell_cpy.size(sep, sep, "square_limit")
   NWell_cpy2.size(-sep, -sep, "square_limit")
   AFil_d = NWell_cpy - NWell_cpy2
@@ -187,6 +187,7 @@
   Cnt_gp_cpy=Cont.dup
   TRANS_gp_cpy=TRANS.dup
   NWell_gp_cpy=NWell.dup
+  NWell_gp_cpy2=NWell.dup
   pSD_cpy = pSD.dup
   nSD_block_cpy = nSD_block.dup
   SalBlock_cpy = SalBlock.dup
@@ -209,7 +210,6 @@
   GFil_f = TRANS_gp_cpy
 
   sep=1.1                                     ###GFil.e
-  NWell_gp_cpy2 = NWell_gp_cpy
   NWell_gp_cpy.size(sep, sep, "square_limit")
   NWell_gp_cpy2.size(-sep, -sep, "square_limit")
   GFil_e = NWell_gp_cpy - NWell_gp_cpy2

--- a/ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_filler_Metal.lym
+++ b/ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_filler_Metal.lym
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="utf-8"?>
+<klayout-macro>
+ <description>Fill Metal</description>
+ <version>0.1</version>
+ <category>filler</category>
+ <prolog/>
+ <epilog/>
+ <doc/>
+ <autorun>false</autorun>
+ <autorun-early>false</autorun-early>
+ <priority>0</priority>
+ <shortcut/>
+ <show-in-menu>true</show-in-menu>
+ <group-name>filler</group-name>
+ <menu-path>sg13g2_menu&gt;end("SG13G2 PDK").end</menu-path>
+ <interpreter>dsl</interpreter>
+ <dsl-interpreter-name>drc-dsl-xml</dsl-interpreter-name>
+ <text>
+	# Automatic filler generation script for TopMetal
+	Activ = source.input("1/0")
+	Activ_pin = source.input("1/2")
+	Activ_mask = source.input("1/20")
+	Activ_filler = source.input("1/22")
+	Activ_nofill = source.input("1/23")
+	BiWind = source.input("3/0")
+	GatPoly = source.input("5/0")
+	GatPoly_pin = source.input("5/2")
+	GatPoly_filler = source.input("5/22")
+	GatPoly_nofill = source.input("5/23")
+	Cont = source.input("6/0")
+	nSD = source.input("7/0")
+	nSD_block = source.input("7/21")
+	Metal1 = source.input("8/0")
+	Metal1_pin = source.input("8/2")
+	Metal1_filler = source.input("8/22")
+	Metal1_nofill = source.input("8/23")
+	Metal1_slit = source.input("8/24")
+	Passiv = source.input("9/0")
+	Metal2 = source.input("10/0")
+	Metal2_pin = source.input("10/2")
+	Metal2_filler = source.input("10/22")
+	Metal2_nofill = source.input("10/23")
+	Metal2_slit = source.input("10/24")
+	BasPoly = source.input("13/0")
+	pSD = source.input("14/0")
+	DigiBnd = source.input("16/0")
+	Via1 = source.input("19/0")
+	RES = source.input("24/0")
+	SRAM = source.input("25/0")
+	TRANS = source.input("26/0")
+	IND = source.input("27/0")
+	SalBlock = source.input("28/0")
+	Via2 = source.input("29/0")
+	Metal3 = source.input("30/0")
+	Metal3_pin = source.input("30/2")
+	Metal3_filler = source.input("30/22")
+	Metal3_nofill = source.input("30/23")
+	Metal3_slit = source.input("30/24")
+	NWell = source.input("31/0")
+	NWell_pin = source.input("31/2")
+	nBuLay = source.input("32/0")
+	nBuLay_block = source.input("32/21")
+	EmWind = source.input("33/0")
+	DeepCo = source.input("35/0")
+	MIM = source.input("36/0")
+	EdgeSeal = source.input("39/0")
+	dfpad = source.input("41/0")
+	dfpad_pillar = source.input("41/35")
+	dfpad_sbump = source.input("41/36")
+	ThickGateOx = source.input("44/0")
+	PWell = source.input("46/0")
+	PWell_block = source.input("46/21")
+	Via3 = source.input("49/0")
+	Metal4 = source.input("50/0")
+	Metal4_pin = source.input("50/2")
+	Metal4_filler = source.input("50/22")
+	Metal4_nofill = source.input("50/23")
+	Metal4_slit = source.input("50/24")
+	EmPoly = source.input("55/0")
+	DigiSub = source.input("60/0")
+	TEXT_0 = source.labels("63/0")
+	Via4 = source.input("66/0")
+	Metal5 = source.input("67/0")
+	Metal5_pin = source.input("67/2")
+	Metal5_filler = source.input("67/22")
+	Metal5_nofill = source.input("67/23")
+	Metal5_slit = source.input("67/24")
+	Polimide = source.input("98/0")
+	Recog = source.input("99/0")
+	Recog_esd = source.input("99/30")
+	Recog_diode = source.input("99/31")
+	Recog_tsv = source.input("99/32")
+	EXTBlock = source.input("111/0")
+	TopVia1 = source.input("125/0")
+	TopMetal1 = source.input("126/0")
+	TopMetal1_pin = source.input("126/2")
+	TopMetal1_filler = source.input("126/22")
+	TopMetal1_nofill = source.input("126/23")
+	TopMetal1_slit = source.input("126/24")
+	PolyRes = source.input("128/0")
+	Vmim = source.input("129/0")
+	TopVia2 = source.input("133/0")
+	TopMetal2 = source.input("134/0")
+	TopMetal2_pin = source.input("134/2")
+	TopMetal2_filler = source.input("134/22")
+	TopMetal2_nofill = source.input("134/23")
+	TopMetal2_slit = source.input("134/24")
+	ColWind = source.input("139/0")
+	RFMEM = source.input("147/0")
+	DeepVia = source.input("152/0")
+	LBE = source.input("157/0")
+	NoMetFiller = source.input("160/0")
+
+	# Paramter
+	width = 1.0
+	height = 5.0
+	distance_m1 = 1.0
+	distance_m2 = 0.8
+	distance_m3 = 2.0
+	distance_m4 = 2.0
+	distance_m5 = 2.0
+
+	# Create filler cell
+	pattern_m1 = fill_pattern("Met1_FILL_CELL").shape(8, 22, box(0.0, 0.0, width, height))
+	pattern_m2 = fill_pattern("Met1_FILL_CELL").shape(10, 22, box(0.0, 0.0, width, height))
+	pattern_m3 = fill_pattern("Met1_FILL_CELL").shape(30, 22, box(0.0, 0.0, width, height))
+	pattern_m4 = fill_pattern("Met1_FILL_CELL").shape(50, 22, box(0.0, 0.0, width, height))
+	pattern_m5 = fill_pattern("Met1_FILL_CELL").shape(67, 22, box(0.0, 0.0, width, height))
+	 
+	# Define noFill exclusion layer
+	M1Fil_c = Metal1.dup
+	M1Fil_c.size(0.42, 0.42, "square_limit")
+	M1Fil_d = TRANS.dup
+	M1Fil_d.size(1.0, 1.0, "square_limit")
+	exclLayM1 = M1Fil_c | M1Fil_d | Metal1_filler | Metal1_nofill | Metal1_slit | TRANS
+
+	M2Fil_c = Metal2.dup
+	M2Fil_c.size(0.42, 0.42, "square_limit")
+	M2Fil_d = TRANS.dup
+	M2Fil_d.size(1.0, 1.0, "square_limit")
+	exclLayM2 = M2Fil_c | M2Fil_d | Metal2_filler | Metal2_nofill | Metal2_slit | TRANS
+
+	M3Fil_c = Metal3.dup
+	M3Fil_c.size(0.42, 0.42, "square_limit")
+	M3Fil_d = TRANS.dup
+	M3Fil_d.size(1.0, 1.0, "square_limit")
+	exclLayM3 = M3Fil_c | M3Fil_d | Metal3_filler | Metal3_nofill | Metal3_slit | TRANS
+
+	M4Fil_c = Metal4.dup
+	M4Fil_c.size(0.42, 0.42, "square_limit")
+	M4Fil_d = TRANS.dup
+	M4Fil_d.size(1.0, 1.0, "square_limit")
+	exclLayM4 = M4Fil_c | M4Fil_d | Metal4_filler | Metal4_nofill | Metal4_slit | TRANS
+
+	M5Fil_c = Metal5.dup
+	M5Fil_c.size(0.42, 0.42, "square_limit")
+	M5Fil_d = TRANS.dup
+	M5Fil_d.size(1.0, 1.0, "square_limit")
+	exclLayM5 = M5Fil_c | M5Fil_d | Metal5_filler | Metal5_nofill | Metal5_slit | TRANS
+	
+	# perform fill
+	(source.extent - exclLayM1).fill(pattern_m1, hstep(width + distance_m1), vstep(height + distance_m1))
+	(source.extent - exclLayM2).fill(pattern_m2, hstep(width + distance_m2), vstep(height + distance_m2))
+	(source.extent - exclLayM3).fill(pattern_m3, hstep(width + distance_m3), vstep(height + distance_m3))
+	(source.extent - exclLayM4).fill(pattern_m4, hstep(width + distance_m4), vstep(height + distance_m4))
+	(source.extent - exclLayM5).fill(pattern_m5, hstep(width + distance_m5), vstep(height + distance_m5))
+</text>
+</klayout-macro>

--- a/ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_filler_TopMetal.lym
+++ b/ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_filler_TopMetal.lym
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="utf-8"?>
+<klayout-macro>
+ <description>Fill TopMetal</description>
+ <version>0.1</version>
+ <category>filler</category>
+ <prolog/>
+ <epilog/>
+ <doc/>
+ <autorun>false</autorun>
+ <autorun-early>false</autorun-early>
+ <priority>0</priority>
+ <shortcut/>
+ <show-in-menu>true</show-in-menu>
+ <group-name>filler</group-name>
+ <menu-path>sg13g2_menu&gt;end("SG13G2 PDK").end</menu-path>
+ <interpreter>dsl</interpreter>
+ <dsl-interpreter-name>drc-dsl-xml</dsl-interpreter-name>
+ <text>
+	# Automatic filler generation script for TopMetal
+	Activ = source.input("1/0")
+	Activ_pin = source.input("1/2")
+	Activ_mask = source.input("1/20")
+	Activ_filler = source.input("1/22")
+	Activ_nofill = source.input("1/23")
+	BiWind = source.input("3/0")
+	GatPoly = source.input("5/0")
+	GatPoly_pin = source.input("5/2")
+	GatPoly_filler = source.input("5/22")
+	GatPoly_nofill = source.input("5/23")
+	Cont = source.input("6/0")
+	nSD = source.input("7/0")
+	nSD_block = source.input("7/21")
+	Metal1 = source.input("8/0")
+	Metal1_pin = source.input("8/2")
+	Metal1_filler = source.input("8/22")
+	Metal1_nofill = source.input("8/23")
+	Metal1_slit = source.input("8/24")
+	Passiv = source.input("9/0")
+	Metal2 = source.input("10/0")
+	Metal2_pin = source.input("10/2")
+	Metal2_filler = source.input("10/22")
+	Metal2_nofill = source.input("10/23")
+	Metal2_slit = source.input("10/24")
+	BasPoly = source.input("13/0")
+	pSD = source.input("14/0")
+	DigiBnd = source.input("16/0")
+	Via1 = source.input("19/0")
+	RES = source.input("24/0")
+	SRAM = source.input("25/0")
+	TRANS = source.input("26/0")
+	IND = source.input("27/0")
+	SalBlock = source.input("28/0")
+	Via2 = source.input("29/0")
+	Metal3 = source.input("30/0")
+	Metal3_pin = source.input("30/2")
+	Metal3_filler = source.input("30/22")
+	Metal3_nofill = source.input("30/23")
+	Metal3_slit = source.input("30/24")
+	NWell = source.input("31/0")
+	NWell_pin = source.input("31/2")
+	nBuLay = source.input("32/0")
+	nBuLay_block = source.input("32/21")
+	EmWind = source.input("33/0")
+	DeepCo = source.input("35/0")
+	MIM = source.input("36/0")
+	EdgeSeal = source.input("39/0")
+	dfpad = source.input("41/0")
+	dfpad_pillar = source.input("41/35")
+	dfpad_sbump = source.input("41/36")
+	ThickGateOx = source.input("44/0")
+	PWell = source.input("46/0")
+	PWell_block = source.input("46/21")
+	Via3 = source.input("49/0")
+	Metal4 = source.input("50/0")
+	Metal4_pin = source.input("50/2")
+	Metal4_filler = source.input("50/22")
+	Metal4_nofill = source.input("50/23")
+	Metal4_slit = source.input("50/24")
+	EmPoly = source.input("55/0")
+	DigiSub = source.input("60/0")
+	TEXT_0 = source.labels("63/0")
+	Via4 = source.input("66/0")
+	Metal5 = source.input("67/0")
+	Metal5_pin = source.input("67/2")
+	Metal5_filler = source.input("67/22")
+	Metal5_nofill = source.input("67/23")
+	Metal5_slit = source.input("67/24")
+	Polimide = source.input("98/0")
+	Recog = source.input("99/0")
+	Recog_esd = source.input("99/30")
+	Recog_diode = source.input("99/31")
+	Recog_tsv = source.input("99/32")
+	EXTBlock = source.input("111/0")
+	TopVia1 = source.input("125/0")
+	TopMetal1 = source.input("126/0")
+	TopMetal1_pin = source.input("126/2")
+	TopMetal1_filler = source.input("126/22")
+	TopMetal1_nofill = source.input("126/23")
+	TopMetal1_slit = source.input("126/24")
+	PolyRes = source.input("128/0")
+	Vmim = source.input("129/0")
+	TopVia2 = source.input("133/0")
+	TopMetal2 = source.input("134/0")
+	TopMetal2_pin = source.input("134/2")
+	TopMetal2_filler = source.input("134/22")
+	TopMetal2_nofill = source.input("134/23")
+	TopMetal2_slit = source.input("134/24")
+	ColWind = source.input("139/0")
+	RFMEM = source.input("147/0")
+	DeepVia = source.input("152/0")
+	LBE = source.input("157/0")
+	NoMetFiller = source.input("160/0")
+
+	# Paramter
+	width = 5.0
+	height = 10.0
+	distance = 3.0
+
+	# Create filler cell
+	pattern_tm1 = fill_pattern("TM1_FILL_CELL").shape(126, 22, box(0.0, 0.0, width, height))
+	pattern_tm2 = fill_pattern("TM2_FILL_CELL").shape(134, 22, box(0.0, 0.0, width, height))
+	 
+	# Define noFill exclusion layer
+	TM1Fil_c = TopMetal1.dup
+	TM1Fil_c.size(3.0, 3.0, "square_limit")
+	TM1Fil_d = TRANS.dup
+	TM1Fil_d.size(4.9, 4.9, "square_limit")
+	exclLayTM1 = TM1Fil_c | TM1Fil_d | TopMetal1_filler | TopMetal1_nofill | TopMetal1_slit | TRANS
+
+	TM2Fil_c = TopMetal2.dup
+	TM2Fil_c.size(3.0, 3.0, "square_limit")
+	TM2Fil_d = TRANS.dup
+	TM2Fil_d.size(4.9, 4.9, "square_limit")
+	exclLayTM2 = TM2Fil_c | TM2Fil_d | TopMetal2_filler | TopMetal2_nofill | TopMetal2_slit | TRANS
+
+	# perform fill
+	(source.extent - exclLayTM1).fill(pattern_tm1, hstep(width + distance), vstep(height + distance))
+	(source.extent - exclLayTM2).fill(pattern_tm2, hstep(width + distance), vstep(height + distance))
+</text>
+</klayout-macro>

--- a/ihp-sg13g2/libs.tech/klayout/tech/scripts/filler.py
+++ b/ihp-sg13g2/libs.tech/klayout/tech/scripts/filler.py
@@ -1,0 +1,53 @@
+"""Module to automatically apply filler cells to a GDS file and store the result to a
+parametrizable output file. This module is required because .lym files cannot alter and save
+a GDS file in batch mode.
+
+Can be used in Klayout's batch mode. For example:
+
+klayout -n sg13g2 -zz -r filler.py \
+        -rd output_file=filled-design.gds.gz \
+        input-file.gds.gz
+
+This script has optional arguments to disable fill for some areas:
+
+* no_activ - Disable Activ and GatPoly fill
+* no_metal - Disable Metal1 to Metal 5 fill
+* no_topmetal - Disable TopMetal1 and TopMetal2 fill
+
+These arguments don't take a value. See the following example.
+
+klayout -n sg13g2 -zz -r filler.py \
+        -rd output_file=filled-design.gds.gz \
+        -rd no_activ \
+        -rd no_metal \
+        input-file.gds.gz
+"""
+# pylint: disable=import-error
+
+import pathlib
+import os
+import sys
+import pya
+
+LIB = 'SG13_dev'
+
+try:
+    output_file
+except NameError:
+    print("Missing output_file argument. Please define '-rd output_file=<path-to-output-file>'")
+    sys.exit(1)
+
+NO_ACTIV = 'no_activ' in globals()
+NO_METAL = 'no_metal' in globals()
+NO_TOPMETAL = 'no_topmetal' in globals()
+
+scripts = [(NO_ACTIV, 'ActGatP'), (NO_METAL, 'Metal'), (NO_TOPMETAL, 'TopMetal')]
+
+for enabled, area in scripts:
+    if enabled:
+        print(f"Skip {area} fill because disabled by argument")
+        path = pathlib.Path(os.environ['KLAYOUT_HOME']) / f"tech/macros/sg13g2_filler_{area}.lym"
+        pya.Macro(path).run()
+
+layout=pya.CellView.active().layout()
+layout.write(output_file) # pylint: disable=undefined-variable


### PR DESCRIPTION
Add filler macros from Daniel Arevalos and Krzysztof Herman. Also add a Python script to automatically fill a layout and save it.

The following example will fill all layers and generates a DRC clean layout file afterwards.
```
klayout -n sg13g2 -zz -r /home/daniel/work/elements/i2c-gpio-expander/pdks/IHP-Open-PDK/ihp-sg13g2/libs.tech/klayout//tech/scripts/filler.py \
	-rd output_file=/home/daniel/work/elements/i2c-gpio-expander/tools/OpenROAD-flow-scripts/flow/results/ihp-sg13g2/SG13G2Top/base/6_final.gds \
	/home/daniel/work/elements/i2c-gpio-expander/tools/OpenROAD-flow-scripts/flow/results/ihp-sg13g2/SG13G2Top/base/6_final.gds
```