### PR TITLE
use Xyce vbic build-in model instead Verilog-A model

### DIFF
--- a/ihp-sg13g2/libs.tech/xyce/models/sg13g2_hbt_mod.lib
+++ b/ihp-sg13g2/libs.tech/xyce/models/sg13g2_hbt_mod.lib
@@ -42,10 +42,12 @@
 +El=le*1e6
 +selft=1
 
-Yvbic13_4t_va vbic1 c b e s1 npn13G2_NX_vbic
+*Yvbic13_4t_va vbic1 c b e s1 npn13G2_NX_vbic
+Qnpn13G2 c b e s1 t npn13G2_NX_vbic dtemp=dtemp m=1
 
-.model npn13G2_NX_vbic vbic13_4t_va
-*+ level = 12
+*.model npn13G2_NX_vbic vbic13_4t_va
+.model npn13G2_NX_vbic npn
++ level = 12
 *+ vbe_max = 1.6
 *+ vbc_max = 5.1
 *+ vce_max = 1.6
@@ -168,10 +170,12 @@ Csub s1 bn C = '2.30E-14-(1.50E-15*Nx)'
 +El=le*1e6
 +selft=1
 
-Yvbic13_4t_va vbic1 c b e s1 npn13G2l_NX_vbic
+*Yvbic13_4t_va vbic1 c b e s1 npn13G2l_NX_vbic
+Qnpn13G21 c b e s1 t npn13G21_NX_vbic dtemp=dtemp m=1
 
-.model npn13G2l_NX_vbic vbic13_4t_va
-*+ level = 12
+*.model npn13G2l_NX_vbic vbic13_4t_va
+.model npn13G21_NX_vbic npn
++ level = 12
 *+ vbe_max = 1.6
 *+ vbc_max = 5.1
 *+ vce_max = 1.6
@@ -294,10 +298,12 @@ Rt t 0 R = 1e9
 +El=le*1e6
 +selft=1
 
-Yvbic13_4t_va vbic1 c b e s1 npn13G2v_NX_vbic
+*Yvbic13_4t_va vbic1 c b e s1 npn13G2v_NX_vbic
+Qnpn13G21 c b e s1 t npn13G2v_NX_vbic dtemp=dtemp m=1
 
-.model npn13G2v_NX_vbic vbic13_4t_va
-*+ level = 12
+*.model npn13G2v_NX_vbic vbic13_4t_va
+.model npn13G2v_NX_vbic npn
++ level = 12
 *+ vbe_max = 1.6
 *+ vbc_max = 7.0
 *+ vce_max = 2.2


### PR DESCRIPTION
For easier usage without need to compile Verilog-A code we use the Xyce build-in model for npn13G2 devices.
Because of outdated psp version 103.4 and missing if/then/else capabilities in netlist syntax this is not possible for MOSlv and MOShv devices.