### PR TITLE
libs.tech: Fix klayout extraction of diodes

### DIFF
--- a/ihp-sg13g2/libs.tech/klayout/tech/lvs/rule_decks/diode_derivations.lvs
+++ b/ihp-sg13g2/libs.tech/klayout/tech/lvs/rule_decks/diode_derivations.lvs
@@ -35,12 +35,12 @@ antenna_d_exc = pwell_block.join(salblock_drw)
 antenna_d_mk = recog_diode.not(antenna_d_exc)
 
 # ==== dantenna diode ====
-dantenna_n = activ.and(antenna_d_mk).not(psd_drw).not(nwell_drw)
-dantenna_p = pwell.and(antenna_d_mk).covering(dantenna_n)
+dantenna_n = antenna_d_mk.and(activ).not(psd_drw).not(nwell_drw)
+dantenna_p = antenna_d_mk.and(pwell).covering(dantenna_n)
 
 # ==== dpantenna diode ====
-dpantenna_p = pactiv.and(antenna_d_mk)
-dpantenna_n = nwell_drw.covering(dpantenna_p)
+dpantenna_p = antenna_d_mk.and(pactiv)
+dpantenna_n = dpantenna_p.inside(nwell_drw)
 
 # ==== schottky_nbl1 diode ====
 schottky_mk = recog_diode.and(thickgateox_drw).not(diode_exclude)

--- a/ihp-sg13g2/libs.tech/klayout/tech/lvs/sg13g2_full.lylvs
+++ b/ihp-sg13g2/libs.tech/klayout/tech/lvs/sg13g2_full.lylvs
@@ -3531,12 +3531,12 @@ antenna_d_exc = pwell_block.join(salblock_drw)
 antenna_d_mk = recog_diode.not(antenna_d_exc)
 
 # ==== dantenna diode ====
-dantenna_n = activ.and(antenna_d_mk).not(psd_drw).not(nwell_drw)
-dantenna_p = pwell.and(antenna_d_mk).covering(dantenna_n)
+dantenna_n = antenna_d_mk.and(activ).not(psd_drw).not(nwell_drw)
+dantenna_p = antenna_d_mk.and(pwell).covering(dantenna_n)
 
 # ==== dpantenna diode ====
-dpantenna_p = pactiv.and(antenna_d_mk)
-dpantenna_n = nwell_drw.covering(dpantenna_p)
+dpantenna_p = antenna_d_mk.and(pactiv)
+dpantenna_n = dpantenna_p.inside(nwell_drw)
 
 # ==== schottky_nbl1 diode ====
 schottky_mk = recog_diode.and(thickgateox_drw).not(diode_exclude)


### PR DESCRIPTION
Diodes were extracted at the wrong hierarchy level. Matthias (KLayout author) was kind enough to debug this issue and came up with this patch.

See related discussion :

https://www.klayout.de/forum/discussion/2605/device-extracted-at-wrong-level-of-hierarchy#latest

But as a summary, KLayout's booleans use the first argument's hierarchy as reference. so it's important to make sure to use a "cell local" layer/polygon as first argument to ensure extraction at the proper level
