### PR TITLE
ihp-sg13g2: libs.tech: klayout: python: Move getProcessNames()

### DIFF
--- a/ihp-sg13g2/libs.tech/klayout/python/sg13g2_pycell_lib/__init__.py
+++ b/ihp-sg13g2/libs.tech/klayout/python/sg13g2_pycell_lib/__init__.py
@@ -148,12 +148,10 @@ class PyCellLib(pya.Library):
 
         tech = Tech.get('SG13_dev')
 
-        processNames = getProcessNames()
-
         if os.getenv('IHP_PYCELL_LIB_PRINT_PROCESS_TREE') is not None:
             processChain = ''
             isFirst = True
-            for processName in reversed(processNames):
+            for processName in reversed(getProcessNames()):
                 if not isFirst:
                     processChain += ' <- '
                 processChain += "'" + processName + "'"


### PR DESCRIPTION
This function has a hard depdendency to 'psutil' but is only required when IHP_PYCELL_LIB_PRINT_PROCESS_TREE is set. Move 'getProcessNames' inside the if block to allow using this PDK without 'psutil' installed.

Fixes #226

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR
