### PR TITLE
new instantiation scheme for lv and hv MOS to fix bug in RG calculation

### DIFF
--- a/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moshv_mod.lib
+++ b/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moshv_mod.lib
@@ -73,24 +73,24 @@
 
 .if (as <= 1e-50)  
     .if (floor(floor(ng/2+0.501)*2+0.001) != ng)		  
-        Nsg13_hv_nmos d g s b sg13g2_hv_nmos_psp w='w/ng' l=l mult='ng*m'   
-          + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)/ng'   
-          + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)/ng'  
-          + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)/ng'  
-          + pd='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)/ng'  
+        Nsg13_hv_nmos d g s b sg13g2_hv_nmos_psp w='w' l=l nf='ng' mult='m'   
+          + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'   
+          + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'  
+          + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'  
+          + pd='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'  
           + dta=trise  
           + ngcon=2   
     .else
-        Nsg13_hv_nmos d g s b sg13g2_hv_nmos_psp w='w/ng' l=l mult='ng*m'   
-          + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)/ng'  
-          + ad='max(w/ng,wmin)*z2/2'  
-          + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)/ng'  
-          + pd='max(w/ng,wmin)+z2'  
+        Nsg13_hv_nmos d g s b sg13g2_hv_nmos_psp w='w' l=l nf='ng' mult='m'  
+          + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)'  
+          + ad='max(w/ng,wmin)*z2/2*ng'  
+          + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)'  
+          + pd='(max(w/ng,wmin)+z2)*ng'  
           + dta=trise  
           + ngcon=2   
     .endif
 .else
-    Nsg13_hv_nmos d g s b sg13g2_hv_nmos_psp w='w/ng' l=l as='as/ng' ad='ad/ng' pd='pd/ng' ps='ps/ng' mult='ng*m'   
+    Nsg13_hv_nmos d g s b sg13g2_hv_nmos_psp w='w' l=l as='as' ad='ad' pd='pd' ps='ps' nf='ng' mult='m'   
       + dta=trise  
       + ngcon=2   
 .endif
@@ -103,24 +103,24 @@
 .include sg13g2_moshv_parm.lib
 .if (as <= 1e-50)  
     .if (floor(floor(ng/2+0.501)*2+0.001) != ng)		  
-        Nsg13_hv_pmos d g s b sg13g2_hv_pmos_psp w='w/ng' l=l mult='ng*m'  
-          + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)/ng'   
-          + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)/ng'  
-          + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)/ng'  
-          + pd='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)/ng'  
+        Nsg13_hv_pmos d g s b sg13g2_hv_pmos_psp w='w' l=l nf='ng' mult='m'  
+          + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'   
+          + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'  
+          + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'  
+          + pd='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'  
           + dta=trise  
           + ngcon=2   
     .else
-        Nsg13_hv_pmos d g s b sg13g2_hv_pmos_psp w='w/ng' l=l mult='ng*m'   
-          + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)/ng'  
-          + ad='max(w/ng,wmin)*z2/2'  
-          + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)/ng'  
-          + pd='max(w/ng,wmin)+z2'  
+        Nsg13_hv_pmos d g s b sg13g2_hv_pmos_psp w='w' l=l nf='ng' mult='m'  
+          + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)'  
+          + ad='max(w/ng,wmin)*z2/2*ng'  
+          + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)'  
+          + pd='(max(w/ng,wmin)+z2)*ng'  
           + dta=trise  
           + ngcon=2   
     .endif
 .else
-    Nsg13_hv_pmos d g s b sg13g2_hv_pmos_psp w='w/ng' l=l as='as/ng' ad='ad/ng' pd='pd/ng' ps='ps/ng' mult='ng*m'  
+    Nsg13_hv_pmos d g s b sg13g2_hv_pmos_psp w='w' l=l as='as' ad='ad' pd='pd' ps='ps' nf='ng' mult='m'  
       + dta=trise  
       + ngcon=2   
 .endif

--- a/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moslv_mod.lib
+++ b/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moslv_mod.lib
@@ -40,7 +40,6 @@
 *******************************************************************************   
   
   
-  
 *******************************************************************************   
 * MOS transistor section  
 *******************************************************************************   
@@ -68,61 +67,60 @@
 * if as is given externally, no adjustment for ng is done! -> must be done in the extractor  
 * if ng>1 and as=0 (in schematic) recalculate!  
   
-
 * include the model parameters
 .include sg13g2_moslv_parm.lib
 
-.if (as <= 1e-50)  
-    .if (floor(floor(ng/2+0.501)*2+0.001) != ng)		  
-        Nsg13_lv_nmos d g s b sg13g2_lv_nmos_psp w='w/ng' l=l mult='ng*m'   
-          + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)/ng'   
-          + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)/ng'  
-          + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)/ng'  
-          + pd='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)/ng'  
-          + dta=trise  
-          + ngcon=2   
+.if (as <= 1e-50)
+    .if (floor(floor(ng/2+0.501)*2+0.001) != ng)
+        Nsg13_lv_nmos d g s b sg13g2_lv_nmos_psp w='w' l=l nf='ng' mult='m'
+          + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
+          + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
+          + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+          + pd='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+          + dta=trise
+          + ngcon=2
     .else
-        Nsg13_lv_nmos d g s b sg13g2_lv_nmos_psp w='w/ng' l=l mult='ng*m'   
-          + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)/ng'  
-          + ad='max(w/ng,wmin)*z2/2'  
-          + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)/ng'  
-          + pd='max(w/ng,wmin)+z2'  
-          + dta=trise  
-          + ngcon=2   
+        Nsg13_lv_nmos d g s b sg13g2_lv_nmos_psp w='w' l=l nf='ng' mult='m'
+          + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)'
+          + ad='max(w/ng,wmin)*z2/2*ng'
+          + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)'
+          + pd='(max(w/ng,wmin)+z2)*ng'
+          + dta=trise
+          + ngcon=2
     .endif
 .else
-    Nsg13_lv_nmos d g s b sg13g2_lv_nmos_psp w='w/ng' l=l as='as/ng' ad='ad/ng' pd='pd/ng' ps='ps/ng' mult='ng*m'   
-      + dta=trise  
-      + ngcon=2   
+    Nsg13_lv_nmos d g s b sg13g2_lv_nmos_psp w='w' l=l as='as' ad='ad' pd='pd' ps='ps' nf='ng' mult='m'
+      + dta=trise
+      + ngcon=2
 .endif
 .ends
   
 .subckt sg13_lv_pmos d g s b   
 + w=0.35u l=0.28u ng=1 m=1 as=0 ad=0 pd=0 ps=0 trise=0 z1=0.34e-6 z2=0.38e-6 wmin=0.15e-6 rfmode=0 pre_layout=1  
   
-
 .include sg13g2_moslv_parm.lib
-.if (as <= 1e-50)  
-    .if (floor(floor(ng/2+0.501)*2+0.001) != ng)		  
-        Nsg13_lv_pmos d g s b sg13g2_lv_pmos_psp w='w/ng' l=l mult='ng*m'  
-          + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)/ng'   
-          + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)/ng'  
-          + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)/ng'  
-          + pd='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)/ng'  
-          + dta=trise  
-          + ngcon=2   
+
+.if (as <= 1e-50)
+    .if (floor(floor(ng/2+0.501)*2+0.001) != ng)
+        Nsg13_lv_pmos d g s b sg13g2_lv_pmos_psp w='w' l=l nf='ng' mult='m'
+          + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
+          + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
+          + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+          + pd='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+          + dta=trise
+          + ngcon=2
     .else
-        Nsg13_lv_pmos d g s b sg13g2_lv_pmos_psp w='w/ng' l=l mult='ng*m'   
-          + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)/ng'  
-          + ad='max(w/ng,wmin)*z2/2'  
-          + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)/ng'  
-          + pd='max(w/ng,wmin)+z2'  
-          + dta=trise  
-          + ngcon=2   
+        Nsg13_lv_pmos d g s b sg13g2_lv_pmos_psp w='w' l=l nf='ng' mult='m'
+          + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)'
+          + ad='max(w/ng,wmin)*z2/2*ng'
+          + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)'
+          + pd='(max(w/ng,wmin)+z2)*ng'
+          + dta=trise
+          + ngcon=2
     .endif
 .else
-    Nsg13_lv_pmos d g s b sg13g2_lv_pmos_psp w='w/ng' l=l as='as/ng' ad='ad/ng' pd='pd/ng' ps='ps/ng' mult='ng*m'  
-      + dta=trise  
-      + ngcon=2   
+    Nsg13_lv_pmos d g s b sg13g2_lv_pmos_psp w='w' l=l as='as' ad='ad' pd='pd' ps='ps' nf='ng' mult='m'
+      + dta=trise
+      + ngcon=2
 .endif
 .ends


### PR DESCRIPTION
Fixes #164

This PR solves the problem in wrong RG calculation with a high impact to correct noise calculation in rfmode=1 for multifinger lv and hv MOS devices.
