### PR TITLE
libs.ref: Don't ignore sub-directories

### DIFF
--- a/ihp-sg13g2/libs.ref/.gitignore
+++ b/ihp-sg13g2/libs.ref/.gitignore
@@ -1,0 +1,7 @@
+# Make sure we don't ignore sub-directories in the root .gitignore
+!cdl/
+!doc/
+!gds/
+!lib/
+!spice/
+!verilog/


### PR DESCRIPTION
The .gitignore in the root level ignores directories like lib/. This will prevent checking in new libs as Git would ignore those.

Fixes #177
