### PR TITLE
Update KLayout DRC scripts

### DIFF
--- a/ihp-sg13g2/libs.tech/klayout/tech/drc/MissingRules_maximal.md
+++ b/ihp-sg13g2/libs.tech/klayout/tech/drc/MissingRules_maximal.md
@@ -4,11 +4,6 @@
 | ----------- | ------------------------------------------------------------------------------------------------------------------------------ |
 | NW.b        | Min. NWell space or notch (same net). NWell regions separated by less than this value will be merged.                          |
 | NW.b1       | Min. PWell width between NWell regions (different net) (Note 3)                                                                |
-| NW.c        | Min. NWell enclosure of P+Activ not inside ThickGateOx                                                                         |
-| NW.c1       | Min. NWell enclosure of P+Activ inside ThickGateOx                                                                             |
-| NW.d        | Min. NWell space to external N+Activ not inside ThickGateOx                                                                    |
-| NW.e        | Min. NWell enclosure of NWell tie surrounded entirely by NWell in N+Activ not inside ThickGateOx                               |
-| NW.e1       | Min. NWell enclosure of NWell tie surrounded entirely by NWell in N+Activ inside ThickGateOx                                   |
 | PWB.d       | Min. PWell:block overlap of NWell                                                                                              |
 | PWB.e       | Min. PWell:block space to (N+Activ not inside ThickGateOx) in PWell                                                            |
 | PWB.e1      | Min. PWell:block space to (N+Activ inside ThickGateOx) in PWell                                                                |
@@ -19,12 +14,10 @@
 | NBL.d       | Min. PWell width between nBuLay and NWell (different net) (Note 1)                                                             |
 | NBL.e       | Min. nBuLay space to unrelated N+Activ                                                                                         |
 | NBL.f       | Min. nBuLay space to unrelated P+Activ                                                                                         |
-| Act.c       | Min. Activ drain/source extension                                                                                              |
 | AFil.c      | Min. Activ:filler space to Cont, GatPoly                                                                                       |
 | AFil.c1     | Min. Activ:filler space to Activ                                                                                               |
 | AFil.d      | Min. Activ:filler space to NWell, nBuLay                                                                                       |
 | AFil.e      | Min. Activ:filler space to TRANS                                                                                               |
-| AFil.i      | Min. Activ:filler space to edges of PWell:block                                                                                |
 | AFil.j      | Min. nSD:block and SalBlock enclosure of Activ:filler inside PWell:block                                                       |
 | Gat.a1      | Min. GatPoly width for channel length of 1.2 V NFET                                                                            |
 | Gat.a2      | Min. GatPoly width for channel length of 1.2 V PFET                                                                            |
@@ -33,14 +26,7 @@
 | GFil.i      | Max. GatPoly:nofill area (µm²)                                                                                                 |
 | pSD.c1      | Min. pSD enclosure of P+Activ in PWell                                                                                         |
 | nSDB.d      | Min. nSD:block overlap of pSD (Note 1)                                                                                         |
-| Cnt.c       | Min. Activ enclosure of Cont                                                                                                   |
-| Cnt.d       | Min. GatPoly enclosure of Cont                                                                                                 |
-| Cnt.e       | Min. Cont on GatPoly space to Activ                                                                                            |
-| Cnt.g1      | Min. pSD space to Cont on nSD-Activ                                                                                            |
-| Cnt.g2      | Min. pSD overlap of Cont on pSD-Activ                                                                                          |
 | CntB.b1     | Min. ContBar space with common run > 5 µm                                                                                      |
-| CntB.c      | Min. Activ enclosure of ContBar                                                                                                |
-| CntB.d      | Min. GatPoly enclosure of ContBar                                                                                              |
 | CntB.h1     | Min. Metal1 enclosure of ContBar                                                                                               |
 | M1.e        | Min. space of Metal1 lines if, at least one line is wider than 0.3 µm and the parallel run is more than 1.0 µm                 |
 | M1.f        | Min. space of Metal1 lines if, at least one line is wider than 10.0 µm and the parallel run is more than 10.0 µm               |
@@ -90,8 +76,6 @@
 | npn13G2.bR  | Max. recommended total number of npn13G2 emitters per chip                                                                     |
 | npn13G2L.cR | Max. recommended total number of npn13G2L emitters per chip                                                                    |
 | npn13G2V.cR | Max. recommended total number of npn13G2V emitters per chip                                                                    |
-| Rppd.d      | Min. EXTBlock enclosure of GatPoly                                                                                             |
-| Rhi.e       | Min. EXTBlock enclosure of GatPoly                                                                                             |
 | nmosi.e1    | A separate Iso-PWell contact unabutted to a nmosi device is not allowed                                                        |
 | nmosi.e2    | nmosi unabutted to an Iso-PWell-Activ tie is not allowed                                                                       |
 | Sdiod.d     | Min. and max. ContBar width inside nBuLay                                                                                      |
@@ -134,15 +118,6 @@
 | Slt.i.M5    | Min. Metal5:slit density for any Metal5 plate bigger than 35 µm x 35 µm [%]                                                    |
 | Slt.i.TM1   | Min. TopMetal1:slit density for any TopMetal1 plate bigger than 35 µm x 35 µm [%]                                              |
 | Slt.i.TM2   | Min. TopMetal2:slit density for any TopMetal2 plate bigger than 35 µm x 35 µm [%]                                              |
-| NW.c1.dig   | Min. NWell enclosure of P+Activ inside ThickGateOx                                                                             |
-| NW.e1.dig   | Min. NWell enclosure of NWell tie surrounded entirely by NWell in N+Activ inside ThickGateOx                                   |
-| Cnt.c.Digi  | Min. Activ enclosure of Cont                                                                                                   |
-| NW.c.SRAM   | Min. NWell enclosure of P+Activ not inside ThickGateOx                                                                         |
-| NW.d.SRAM   | Min. NWell space to external N+Activ not inside ThickGateOx                                                                    |
-| Act.c.SRAM  | Min. Activ drain/source extension                                                                                              |
-| Cnt.c.SRAM  | Min. Activ enclosure of Cont                                                                                                   |
-| Cnt.d.SRAM  | Min. GatPoly enclosure of Cont                                                                                                 |
-| Cnt.g2.SRAM | Min. pSD overlap of Cont on pSD-Activ                                                                                          |
 | M1.i.SRAM   | Min. space of Metal1 lines of which at least one is bent by 45-degree                                                          |
 | V1.c1.SRAM  | Min. Metal1 endcap enclosure of Via1                                                                                           |
 | V2.c1.SRAM  | Min. Metal2 endcap enclosure of Via2                                                                                           |

--- a/ihp-sg13g2/libs.tech/klayout/tech/drc/README_maximal.md
+++ b/ihp-sg13g2/libs.tech/klayout/tech/drc/README_maximal.md
@@ -2,446 +2,471 @@
 
 List of available DRC rules:
 
-| Name                     | Description                                                                             |
-| ------------------------ | --------------------------------------------------------------------------------------- |
-| NW.a                     | Min. NWell width                                                                        |
-| NW.d1                    | Min. NWell space to external N+Activ inside ThickGateOx                                 |
-| NW.f                     | Min. NWell space to substrate tie in P+Activ not inside ThickGateOx                     |
-| NW.f1                    | Min. NWell space to substrate tie in P+Activ inside ThickGateOx                         |
-| PWB.a                    | Min. PWell:block width                                                                  |
-| PWB.b                    | Min. PWell:block space or notch                                                         |
-| PWB.c                    | Min. PWell:block space to unrelated NWell                                               |
-| NBL.a                    | Min. nBuLay width                                                                       |
-| NBLB.a                   | Min. nBuLay:block width                                                                 |
-| NBLB.b                   | Min. nBuLay:block space or notch                                                        |
-| NBLB.c                   | Min. nBuLay enclosure of nBuLay:block                                                   |
-| NBLB.d                   | Min. nBuLay:block space to unrelated nBuLay                                             |
-| Act.a                    | Min. Activ width                                                                        |
-| Act.b                    | Min. Activ space or notch                                                               |
-| Act.d                    | Min. Activ area (µm²)                                                                   |
-| Act.e                    | Min. Activ enclosed area (µm²)                                                          |
-| AFil.a                   | Max. Activ:filler width                                                                 |
-| AFil.a1                  | Min. Activ:filler width                                                                 |
-| AFil.b                   | Min. Activ:filler space                                                                 |
-| AFil.g                   | Min. global Activ density [%]                                                           |
-| AFil.g1                  | Max. global Activ density [%]                                                           |
-| AFil.g2                  | Min. Activ coverage ratio for any 800 x 800 µm² chip area [%]                           |
-| AFil.g3                  | Max. Activ coverage ratio for any 800 x 800 µm² chip area [%]                           |
-| TGO.a                    | Min. ThickGateOx extension over Activ                                                   |
-| TGO.b                    | Min. space between ThickGateOx and Activ outside thick gate oxide region                |
-| TGO.c                    | Min. ThickGateOx extension over GatPoly over Activ                                      |
-| TGO.d                    | Min. space between ThickGateOx and GatPoly over Activ outside thick gate oxide region   |
-| TGO.e                    | Min. ThickGateOx space (merge if less than this value)                                  |
-| TGO.f                    | Min. ThickGateOx width                                                                  |
-| Gat.a                    | Min. GatPoly width                                                                      |
-| Gat.a3                   | Min. GatPoly width for channel length of 3.3 V NFET                                     |
-| Gat.a4                   | Min. GatPoly width for channel length of 3.3 V PFET                                     |
-| Gat.b                    | Min. GatPoly space or notch                                                             |
-| Gat.b1                   | Min. space between unrelated 3.3 V GatPoly over Activ regions                           |
-| Gat.c                    | Min. GatPoly extension over Activ (end cap)                                             |
-| Gat.d                    | Min. GatPoly space to Activ                                                             |
-| Gat.e                    | Min. GatPoly area (µm²)                                                                 |
-| Gat.f                    | 45-degree and 90-degree angles for GatPoly on Activ area are not allowed                |
-| GFil.a                   | Max. GatPoly:filler width                                                               |
-| GFil.b                   | Min. GatPoly:filler width                                                               |
-| GFil.c                   | Min. GatPoly:filler space                                                               |
-| GFil.d.Activ             | Min. GatPoly:filler space to Activ                                                      |
-| GFil.d.GatPoly           | Min. GatPoly:filler space to GatPoly                                                    |
-| GFil.d.Cont              | Min. GatPoly:filler space to Cont                                                       |
-| GFil.d.pSD               | Min. GatPoly:filler space to pSD                                                        |
-| GFil.d.nSD_block         | Min. GatPoly:filler space to nSD:block                                                  |
-| GFil.d.SalBlock          | Min. GatPoly:filler space to SalBlock                                                   |
-| GFil.f                   | Min. GatPoly:filler space to TRANS                                                      |
-| GFil.g                   | Min. global GatPoly density [%]                                                         |
-| GFil.j                   | Min. GatPoly:filler extension over Activ:filler (end cap)                               |
-| pSD.a                    | Min. pSD width                                                                          |
-| pSD.b                    | Min. pSD space or notch (Note 1)                                                        |
-| pSD.c                    | Min. pSD enclosure of P+Activ in NWell                                                  |
-| pSD.d                    | Min. pSD space to unrelated N+Activ in PWell                                            |
-| pSD.d1                   | Min. pSD space to N+Activ in NWell                                                      |
-| pSD.e                    | Min. pSD overlap of Activ at one position when forming abutted substrate tie (Note 2)   |
-| pSD.f                    | Min. Activ extension over pSD at one position when forming abutted NWell tie (Note 2)   |
-| pSD.g                    | Min. N+Activ or P+Activ area (µm²) when forming abutted tie (Note 2)                    |
-| pSD.i                    | Min. pSD enclosure of PFET gate not inside ThickGateOx                                  |
-| pSD.i1                   | Min. pSD enclosure of PFET gate inside ThickGateOx                                      |
-| pSD.j                    | Min. pSD space to NFET gate not inside ThickGateOx                                      |
-| pSD.j1                   | Min. pSD space to NFET gate inside ThickGateOx                                          |
-| pSD.k                    | Min. pSD area (µm²)                                                                     |
-| pSD.l                    | Min. pSD enclosed area (µm²)                                                            |
-| pSD.m                    | Min. pSD space to n-type poly resistors                                                 |
-| pSD.n                    | Min. pSD enclosure of p-type poly resistors                                             |
-| nSDB.a                   | Min. nSD:block width                                                                    |
-| nSDB.b                   | Min. nSD:block space or notch                                                           |
-| nSDB.c                   | Min. nSD:block space to unrelated pSD                                                   |
-| nSDB.e                   | Min. nSD:block space to Cont (Note 2)                                                   |
-| EXT.a                    | Min. EXTBlock width                                                                     |
-| EXT.b                    | Min. EXTBlock space or notch                                                            |
-| EXT.c                    | Min. EXTBlock space to pSD                                                              |
-| Sal.a                    | Min. SalBlock width                                                                     |
-| Sal.b                    | Min. SalBlock space or notch                                                            |
-| Sal.c                    | Min. SalBlock extension over Activ or GatPoly                                           |
-| Sal.d                    | Min. SalBlock space to unrelated Activ or GatPoly                                       |
-| Sal.e                    | Min. SalBlock space to Cont                                                             |
-| Cnt.a                    | Min. and max. Cont width                                                                |
-| Cnt.b                    | Min. Cont space                                                                         |
-| Cnt.b1                   | Min. Cont space in a contact array of more than 4 rows and more then 4 columns (Note 1) |
-| Cnt.f                    | Min. Cont on Activ space to GatPoly                                                     |
-| Cnt.g                    | Cont must be within Activ or GatPoly                                                    |
-| Cnt.h                    | Cont must be covered with Metal1                                                        |
-| Cnt.j                    | Cont on GatPoly over Activ is not allowed                                               |
-| CntB.a                   | Min. and max. ContBar width                                                             |
-| CntB.a1                  | Min. ContBar length                                                                     |
-| CntB.b                   | Min. ContBar space                                                                      |
-| CntB.b2                  | Min. ContBar space to Cont                                                              |
-| CntB.e                   | Min. ContBar on GatPoly space to Activ                                                  |
-| CntB.f                   | Min. ContBar on Activ space to GatPoly                                                  |
-| CntB.g                   | ContBar must be within Activ or GatPoly                                                 |
-| CntB.g1                  | Min. pSD space to ContBar on nSD-Activ                                                  |
-| CntB.g2                  | Min. pSD overlap of ContBar on pSD-Activ                                                |
-| CntB.h                   | ContBar must be covered with Metal1                                                     |
-| CntB.j                   | ContBar on GatPoly over Activ is not allowed                                            |
-| M1.a                     | Min. Metal1 width                                                                       |
-| M1.b                     | Min. Metal1 space or notch                                                              |
-| M1.c                     | Min. Metal1 enclosure of Cont                                                           |
-| M1.c1                    | Min. Metal1 endcap enclosure of Cont (Note 1)                                           |
-| M1.d                     | Min. Metal1 area (µm²)                                                                  |
-| M1.j                     | Min. global Metal1 density [%]                                                          |
-| M1.k                     | Max. global Metal1 density [%]                                                          |
-| M2.a                     | Min. Metal2 width                                                                       |
-| M2.b                     | Min. Metal2 space or notch                                                              |
-| M2.c                     | Min. Metal2 enclosure of Via1                                                           |
-| M2.c1                    | Min. Metal2 endcap enclosure of Via1 (Note 1)                                           |
-| M2.d                     | Min. Metal2 area (µm²)                                                                  |
-| M2.j                     | Min. global Metal2 density [%]                                                          |
-| M2.k                     | Max. global Metal2 density [%]                                                          |
-| M3.a                     | Min. Metal3 width                                                                       |
-| M3.b                     | Min. Metal3 space or notch                                                              |
-| M3.c                     | Min. Metal3 enclosure of Via2                                                           |
-| M3.c1                    | Min. Metal3 endcap enclosure of Via2 (Note 1)                                           |
-| M3.d                     | Min. Metal3 area (µm²)                                                                  |
-| M3.j                     | Min. global Metal3 density [%]                                                          |
-| M3.k                     | Max. global Metal3 density [%]                                                          |
-| M4.a                     | Min. Metal4 width                                                                       |
-| M4.b                     | Min. Metal4 space or notch                                                              |
-| M4.c                     | Min. Metal4 enclosure of Via3                                                           |
-| M4.c1                    | Min. Metal4 endcap enclosure of Via3 (Note 1)                                           |
-| M4.d                     | Min. Metal4 area (µm²)                                                                  |
-| M4.j                     | Min. global Metal4 density [%]                                                          |
-| M4.k                     | Max. global Metal4 density [%]                                                          |
-| M5.a                     | Min. Metal5 width                                                                       |
-| M5.b                     | Min. Metal5 space or notch                                                              |
-| M5.c                     | Min. Metal5 enclosure of Via4                                                           |
-| M5.c1                    | Min. Metal5 endcap enclosure of Via4 (Note 1)                                           |
-| M5.d                     | Min. Metal5 area (µm²)                                                                  |
-| M5.j                     | Min. global Metal5 density [%]                                                          |
-| M5.k                     | Max. global Metal5 density [%]                                                          |
-| M1Fil.a1                 | Min. Metal1:filler width                                                                |
-| M1Fil.b                  | Min. Metal1:filler space                                                                |
-| M1Fil.c                  | Min. Metal1:filler space to Metal1                                                      |
-| M1Fil.d                  | Min. Metal1:filler space to TRANS                                                       |
-| M1Fil.h                  | Min. Metal1 and Metal1:filler coverage ratio for any 800 x 800 µm² chip area [%]        |
-| M1Fil.k                  | Max. Metal1 and Metal1:filler coverage ratio for any 800 x 800 µm² chip area [%]        |
-| M2Fil.a1                 | Min. Metal2:filler width                                                                |
-| M2Fil.b                  | Min. Metal2:filler space                                                                |
-| M2Fil.c                  | Min. Metal2:filler space to Metal2                                                      |
-| M2Fil.d                  | Min. Metal2:filler space to TRANS                                                       |
-| M2Fil.h                  | Min. Metal2 and Metal2:filler coverage ratio for any 800 x 800 µm² chip area [%]        |
-| M2Fil.k                  | Max. Metal2 and Metal2:filler coverage ratio for any 800 x 800 µm² chip area [%]        |
-| M3Fil.a1                 | Min. Metal3:filler width                                                                |
-| M3Fil.b                  | Min. Metal3:filler space                                                                |
-| M3Fil.c                  | Min. Metal3:filler space to Metal3                                                      |
-| M3Fil.d                  | Min. Metal3:filler space to TRANS                                                       |
-| M3Fil.h                  | Min. Metal3 and Metal3:filler coverage ratio for any 800 x 800 µm² chip area [%]        |
-| M3Fil.k                  | Max. Metal3 and Metal3:filler coverage ratio for any 800 x 800 µm² chip area [%]        |
-| M4Fil.a1                 | Min. Metal4:filler width                                                                |
-| M4Fil.b                  | Min. Metal4:filler space                                                                |
-| M4Fil.c                  | Min. Metal4:filler space to Metal4                                                      |
-| M4Fil.d                  | Min. Metal4:filler space to TRANS                                                       |
-| M4Fil.h                  | Min. Metal4 and Metal4:filler coverage ratio for any 800 x 800 µm² chip area [%]        |
-| M4Fil.k                  | Max. Metal4 and Metal4:filler coverage ratio for any 800 x 800 µm² chip area [%]        |
-| M5Fil.a1                 | Min. Metal5:filler width                                                                |
-| M5Fil.b                  | Min. Metal5:filler space                                                                |
-| M5Fil.c                  | Min. Metal5:filler space to Metal5                                                      |
-| M5Fil.d                  | Min. Metal5:filler space to TRANS                                                       |
-| M5Fil.h                  | Min. Metal5 and Metal5:filler coverage ratio for any 800 x 800 µm² chip area [%]        |
-| M5Fil.k                  | Max. Metal5 and Metal5:filler coverage ratio for any 800 x 800 µm² chip area [%]        |
-| V1.a                     | Min. and max. Via1 width                                                                |
-| V1.b                     | Min. Via1 space                                                                         |
-| V1.b1                    | Min. Via1 space in an array of more than 3 rows and more then 3 columns (Note 1)        |
-| V1.c1                    | Min. Metal1 endcap enclosure of Via1 (Note 2)                                           |
-| V2.a                     | Min. and max. Via2 width                                                                |
-| V2.b                     | Min. Via2 space                                                                         |
-| V2.b1                    | Min. Via2 space in an array of more than 3 rows and more then 3 columns (Note 1)        |
-| V2.c1                    | Min. Metal2 endcap enclosure of Via2 (Note 2)                                           |
-| V3.a                     | Min. and max. Via3 width                                                                |
-| V3.b                     | Min. Via3 space                                                                         |
-| V3.b1                    | Min. Via3 space in an array of more than 3 rows and more then 3 columns (Note 1)        |
-| V3.c1                    | Min. Metal3 endcap enclosure of Via3 (Note 2)                                           |
-| V4.a                     | Min. and max. Via4 width                                                                |
-| V4.b                     | Min. Via4 space                                                                         |
-| V4.b1                    | Min. Via4 space in an array of more than 3 rows and more then 3 columns (Note 1)        |
-| V4.c1                    | Min. Metal4 endcap enclosure of Via4 (Note 2)                                           |
-| TV1.a                    | Min. and max. TopVia1 width                                                             |
-| TV1.b                    | Min. TopVia1 space                                                                      |
-| TM1.a                    | Min. TopMetal1 width                                                                    |
-| TM1.b                    | Min. TopMetal1 space or notch                                                           |
-| TM1.c                    | Min. global TopMetal1 density [%]                                                       |
-| TM1.d                    | Max. global TopMetal1 density [%]                                                       |
-| TM1Fil.a                 | Min. TopMetal1:filler width                                                             |
-| TM1Fil.b                 | Min. TopMetal1:filler space                                                             |
-| TM1Fil.c                 | Min. TopMetal1:filler space to TopMetal1                                                |
-| TM1Fil.d                 | Min. TopMetal1:filler space to TRANS                                                    |
-| TV2.a                    | Min. and max. TopVia2 width                                                             |
-| TV2.b                    | Min. TopVia2 space                                                                      |
-| TM2.a                    | Min. TopMetal2 width                                                                    |
-| TM2.b                    | Min. TopMetal2 space or notch                                                           |
-| TM2.c                    | Min. global TopMetal2 density [%]                                                       |
-| TM2.d                    | Max. global TopMetal2 density [%]                                                       |
-| TM2Fil.a                 | Min. TopMetal2:filler width                                                             |
-| TM2Fil.b                 | Min. TopMetal2:filler space                                                             |
-| TM2Fil.c                 | Min. TopMetal2:filler space to TopMetal2                                                |
-| TM2Fil.d                 | Min. TopMetal2:filler space to TRANS                                                    |
-| Pas.a                    | Min. Passiv width                                                                       |
-| Pas.b                    | Min. Passiv space or notch                                                              |
-| npn13G2.a                | Min. and max. npn13G2 emitter length                                                    |
-| npn13G2L.a               | Min. npn13G2L emitter length                                                            |
-| npn13G2L.b               | Max. npn13G2L emitter length                                                            |
-| npn13G2V.a               | Min. npn13G2V emitter length                                                            |
-| npn13G2V.b               | Max. npn13G2V emitter length                                                            |
-| Rsil.a                   | Min. GatPoly width                                                                      |
-| Rsil.b                   | Min. RES space to Cont                                                                  |
-| Rsil.c                   | Min. RES extension over GatPoly                                                         |
-| Rsil.d                   | Min. pSD space to GatPoly                                                               |
-| Rsil.e                   | Min. EXTBlock enclosure of GatPoly                                                      |
-| Rsil.f                   | Min. RES length                                                                         |
-| Rppd.a                   | Min. GatPoly width                                                                      |
-| Rppd.b                   | Min. pSD enclosure of GatPoly                                                           |
-| Rppd.c                   | Min. and max. SalBlock space to Cont                                                    |
-| Rppd.e                   | Min. SalBlock length                                                                    |
-| Rhi.a                    | Min. GatPoly width                                                                      |
-| Rhi.b                    | pSD and nSD are identical (Note 1)                                                      |
-| Rhi.c                    | Min. pSD and nSD enclosure of GatPoly                                                   |
-| Rhi.d                    | Min. and max. SalBlock space to Cont                                                    |
-| Rhi.f                    | Min. SalBlock length                                                                    |
-| nmosi.b                  | Min. nBuLay enclosure of Iso-PWell-Activ (Note 1)                                       |
-| nmosi.c                  | Min. NWell space to Iso-PWell-Activ                                                     |
-| nmosi.d                  | Min. NWell-nBuLay width forming an unbroken ring around any Iso-PWell-Activ (Note 2)    |
-| nmosi.f                  | Min. nSD:block width to separate ptap in nmosi                                          |
-| nmosi.g                  | Min. SalBlock overlap of nSD:block over Activ                                           |
-| Sdiod.a                  | Min. and max. PWell:block enclosure of ContBar                                          |
-| Sdiod.b                  | Min. and max. nSD:block enclosure of ContBar                                            |
-| Sdiod.c                  | Min. and max. SalBlock enclosure of ContBar                                             |
-| Pad.aR                   | Min. recommended Pad width                                                              |
-| Pad.a1                   | Max. Pad width                                                                          |
-| Pad.bR                   | Min. recommended Pad space                                                              |
-| Pad.d                    | Min. Pad space to EdgeSeal                                                              |
-| Pad.dR                   | Min. recommended Pad to EdgeSeal space (Note 1)                                         |
-| Pad.d1R                  | Min. recommended Pad to Activ (inside chip area) space                                  |
-| Pad.gR                   | TopMetal1 (within dfpad) enclosure of TopVia2                                           |
-| Pad.jR                   | No devices under Pad allowed (Note 2)                                                   |
-| Pad.kR                   | TopVia2 under Pad not allowed (Note 3)                                                  |
-| Padc.b                   | Min. CuPillarPad space                                                                  |
-| Padc.d                   | Min. CuPillarPad space to EdgeSeal                                                      |
-| Seal.a_Activ             | Min. EdgeSeal-Activ width                                                               |
-| Seal.a_pSD               | Min. EdgeSeal-pSD width                                                                 |
-| Seal.a_Metal1            | Min. EdgeSeal-Metal1 width                                                              |
-| Seal.a_Metal2            | Min. EdgeSeal-Metal2 width                                                              |
-| Seal.a_Metal3            | Min. EdgeSeal-Metal3 width                                                              |
-| Seal.a_Metal4            | Min. EdgeSeal-Metal4 width                                                              |
-| Seal.a_Metal5            | Min. EdgeSeal-Metal5 width                                                              |
-| Seal.a_TopMetal1         | Min. EdgeSeal-TopMetal1 width                                                           |
-| Seal.a_TopMetal2         | Min. EdgeSeal-TopMetal2 width                                                           |
-| Seal.c                   | EdgeSeal-Cont ring width                                                                |
-| Seal.c1.Via1             | EdgeSeal-Via1 ring width                                                                |
-| Seal.c1.Via2             | EdgeSeal-Via2 ring width                                                                |
-| Seal.c1.Via3             | EdgeSeal-Via3 ring width                                                                |
-| Seal.c1.Via4             | EdgeSeal-Via4 ring width                                                                |
-| Seal.c2                  | EdgeSeal-TopVia1 ring width                                                             |
-| Seal.c3                  | EdgeSeal-TopVia2 ring width                                                             |
-| Seal.e                   | Min. Passiv ring width outside of sealring                                              |
-| MIM.a                    | Min. MIM width                                                                          |
-| MIM.b                    | Min. MIM space                                                                          |
-| MIM.e                    | Min. TopMetal1 space to MIM                                                             |
-| MIM.f                    | Min. MIM area per MIM device (µm²)                                                      |
-| MIM.g                    | Max. MIM area per MIM device (µm²)                                                      |
-| MIM.h                    | TopVia1 must be over MIM                                                                |
-| LU.a                     | Max. space from any portion of P+Activ inside NWell to an nSD-NWell tie                 |
-| LU.c                     | Max. extension of an abutted NWell tie beyond Cont                                      |
-| LU.c1                    | Max. extension of an abutted substrate tie beyond Cont                                  |
-| LU.d                     | Max. extension of NWell tie Activ tie beyond Cont                                       |
-| LU.d1                    | Max. extension of an substrate tie Activ beyond Cont                                    |
-| Slt.a.M1                 | Min. Metal1:slit width                                                                  |
-| Slt.b.M1                 | Max. Metal1:slit width                                                                  |
-| Slt.c.M1                 | Max. Metal1 width without requiring a slit                                              |
-| Slt.e.M1                 | No slits required on bond pads                                                          |
-| Slt.f.M1                 | Min. Metal1 enclosure of Metal1:slit                                                    |
-| Slt.h1                   | Min. Metal1:slit space to Cont and Via1                                                 |
-| Slt.a.M2                 | Min. Metal2:slit width                                                                  |
-| Slt.b.M2                 | Max. Metal2:slit width                                                                  |
-| Slt.c.M2                 | Max. Metal2 width without requiring a slit                                              |
-| Slt.e.M2                 | No slits required on bond pads                                                          |
-| Slt.f.M2                 | Min. Metal2 enclosure of Metal2:slit                                                    |
-| Slt.h2.M2                | Min. Metal2:slit space to Via1 and Via2                                                 |
-| Slt.a.M3                 | Min. Metal3:slit width                                                                  |
-| Slt.b.M3                 | Max. Metal3:slit width                                                                  |
-| Slt.c.M3                 | Max. Metal3 width without requiring a slit                                              |
-| Slt.e.M3                 | No slits required on bond pads                                                          |
-| Slt.f.M3                 | Min. Metal3 enclosure of Metal2:slit                                                    |
-| Slt.h2.M3                | Min. Metal3:slit space to Via2 and Via3                                                 |
-| Slt.a.M4                 | Min. Metal4:slit width                                                                  |
-| Slt.b.M4                 | Max. Metal4:slit width                                                                  |
-| Slt.c.M4                 | Max. Metal4 width without requiring a slit                                              |
-| Slt.e.M4                 | No slits required on bond pads                                                          |
-| Slt.f.M4                 | Min. Metal4 enclosure of Metal4:slit                                                    |
-| Slt.h2.M4                | Min. Metal4:slit space to Via3 and Via4                                                 |
-| Slt.a.M5                 | Min. Metal5:slit width                                                                  |
-| Slt.b.M5                 | Max. Metal5:slit width                                                                  |
-| Slt.c.M5                 | Max. Metal5 width without requiring a slit                                              |
-| Slt.e.M5                 | No slits required on bond pads                                                          |
-| Slt.f.M5                 | Min. Metal5 enclosure of Metal5:slit                                                    |
-| Slt.g.M5                 | Min. Metal5:slit and TopMetal1:slit space to MIM                                        |
-| Slt.h2.M5                | Min. Metal5:slit space to Via4 and Via5                                                 |
-| Slt.a.TM1                | Min. TopMetal1:slit width                                                               |
-| Slt.b.TM1                | Max. TopMetal1:slit width                                                               |
-| Slt.c.TM1                | Max. TopMetal1 width without requiring a slit                                           |
-| Slt.e.TM1                | No slits required on bond pads                                                          |
-| Slt.f.TM1                | Min. TopMetal1 enclosure of TopMetal1:slit                                              |
-| Slt.g.TM1                | Min. Metal5:slit and TopMetal1:slit space to MIM                                        |
-| Slt.h3                   | Min. TopMetal1:slit space to TopVia1 and TopVia2                                        |
-| Slt.a.TM2                | Min. TopMetal2:slit width                                                               |
-| Slt.b.TM2                | Max. TopMetal2:slit width                                                               |
-| Slt.c.TM2                | Max. TopMetal2 width without requiring a slit                                           |
-| Slt.e.TM2                | No slits required on bond pads                                                          |
-| Slt.f.TM2                | Min. TopMetal2 enclosure of TopMetal2:slit                                              |
-| Slt.h4                   | Min. TopMetal2:slit space to TopVia2                                                    |
-| Pin.a                    | Min. Activ enclosure of Activ:pin                                                       |
-| Pin.b                    | Min. GatPoly enclosure of GatPoly:pin                                                   |
-| Pin.e                    | Min. Metal1 enclosure of Metal1:pin                                                     |
-| Pin.f.M2                 | Min. Metal2 enclosure of Metal2:pin                                                     |
-| Pin.f.M3                 | Min. Metal3 enclosure of Metal3:pin                                                     |
-| Pin.f.M4                 | Min. Metal4 enclosure of Metal4:pin                                                     |
-| Pin.f.M5                 | Min. Metal5 enclosure of Metal5:pin                                                     |
-| Pin.g                    | Min. TopMetal1 enclosure of TopMetal1:pin                                               |
-| Pin.h                    | Min. TopMetal2 enclosure of TopMetal2:pin                                               |
-| NW.d1.dig                | Min. NWell space to external N+Activ inside ThickGateOx                                 |
-| NW.f1.dig                | Min. NWell space to substrate tie in P+Activ inside ThickGateOx                         |
-| Gat.a.SRAM               | Min. GatPoly width                                                                      |
-| Gat.b.SRAM               | Min. GatPoly space or notch                                                             |
-| Gat.c.SRAM               | Min. GatPoly extension over Activ (end cap)                                             |
-| Gat.d.SRAM               | Min. GatPoly space to Activ                                                             |
-| pSD.e.SRAM               | Min. pSD overlap of Activ when forming abutted substrate tie                            |
-| pSD.g.SRAM               | Min. N+Activ or P+Activ width when forming abutted tie                                  |
-| pSD.i.SRAM               | Min. pSD enclosure of PFET gate not inside ThickGateOx                                  |
-| pSD.j.SRAM               | Min. pSD space to NFET gate not inside ThickGateOx                                      |
-| Cnt.f.SRAM               | Min. Cont on Activ space to GatPoly                                                     |
-| M1.b.SRAM                | Min. Metal1 space or notch                                                              |
-| M1.c1.SRAM               | Min. Metal1 endcap enclosure of Cont                                                    |
-| M2.b.SRAM                | Min. Metal2 space or notch                                                              |
-| M2.c1.SRAM               | Min. Metal2 endcap enclosure of Via1                                                    |
-| M3.b.SRAM                | Min. Metal3 space or notch                                                              |
-| M3.c1.SRAM               | Min. Metal3 endcap enclosure of Via2                                                    |
-| M4.b.SRAM                | Min. Metal4 space or notch                                                              |
-| M4.c1.SRAM               | Min. Metal4 endcap enclosure of Via3                                                    |
-| M5.b.SRAM                | Min. Metal5 space or notch                                                              |
-| M5.c1.SRAM               | Min. Metal5 endcap enclosure of Via4                                                    |
-| LBE.a                    | Min. LBE width                                                                          |
-| LBE.b                    | Max. LBE width                                                                          |
-| LBE.b1                   | Max. LBE area (µm²)                                                                     |
-| LBE.b2                   | Min. LBE area (µm²)                                                                     |
-| LBE.c                    | Min. LBE space or notch                                                                 |
-| LBE.d                    | Min. LBE space to inner edge of EdgeSeal                                                |
-| LBE.e.dfPad              | Min. LBE space to dfpad and Passiv                                                      |
-| LBE.e.Passiv             | Min. LBE space to dfpad and Passiv                                                      |
-| LBE.f                    | Min. LBE space to Activ                                                                 |
-| LBE.h                    | No LBE ring allowed                                                                     |
-| LBE.i                    | Max. global LBE density [%]                                                             |
-| TSV_G.a                  | DeepVia has to be a ring structure                                                      |
-| TSV_G.d                  | Min. DeepVia space                                                                      |
-| TSV_G.f                  | Min. PWell:block enclosure of DeepVia                                                   |
-| TSV_G.g                  | Min. Metal1 enclosure of DeepVia ring structure                                         |
-| TSV_G.i                  | Max. global DeepVia density [%]                                                         |
-| TSV_G.j                  | Max. DeepVia coverage ratio for any 500.0 x 500.0 µm² chip area [%]                     |
-| forbidden.BiWind         | Forbidden drawn layer BiWind on GDS layer 3/0                                           |
-| forbidden.PEmWind        | Forbidden drawn layer PEmWind on GDS layer 11/0                                         |
-| forbidden.BasPoly        | Forbidden drawn layer BasPoly on GDS layer 13/0                                         |
-| forbidden.DeepCo         | Forbidden drawn layer DeepCo on GDS layer 35/0                                          |
-| forbidden.PEmPoly        | Forbidden drawn layer PEmPoly on GDS layer 53/0                                         |
-| forbidden.EmPoly         | Forbidden gen./drawn layer EmPoly on GDS layer 53/0                                     |
-| forbidden.LDMOS          | Forbidden drawn layer LDMOS on GDS layer 57/0                                           |
-| forbidden.PBiWind        | Forbidden drawn layer PBiWind on GDS layer 58/0                                         |
-| forbidden.Flash          | Forbidden drawn layer Flash on GDS layer 71/0                                           |
-| forbidden.ColWind        | Forbidden drawn layer ColWind on GDS layer 139/0                                        |
-| OffGrid.NWell            | NWell is off-grid                                                                       |
-| OffGrid.PWell            | PWell is off-grid                                                                       |
-| OffGrid.PWell_block      | PWell_block is off-grid                                                                 |
-| OffGrid.nBuLay           | nBuLay is off-grid                                                                      |
-| OffGrid.nBuLay_block     | nBuLay_block is off-grid                                                                |
-| OffGrid.Activ            | Activ is off-grid                                                                       |
-| OffGrid.ThickGateOx      | ThickGateOx is off-grid                                                                 |
-| OffGrid.Activ_filler     | Activ_filler is off-grid                                                                |
-| OffGrid.GatPoly_filler   | GatPoly_filler is off-grid                                                              |
-| OffGrid.GatPoly          | GatPoly is off-grid                                                                     |
-| OffGrid.pSD              | pSD is off-grid                                                                         |
-| OffGrid.nSD              | nSD is off-grid                                                                         |
-| OffGrid.nSD_block        | nSD_block is off-grid                                                                   |
-| OffGrid.EXTBlock         | EXTBlock is off-grid                                                                    |
-| OffGrid.SalBlock         | SalBlock is off-grid                                                                    |
-| OffGrid.Cont             | Cont is off-grid                                                                        |
-| OffGrid.Activ_nofill     | Activ_nofill is off-grid                                                                |
-| OffGrid.GatPoly_nofill   | GatPoly_nofill is off-grid                                                              |
-| OffGrid.Metal1           | Metal1 is off-grid                                                                      |
-| OffGrid.Via1             | Via1 is off-grid                                                                        |
-| OffGrid.Metal2           | Metal2 is off-grid                                                                      |
-| OffGrid.Via2             | Via2 is off-grid                                                                        |
-| OffGrid.Metal3           | Metal3 is off-grid                                                                      |
-| OffGrid.Via3             | Via3 is off-grid                                                                        |
-| OffGrid.Metal4           | Metal4 is off-grid                                                                      |
-| OffGrid.Via4             | Via4 is off-grid                                                                        |
-| OffGrid.Metal5           | Metal5 is off-grid                                                                      |
-| OffGrid.MIM              | MIM is off-grid                                                                         |
-| OffGrid.Vmim             | Vmim is off-grid                                                                        |
-| OffGrid.TopVia1          | TopVia1 is off-grid                                                                     |
-| OffGrid.TopMetal1        | TopMetal1 is off-grid                                                                   |
-| OffGrid.TopVia2          | TopVia2 is off-grid                                                                     |
-| OffGrid.TopMetal2        | TopMetal2 is off-grid                                                                   |
-| OffGrid.Passiv           | Passiv is off-grid                                                                      |
-| OffGrid.Metal1_filler    | Metal1_filler is off-grid                                                               |
-| OffGrid.Metal2_filler    | Metal2_filler is off-grid                                                               |
-| OffGrid.Metal3_filler    | Metal3_filler is off-grid                                                               |
-| OffGrid.Metal4_filler    | Metal4_filler is off-grid                                                               |
-| OffGrid.Metal5_filler    | Metal5_filler is off-grid                                                               |
-| OffGrid.TopMetal1_filler | TopMetal1_filler is off-grid                                                            |
-| OffGrid.TopMetal2_filler | TopMetal2_filler is off-grid                                                            |
-| OffGrid.Metal1_nofill    | Metal1_nofill is off-grid                                                               |
-| OffGrid.Metal2_nofill    | Metal2_nofill is off-grid                                                               |
-| OffGrid.Metal3_nofill    | Metal3_nofill is off-grid                                                               |
-| OffGrid.Metal4_nofill    | Metal4_nofill is off-grid                                                               |
-| OffGrid.Metal5_nofill    | Metal5_nofill is off-grid                                                               |
-| OffGrid.TopMetal1_nofill | TopMetal1_nofill is off-grid                                                            |
-| OffGrid.TopMetal2_nofill | TopMetal2_nofill is off-grid                                                            |
-| OffGrid.NoMetFiller      | NoMetFiller is off-grid                                                                 |
-| OffGrid.Metal1_slit      | Metal1_slit is off-grid                                                                 |
-| OffGrid.Metal2_slit      | Metal2_slit is off-grid                                                                 |
-| OffGrid.Metal3_slit      | Metal3_slit is off-grid                                                                 |
-| OffGrid.Metal4_slit      | Metal4_slit is off-grid                                                                 |
-| OffGrid.Metal5_slit      | Metal5_slit is off-grid                                                                 |
-| OffGrid.TopMetal1_slit   | TopMetal1_slit is off-grid                                                              |
-| OffGrid.TopMetal2_slit   | TopMetal2_slit is off-grid                                                              |
-| OffGrid.EdgeSeal         | EdgeSeal is off-grid                                                                    |
-| OffGrid.EmWind           | EmWind is off-grid                                                                      |
-| OffGrid.dfpad            | dfpad is off-grid                                                                       |
-| OffGrid.Polimide         | Polimide is off-grid                                                                    |
-| OffGrid.TRANS            | TRANS is off-grid                                                                       |
-| OffGrid.IND              | IND is off-grid                                                                         |
-| OffGrid.RES              | RES is off-grid                                                                         |
-| OffGrid.RFMEM            | RFMEM is off-grid                                                                       |
-| OffGrid.Recog_diode      | Recog_diode is off-grid                                                                 |
-| OffGrid.Recog_esd        | Recog_esd is off-grid                                                                   |
-| OffGrid.DigiBnd          | DigiBnd is off-grid                                                                     |
-| OffGrid.DigiSub          | DigiSub is off-grid                                                                     |
-| OffGrid.SRAM             | SRAM is off-grid                                                                        |
-| OffGrid.dfpad_pillar     | dfpad_pillar is off-grid                                                                |
-| OffGrid.dfpad_sbump      | dfpad_sbump is off-grid                                                                 |
-| OffGrid.DeepVia          | DeepVia is off-grid                                                                     |
-| OffGrid.LBE              | LBE is off-grid                                                                         |
-| OffGrid.PolyRes          | PolyRes is off-grid                                                                     |
+| Name                     | Description                                                                                      |
+| ------------------------ | ------------------------------------------------------------------------------------------------ |
+| NW.a                     | Min. NWell width                                                                                 |
+| NW.c                     | Min. NWell enclosure of P+Activ not inside ThickGateOx                                           |
+| NW.c1                    | Min. NWell enclosure of P+Activ inside ThickGateOx                                               |
+| NW.d                     | Min. NWell space to external N+Activ not inside ThickGateOx                                      |
+| NW.d1                    | Min. NWell space to external N+Activ inside ThickGateOx                                          |
+| NW.e                     | Min. NWell enclosure of NWell tie surrounded entirely by NWell in N+Activ not inside ThickGateOx |
+| NW.e1                    | Min. NWell enclosure of NWell tie surrounded entirely by NWell in N+Activ inside ThickGateOx     |
+| NW.f                     | Min. NWell space to substrate tie in P+Activ not inside ThickGateOx                              |
+| NW.f1                    | Min. NWell space to substrate tie in P+Activ inside ThickGateOx                                  |
+| PWB.a                    | Min. PWell:block width                                                                           |
+| PWB.b                    | Min. PWell:block space or notch                                                                  |
+| PWB.c                    | Min. PWell:block space to unrelated NWell                                                        |
+| NBL.a                    | Min. nBuLay width                                                                                |
+| NBLB.a                   | Min. nBuLay:block width                                                                          |
+| NBLB.b                   | Min. nBuLay:block space or notch                                                                 |
+| NBLB.c                   | Min. nBuLay enclosure of nBuLay:block                                                            |
+| NBLB.d                   | Min. nBuLay:block space to unrelated nBuLay                                                      |
+| Act.a                    | Min. Activ width                                                                                 |
+| Act.b                    | Min. Activ space or notch                                                                        |
+| Act.c                    | Min. Activ drain/source extension                                                                |
+| Act.d                    | Min. Activ area (µm²)                                                                            |
+| Act.e                    | Min. Activ enclosed area (µm²)                                                                   |
+| AFil.a                   | Max. Activ:filler width                                                                          |
+| AFil.a1                  | Min. Activ:filler width                                                                          |
+| AFil.b                   | Min. Activ:filler space                                                                          |
+| AFil.g                   | Min. global Activ density [%]                                                                    |
+| AFil.g1                  | Max. global Activ density [%]                                                                    |
+| AFil.g2                  | Min. Activ coverage ratio for any 800 x 800 µm² chip area [%]                                    |
+| AFil.g3                  | Max. Activ coverage ratio for any 800 x 800 µm² chip area [%]                                    |
+| AFil.i                   | Min. Activ:filler space to edges of PWell:block                                                  |
+| TGO.a                    | Min. ThickGateOx extension over Activ                                                            |
+| TGO.b                    | Min. space between ThickGateOx and Activ outside thick gate oxide region                         |
+| TGO.c                    | Min. ThickGateOx extension over GatPoly over Activ                                               |
+| TGO.d                    | Min. space between ThickGateOx and GatPoly over Activ outside thick gate oxide region            |
+| TGO.e                    | Min. ThickGateOx space (merge if less than this value)                                           |
+| TGO.f                    | Min. ThickGateOx width                                                                           |
+| Gat.a                    | Min. GatPoly width                                                                               |
+| Gat.a3                   | Min. GatPoly width for channel length of 3.3 V NFET                                              |
+| Gat.a4                   | Min. GatPoly width for channel length of 3.3 V PFET                                              |
+| Gat.b                    | Min. GatPoly space or notch                                                                      |
+| Gat.b1                   | Min. space between unrelated 3.3 V GatPoly over Activ regions                                    |
+| Gat.c                    | Min. GatPoly extension over Activ (end cap)                                                      |
+| Gat.d                    | Min. GatPoly space to Activ                                                                      |
+| Gat.e                    | Min. GatPoly area (µm²)                                                                          |
+| Gat.f                    | 45-degree and 90-degree angles for GatPoly on Activ area are not allowed                         |
+| GFil.a                   | Max. GatPoly:filler width                                                                        |
+| GFil.b                   | Min. GatPoly:filler width                                                                        |
+| GFil.c                   | Min. GatPoly:filler space                                                                        |
+| GFil.d.Activ             | Min. GatPoly:filler space to Activ                                                               |
+| GFil.d.GatPoly           | Min. GatPoly:filler space to GatPoly                                                             |
+| GFil.d.Cont              | Min. GatPoly:filler space to Cont                                                                |
+| GFil.d.pSD               | Min. GatPoly:filler space to pSD                                                                 |
+| GFil.d.nSD_block         | Min. GatPoly:filler space to nSD:block                                                           |
+| GFil.d.SalBlock          | Min. GatPoly:filler space to SalBlock                                                            |
+| GFil.f                   | Min. GatPoly:filler space to TRANS                                                               |
+| GFil.g                   | Min. global GatPoly density [%]                                                                  |
+| GFil.j                   | Min. GatPoly:filler extension over Activ:filler (end cap)                                        |
+| pSD.a                    | Min. pSD width                                                                                   |
+| pSD.b                    | Min. pSD space or notch (Note 1)                                                                 |
+| pSD.c                    | Min. pSD enclosure of P+Activ in NWell                                                           |
+| pSD.d                    | Min. pSD space to unrelated N+Activ in PWell                                                     |
+| pSD.d1                   | Min. pSD space to N+Activ in NWell                                                               |
+| pSD.e                    | Min. pSD overlap of Activ at one position when forming abutted substrate tie (Note 2)            |
+| pSD.f                    | Min. Activ extension over pSD at one position when forming abutted NWell tie (Note 2)            |
+| pSD.g                    | Min. N+Activ or P+Activ area (µm²) when forming abutted tie (Note 2)                             |
+| pSD.i                    | Min. pSD enclosure of PFET gate not inside ThickGateOx                                           |
+| pSD.i1                   | Min. pSD enclosure of PFET gate inside ThickGateOx                                               |
+| pSD.j                    | Min. pSD space to NFET gate not inside ThickGateOx                                               |
+| pSD.j1                   | Min. pSD space to NFET gate inside ThickGateOx                                                   |
+| pSD.k                    | Min. pSD area (µm²)                                                                              |
+| pSD.l                    | Min. pSD enclosed area (µm²)                                                                     |
+| pSD.m                    | Min. pSD space to n-type poly resistors                                                          |
+| pSD.n                    | Min. pSD enclosure of p-type poly resistors                                                      |
+| nSDB.a                   | Min. nSD:block width                                                                             |
+| nSDB.b                   | Min. nSD:block space or notch                                                                    |
+| nSDB.c                   | Min. nSD:block space to unrelated pSD                                                            |
+| nSDB.e                   | Min. nSD:block space to Cont (Note 2)                                                            |
+| EXT.a                    | Min. EXTBlock width                                                                              |
+| EXT.b                    | Min. EXTBlock space or notch                                                                     |
+| EXT.c                    | Min. EXTBlock space to pSD                                                                       |
+| Sal.a                    | Min. SalBlock width                                                                              |
+| Sal.b                    | Min. SalBlock space or notch                                                                     |
+| Sal.c                    | Min. SalBlock extension over Activ or GatPoly                                                    |
+| Sal.d                    | Min. SalBlock space to unrelated Activ or GatPoly                                                |
+| Sal.e                    | Min. SalBlock space to Cont                                                                      |
+| Cnt.a                    | Min. and max. Cont width                                                                         |
+| Cnt.b                    | Min. Cont space                                                                                  |
+| Cnt.b1                   | Min. Cont space in a contact array of more than 4 rows and more then 4 columns (Note 1)          |
+| Cnt.c                    | Min. Activ enclosure of Cont                                                                     |
+| Cnt.d                    | Min. GatPoly enclosure of Cont                                                                   |
+| Cnt.e                    | Min. Cont on GatPoly space to Activ                                                              |
+| Cnt.f                    | Min. Cont on Activ space to GatPoly                                                              |
+| Cnt.g                    | Cont must be within Activ or GatPoly                                                             |
+| Cnt.g1                   | Min. pSD space to Cont on nSD-Activ                                                              |
+| Cnt.g2                   | Min. pSD overlap of Cont on pSD-Activ                                                            |
+| Cnt.h                    | Cont must be covered with Metal1                                                                 |
+| Cnt.j                    | Cont on GatPoly over Activ is not allowed                                                        |
+| CntB.a                   | Min. and max. ContBar width                                                                      |
+| CntB.a1                  | Min. ContBar length                                                                              |
+| CntB.b                   | Min. ContBar space                                                                               |
+| CntB.b2                  | Min. ContBar space to Cont                                                                       |
+| CntB.c                   | Min. Activ enclosure of ContBar                                                                  |
+| CntB.d                   | Min. GatPoly enclosure of ContBar                                                                |
+| CntB.e                   | Min. ContBar on GatPoly space to Activ                                                           |
+| CntB.f                   | Min. ContBar on Activ space to GatPoly                                                           |
+| CntB.g                   | ContBar must be within Activ or GatPoly                                                          |
+| CntB.g1                  | Min. pSD space to ContBar on nSD-Activ                                                           |
+| CntB.g2                  | Min. pSD overlap of ContBar on pSD-Activ                                                         |
+| CntB.h                   | ContBar must be covered with Metal1                                                              |
+| CntB.j                   | ContBar on GatPoly over Activ is not allowed                                                     |
+| M1.a                     | Min. Metal1 width                                                                                |
+| M1.b                     | Min. Metal1 space or notch                                                                       |
+| M1.c                     | Min. Metal1 enclosure of Cont                                                                    |
+| M1.c1                    | Min. Metal1 endcap enclosure of Cont (Note 1)                                                    |
+| M1.d                     | Min. Metal1 area (µm²)                                                                           |
+| M1.j                     | Min. global Metal1 density [%]                                                                   |
+| M1.k                     | Max. global Metal1 density [%]                                                                   |
+| M2.a                     | Min. Metal2 width                                                                                |
+| M2.b                     | Min. Metal2 space or notch                                                                       |
+| M2.c                     | Min. Metal2 enclosure of Via1                                                                    |
+| M2.c1                    | Min. Metal2 endcap enclosure of Via1 (Note 1)                                                    |
+| M2.d                     | Min. Metal2 area (µm²)                                                                           |
+| M2.j                     | Min. global Metal2 density [%]                                                                   |
+| M2.k                     | Max. global Metal2 density [%]                                                                   |
+| M3.a                     | Min. Metal3 width                                                                                |
+| M3.b                     | Min. Metal3 space or notch                                                                       |
+| M3.c                     | Min. Metal3 enclosure of Via2                                                                    |
+| M3.c1                    | Min. Metal3 endcap enclosure of Via2 (Note 1)                                                    |
+| M3.d                     | Min. Metal3 area (µm²)                                                                           |
+| M3.j                     | Min. global Metal3 density [%]                                                                   |
+| M3.k                     | Max. global Metal3 density [%]                                                                   |
+| M4.a                     | Min. Metal4 width                                                                                |
+| M4.b                     | Min. Metal4 space or notch                                                                       |
+| M4.c                     | Min. Metal4 enclosure of Via3                                                                    |
+| M4.c1                    | Min. Metal4 endcap enclosure of Via3 (Note 1)                                                    |
+| M4.d                     | Min. Metal4 area (µm²)                                                                           |
+| M4.j                     | Min. global Metal4 density [%]                                                                   |
+| M4.k                     | Max. global Metal4 density [%]                                                                   |
+| M5.a                     | Min. Metal5 width                                                                                |
+| M5.b                     | Min. Metal5 space or notch                                                                       |
+| M5.c                     | Min. Metal5 enclosure of Via4                                                                    |
+| M5.c1                    | Min. Metal5 endcap enclosure of Via4 (Note 1)                                                    |
+| M5.d                     | Min. Metal5 area (µm²)                                                                           |
+| M5.j                     | Min. global Metal5 density [%]                                                                   |
+| M5.k                     | Max. global Metal5 density [%]                                                                   |
+| M1Fil.a1                 | Min. Metal1:filler width                                                                         |
+| M1Fil.b                  | Min. Metal1:filler space                                                                         |
+| M1Fil.c                  | Min. Metal1:filler space to Metal1                                                               |
+| M1Fil.d                  | Min. Metal1:filler space to TRANS                                                                |
+| M1Fil.h                  | Min. Metal1 and Metal1:filler coverage ratio for any 800 x 800 µm² chip area [%]                 |
+| M1Fil.k                  | Max. Metal1 and Metal1:filler coverage ratio for any 800 x 800 µm² chip area [%]                 |
+| M2Fil.a1                 | Min. Metal2:filler width                                                                         |
+| M2Fil.b                  | Min. Metal2:filler space                                                                         |
+| M2Fil.c                  | Min. Metal2:filler space to Metal2                                                               |
+| M2Fil.d                  | Min. Metal2:filler space to TRANS                                                                |
+| M2Fil.h                  | Min. Metal2 and Metal2:filler coverage ratio for any 800 x 800 µm² chip area [%]                 |
+| M2Fil.k                  | Max. Metal2 and Metal2:filler coverage ratio for any 800 x 800 µm² chip area [%]                 |
+| M3Fil.a1                 | Min. Metal3:filler width                                                                         |
+| M3Fil.b                  | Min. Metal3:filler space                                                                         |
+| M3Fil.c                  | Min. Metal3:filler space to Metal3                                                               |
+| M3Fil.d                  | Min. Metal3:filler space to TRANS                                                                |
+| M3Fil.h                  | Min. Metal3 and Metal3:filler coverage ratio for any 800 x 800 µm² chip area [%]                 |
+| M3Fil.k                  | Max. Metal3 and Metal3:filler coverage ratio for any 800 x 800 µm² chip area [%]                 |
+| M4Fil.a1                 | Min. Metal4:filler width                                                                         |
+| M4Fil.b                  | Min. Metal4:filler space                                                                         |
+| M4Fil.c                  | Min. Metal4:filler space to Metal4                                                               |
+| M4Fil.d                  | Min. Metal4:filler space to TRANS                                                                |
+| M4Fil.h                  | Min. Metal4 and Metal4:filler coverage ratio for any 800 x 800 µm² chip area [%]                 |
+| M4Fil.k                  | Max. Metal4 and Metal4:filler coverage ratio for any 800 x 800 µm² chip area [%]                 |
+| M5Fil.a1                 | Min. Metal5:filler width                                                                         |
+| M5Fil.b                  | Min. Metal5:filler space                                                                         |
+| M5Fil.c                  | Min. Metal5:filler space to Metal5                                                               |
+| M5Fil.d                  | Min. Metal5:filler space to TRANS                                                                |
+| M5Fil.h                  | Min. Metal5 and Metal5:filler coverage ratio for any 800 x 800 µm² chip area [%]                 |
+| M5Fil.k                  | Max. Metal5 and Metal5:filler coverage ratio for any 800 x 800 µm² chip area [%]                 |
+| V1.a                     | Min. and max. Via1 width                                                                         |
+| V1.b                     | Min. Via1 space                                                                                  |
+| V1.b1                    | Min. Via1 space in an array of more than 3 rows and more then 3 columns (Note 1)                 |
+| V1.c1                    | Min. Metal1 endcap enclosure of Via1 (Note 2)                                                    |
+| V2.a                     | Min. and max. Via2 width                                                                         |
+| V2.b                     | Min. Via2 space                                                                                  |
+| V2.b1                    | Min. Via2 space in an array of more than 3 rows and more then 3 columns (Note 1)                 |
+| V2.c1                    | Min. Metal2 endcap enclosure of Via2 (Note 2)                                                    |
+| V3.a                     | Min. and max. Via3 width                                                                         |
+| V3.b                     | Min. Via3 space                                                                                  |
+| V3.b1                    | Min. Via3 space in an array of more than 3 rows and more then 3 columns (Note 1)                 |
+| V3.c1                    | Min. Metal3 endcap enclosure of Via3 (Note 2)                                                    |
+| V4.a                     | Min. and max. Via4 width                                                                         |
+| V4.b                     | Min. Via4 space                                                                                  |
+| V4.b1                    | Min. Via4 space in an array of more than 3 rows and more then 3 columns (Note 1)                 |
+| V4.c1                    | Min. Metal4 endcap enclosure of Via4 (Note 2)                                                    |
+| TV1.a                    | Min. and max. TopVia1 width                                                                      |
+| TV1.b                    | Min. TopVia1 space                                                                               |
+| TM1.a                    | Min. TopMetal1 width                                                                             |
+| TM1.b                    | Min. TopMetal1 space or notch                                                                    |
+| TM1.c                    | Min. global TopMetal1 density [%]                                                                |
+| TM1.d                    | Max. global TopMetal1 density [%]                                                                |
+| TM1Fil.a                 | Min. TopMetal1:filler width                                                                      |
+| TM1Fil.b                 | Min. TopMetal1:filler space                                                                      |
+| TM1Fil.c                 | Min. TopMetal1:filler space to TopMetal1                                                         |
+| TM1Fil.d                 | Min. TopMetal1:filler space to TRANS                                                             |
+| TV2.a                    | Min. and max. TopVia2 width                                                                      |
+| TV2.b                    | Min. TopVia2 space                                                                               |
+| TM2.a                    | Min. TopMetal2 width                                                                             |
+| TM2.b                    | Min. TopMetal2 space or notch                                                                    |
+| TM2.c                    | Min. global TopMetal2 density [%]                                                                |
+| TM2.d                    | Max. global TopMetal2 density [%]                                                                |
+| TM2Fil.a                 | Min. TopMetal2:filler width                                                                      |
+| TM2Fil.b                 | Min. TopMetal2:filler space                                                                      |
+| TM2Fil.c                 | Min. TopMetal2:filler space to TopMetal2                                                         |
+| TM2Fil.d                 | Min. TopMetal2:filler space to TRANS                                                             |
+| Pas.a                    | Min. Passiv width                                                                                |
+| Pas.b                    | Min. Passiv space or notch                                                                       |
+| npn13G2.a                | Min. and max. npn13G2 emitter length                                                             |
+| npn13G2L.a               | Min. npn13G2L emitter length                                                                     |
+| npn13G2L.b               | Max. npn13G2L emitter length                                                                     |
+| npn13G2V.a               | Min. npn13G2V emitter length                                                                     |
+| npn13G2V.b               | Max. npn13G2V emitter length                                                                     |
+| Rsil.a                   | Min. GatPoly width                                                                               |
+| Rsil.b                   | Min. RES space to Cont                                                                           |
+| Rsil.c                   | Min. RES extension over GatPoly                                                                  |
+| Rsil.d                   | Min. pSD space to GatPoly                                                                        |
+| Rsil.e                   | Min. EXTBlock enclosure of GatPoly                                                               |
+| Rsil.f                   | Min. RES length                                                                                  |
+| Rppd.a                   | Min. GatPoly width                                                                               |
+| Rppd.b                   | Min. pSD enclosure of GatPoly                                                                    |
+| Rppd.c                   | Min. and max. SalBlock space to Cont                                                             |
+| Rppd.d                   | Min. EXTBlock enclosure of GatPoly                                                               |
+| Rppd.e                   | Min. SalBlock length                                                                             |
+| Rhi.a                    | Min. GatPoly width                                                                               |
+| Rhi.b                    | pSD and nSD are identical (Note 1)                                                               |
+| Rhi.c                    | Min. pSD and nSD enclosure of GatPoly                                                            |
+| Rhi.d                    | Min. and max. SalBlock space to Cont                                                             |
+| Rhi.e                    | Min. EXTBlock enclosure of GatPoly                                                               |
+| Rhi.f                    | Min. SalBlock length                                                                             |
+| nmosi.b                  | Min. nBuLay enclosure of Iso-PWell-Activ (Note 1)                                                |
+| nmosi.c                  | Min. NWell space to Iso-PWell-Activ                                                              |
+| nmosi.d                  | Min. NWell-nBuLay width forming an unbroken ring around any Iso-PWell-Activ (Note 2)             |
+| nmosi.f                  | Min. nSD:block width to separate ptap in nmosi                                                   |
+| nmosi.g                  | Min. SalBlock overlap of nSD:block over Activ                                                    |
+| Sdiod.a                  | Min. and max. PWell:block enclosure of ContBar                                                   |
+| Sdiod.b                  | Min. and max. nSD:block enclosure of ContBar                                                     |
+| Sdiod.c                  | Min. and max. SalBlock enclosure of ContBar                                                      |
+| Pad.aR                   | Min. recommended Pad width                                                                       |
+| Pad.a1                   | Max. Pad width                                                                                   |
+| Pad.bR                   | Min. recommended Pad space                                                                       |
+| Pad.d                    | Min. Pad space to EdgeSeal                                                                       |
+| Pad.dR                   | Min. recommended Pad to EdgeSeal space (Note 1)                                                  |
+| Pad.d1R                  | Min. recommended Pad to Activ (inside chip area) space                                           |
+| Pad.gR                   | TopMetal1 (within dfpad) enclosure of TopVia2                                                    |
+| Pad.jR                   | No devices under Pad allowed (Note 2)                                                            |
+| Pad.kR                   | TopVia2 under Pad not allowed (Note 3)                                                           |
+| Padc.b                   | Min. CuPillarPad space                                                                           |
+| Padc.d                   | Min. CuPillarPad space to EdgeSeal                                                               |
+| Seal.a_Activ             | Min. EdgeSeal-Activ width                                                                        |
+| Seal.a_pSD               | Min. EdgeSeal-pSD width                                                                          |
+| Seal.a_Metal1            | Min. EdgeSeal-Metal1 width                                                                       |
+| Seal.a_Metal2            | Min. EdgeSeal-Metal2 width                                                                       |
+| Seal.a_Metal3            | Min. EdgeSeal-Metal3 width                                                                       |
+| Seal.a_Metal4            | Min. EdgeSeal-Metal4 width                                                                       |
+| Seal.a_Metal5            | Min. EdgeSeal-Metal5 width                                                                       |
+| Seal.a_TopMetal1         | Min. EdgeSeal-TopMetal1 width                                                                    |
+| Seal.a_TopMetal2         | Min. EdgeSeal-TopMetal2 width                                                                    |
+| Seal.c                   | EdgeSeal-Cont ring width                                                                         |
+| Seal.c1.Via1             | EdgeSeal-Via1 ring width                                                                         |
+| Seal.c1.Via2             | EdgeSeal-Via2 ring width                                                                         |
+| Seal.c1.Via3             | EdgeSeal-Via3 ring width                                                                         |
+| Seal.c1.Via4             | EdgeSeal-Via4 ring width                                                                         |
+| Seal.c2                  | EdgeSeal-TopVia1 ring width                                                                      |
+| Seal.c3                  | EdgeSeal-TopVia2 ring width                                                                      |
+| Seal.e                   | Min. Passiv ring width outside of sealring                                                       |
+| MIM.a                    | Min. MIM width                                                                                   |
+| MIM.b                    | Min. MIM space                                                                                   |
+| MIM.e                    | Min. TopMetal1 space to MIM                                                                      |
+| MIM.f                    | Min. MIM area per MIM device (µm²)                                                               |
+| MIM.g                    | Max. MIM area per MIM device (µm²)                                                               |
+| MIM.h                    | TopVia1 must be over MIM                                                                         |
+| LU.a                     | Max. space from any portion of P+Activ inside NWell to an nSD-NWell tie                          |
+| LU.c                     | Max. extension of an abutted NWell tie beyond Cont                                               |
+| LU.c1                    | Max. extension of an abutted substrate tie beyond Cont                                           |
+| LU.d                     | Max. extension of NWell tie Activ tie beyond Cont                                                |
+| LU.d1                    | Max. extension of an substrate tie Activ beyond Cont                                             |
+| Slt.a.M1                 | Min. Metal1:slit width                                                                           |
+| Slt.b.M1                 | Max. Metal1:slit width                                                                           |
+| Slt.c.M1                 | Max. Metal1 width without requiring a slit                                                       |
+| Slt.e.M1                 | No slits required on bond pads                                                                   |
+| Slt.f.M1                 | Min. Metal1 enclosure of Metal1:slit                                                             |
+| Slt.h1                   | Min. Metal1:slit space to Cont and Via1                                                          |
+| Slt.a.M2                 | Min. Metal2:slit width                                                                           |
+| Slt.b.M2                 | Max. Metal2:slit width                                                                           |
+| Slt.c.M2                 | Max. Metal2 width without requiring a slit                                                       |
+| Slt.e.M2                 | No slits required on bond pads                                                                   |
+| Slt.f.M2                 | Min. Metal2 enclosure of Metal2:slit                                                             |
+| Slt.h2.M2                | Min. Metal2:slit space to Via1 and Via2                                                          |
+| Slt.a.M3                 | Min. Metal3:slit width                                                                           |
+| Slt.b.M3                 | Max. Metal3:slit width                                                                           |
+| Slt.c.M3                 | Max. Metal3 width without requiring a slit                                                       |
+| Slt.e.M3                 | No slits required on bond pads                                                                   |
+| Slt.f.M3                 | Min. Metal3 enclosure of Metal2:slit                                                             |
+| Slt.h2.M3                | Min. Metal3:slit space to Via2 and Via3                                                          |
+| Slt.a.M4                 | Min. Metal4:slit width                                                                           |
+| Slt.b.M4                 | Max. Metal4:slit width                                                                           |
+| Slt.c.M4                 | Max. Metal4 width without requiring a slit                                                       |
+| Slt.e.M4                 | No slits required on bond pads                                                                   |
+| Slt.f.M4                 | Min. Metal4 enclosure of Metal4:slit                                                             |
+| Slt.h2.M4                | Min. Metal4:slit space to Via3 and Via4                                                          |
+| Slt.a.M5                 | Min. Metal5:slit width                                                                           |
+| Slt.b.M5                 | Max. Metal5:slit width                                                                           |
+| Slt.c.M5                 | Max. Metal5 width without requiring a slit                                                       |
+| Slt.e.M5                 | No slits required on bond pads                                                                   |
+| Slt.f.M5                 | Min. Metal5 enclosure of Metal5:slit                                                             |
+| Slt.g.M5                 | Min. Metal5:slit and TopMetal1:slit space to MIM                                                 |
+| Slt.h2.M5                | Min. Metal5:slit space to Via4 and Via5                                                          |
+| Slt.a.TM1                | Min. TopMetal1:slit width                                                                        |
+| Slt.b.TM1                | Max. TopMetal1:slit width                                                                        |
+| Slt.c.TM1                | Max. TopMetal1 width without requiring a slit                                                    |
+| Slt.e.TM1                | No slits required on bond pads                                                                   |
+| Slt.f.TM1                | Min. TopMetal1 enclosure of TopMetal1:slit                                                       |
+| Slt.g.TM1                | Min. Metal5:slit and TopMetal1:slit space to MIM                                                 |
+| Slt.h3                   | Min. TopMetal1:slit space to TopVia1 and TopVia2                                                 |
+| Slt.a.TM2                | Min. TopMetal2:slit width                                                                        |
+| Slt.b.TM2                | Max. TopMetal2:slit width                                                                        |
+| Slt.c.TM2                | Max. TopMetal2 width without requiring a slit                                                    |
+| Slt.e.TM2                | No slits required on bond pads                                                                   |
+| Slt.f.TM2                | Min. TopMetal2 enclosure of TopMetal2:slit                                                       |
+| Slt.h4                   | Min. TopMetal2:slit space to TopVia2                                                             |
+| Pin.a                    | Min. Activ enclosure of Activ:pin                                                                |
+| Pin.b                    | Min. GatPoly enclosure of GatPoly:pin                                                            |
+| Pin.e                    | Min. Metal1 enclosure of Metal1:pin                                                              |
+| Pin.f.M2                 | Min. Metal2 enclosure of Metal2:pin                                                              |
+| Pin.f.M3                 | Min. Metal3 enclosure of Metal3:pin                                                              |
+| Pin.f.M4                 | Min. Metal4 enclosure of Metal4:pin                                                              |
+| Pin.f.M5                 | Min. Metal5 enclosure of Metal5:pin                                                              |
+| Pin.g                    | Min. TopMetal1 enclosure of TopMetal1:pin                                                        |
+| Pin.h                    | Min. TopMetal2 enclosure of TopMetal2:pin                                                        |
+| NW.c1.dig                | Min. NWell enclosure of P+Activ inside ThickGateOx                                               |
+| NW.d1.dig                | Min. NWell space to external N+Activ inside ThickGateOx                                          |
+| NW.e1.dig                | Min. NWell enclosure of NWell tie surrounded entirely by NWell in N+Activ inside ThickGateOx     |
+| NW.f1.dig                | Min. NWell space to substrate tie in P+Activ inside ThickGateOx                                  |
+| Cnt.c.Digi               | Min. Activ enclosure of Cont                                                                     |
+| NW.c.SRAM                | Min. NWell enclosure of P+Activ not inside ThickGateOx                                           |
+| NW.d.SRAM                | Min. NWell space to external N+Activ not inside ThickGateOx                                      |
+| Act.c.SRAM               | Min. Activ drain/source extension                                                                |
+| Gat.a.SRAM               | Min. GatPoly width                                                                               |
+| Gat.b.SRAM               | Min. GatPoly space or notch                                                                      |
+| Gat.c.SRAM               | Min. GatPoly extension over Activ (end cap)                                                      |
+| Gat.d.SRAM               | Min. GatPoly space to Activ                                                                      |
+| pSD.e.SRAM               | Min. pSD overlap of Activ when forming abutted substrate tie                                     |
+| pSD.g.SRAM               | Min. N+Activ or P+Activ width when forming abutted tie                                           |
+| pSD.i.SRAM               | Min. pSD enclosure of PFET gate not inside ThickGateOx                                           |
+| pSD.j.SRAM               | Min. pSD space to NFET gate not inside ThickGateOx                                               |
+| Cnt.c.SRAM               | Min. Activ enclosure of Cont                                                                     |
+| Cnt.d.SRAM               | Min. GatPoly enclosure of Cont                                                                   |
+| Cnt.f.SRAM               | Min. Cont on Activ space to GatPoly                                                              |
+| Cnt.g2.SRAM              | Min. pSD overlap of Cont on pSD-Activ                                                            |
+| M1.b.SRAM                | Min. Metal1 space or notch                                                                       |
+| M1.c1.SRAM               | Min. Metal1 endcap enclosure of Cont                                                             |
+| M2.b.SRAM                | Min. Metal2 space or notch                                                                       |
+| M2.c1.SRAM               | Min. Metal2 endcap enclosure of Via1                                                             |
+| M3.b.SRAM                | Min. Metal3 space or notch                                                                       |
+| M3.c1.SRAM               | Min. Metal3 endcap enclosure of Via2                                                             |
+| M4.b.SRAM                | Min. Metal4 space or notch                                                                       |
+| M4.c1.SRAM               | Min. Metal4 endcap enclosure of Via3                                                             |
+| M5.b.SRAM                | Min. Metal5 space or notch                                                                       |
+| M5.c1.SRAM               | Min. Metal5 endcap enclosure of Via4                                                             |
+| LBE.a                    | Min. LBE width                                                                                   |
+| LBE.b                    | Max. LBE width                                                                                   |
+| LBE.b1                   | Max. LBE area (µm²)                                                                              |
+| LBE.b2                   | Min. LBE area (µm²)                                                                              |
+| LBE.c                    | Min. LBE space or notch                                                                          |
+| LBE.d                    | Min. LBE space to inner edge of EdgeSeal                                                         |
+| LBE.e.dfPad              | Min. LBE space to dfpad and Passiv                                                               |
+| LBE.e.Passiv             | Min. LBE space to dfpad and Passiv                                                               |
+| LBE.f                    | Min. LBE space to Activ                                                                          |
+| LBE.h                    | No LBE ring allowed                                                                              |
+| LBE.i                    | Max. global LBE density [%]                                                                      |
+| TSV_G.a                  | DeepVia has to be a ring structure                                                               |
+| TSV_G.d                  | Min. DeepVia space                                                                               |
+| TSV_G.f                  | Min. PWell:block enclosure of DeepVia                                                            |
+| TSV_G.g                  | Min. Metal1 enclosure of DeepVia ring structure                                                  |
+| TSV_G.i                  | Max. global DeepVia density [%]                                                                  |
+| TSV_G.j                  | Max. DeepVia coverage ratio for any 500.0 x 500.0 µm² chip area [%]                              |
+| forbidden.BiWind         | Forbidden drawn layer BiWind on GDS layer 3/0                                                    |
+| forbidden.PEmWind        | Forbidden drawn layer PEmWind on GDS layer 11/0                                                  |
+| forbidden.BasPoly        | Forbidden drawn layer BasPoly on GDS layer 13/0                                                  |
+| forbidden.DeepCo         | Forbidden drawn layer DeepCo on GDS layer 35/0                                                   |
+| forbidden.PEmPoly        | Forbidden drawn layer PEmPoly on GDS layer 53/0                                                  |
+| forbidden.EmPoly         | Forbidden gen./drawn layer EmPoly on GDS layer 53/0                                              |
+| forbidden.LDMOS          | Forbidden drawn layer LDMOS on GDS layer 57/0                                                    |
+| forbidden.PBiWind        | Forbidden drawn layer PBiWind on GDS layer 58/0                                                  |
+| forbidden.Flash          | Forbidden drawn layer Flash on GDS layer 71/0                                                    |
+| forbidden.ColWind        | Forbidden drawn layer ColWind on GDS layer 139/0                                                 |
+| OffGrid.NWell            | NWell is off-grid                                                                                |
+| OffGrid.PWell            | PWell is off-grid                                                                                |
+| OffGrid.PWell_block      | PWell_block is off-grid                                                                          |
+| OffGrid.nBuLay           | nBuLay is off-grid                                                                               |
+| OffGrid.nBuLay_block     | nBuLay_block is off-grid                                                                         |
+| OffGrid.Activ            | Activ is off-grid                                                                                |
+| OffGrid.ThickGateOx      | ThickGateOx is off-grid                                                                          |
+| OffGrid.Activ_filler     | Activ_filler is off-grid                                                                         |
+| OffGrid.GatPoly_filler   | GatPoly_filler is off-grid                                                                       |
+| OffGrid.GatPoly          | GatPoly is off-grid                                                                              |
+| OffGrid.pSD              | pSD is off-grid                                                                                  |
+| OffGrid.nSD              | nSD is off-grid                                                                                  |
+| OffGrid.nSD_block        | nSD_block is off-grid                                                                            |
+| OffGrid.EXTBlock         | EXTBlock is off-grid                                                                             |
+| OffGrid.SalBlock         | SalBlock is off-grid                                                                             |
+| OffGrid.Cont             | Cont is off-grid                                                                                 |
+| OffGrid.Activ_nofill     | Activ_nofill is off-grid                                                                         |
+| OffGrid.GatPoly_nofill   | GatPoly_nofill is off-grid                                                                       |
+| OffGrid.Metal1           | Metal1 is off-grid                                                                               |
+| OffGrid.Via1             | Via1 is off-grid                                                                                 |
+| OffGrid.Metal2           | Metal2 is off-grid                                                                               |
+| OffGrid.Via2             | Via2 is off-grid                                                                                 |
+| OffGrid.Metal3           | Metal3 is off-grid                                                                               |
+| OffGrid.Via3             | Via3 is off-grid                                                                                 |
+| OffGrid.Metal4           | Metal4 is off-grid                                                                               |
+| OffGrid.Via4             | Via4 is off-grid                                                                                 |
+| OffGrid.Metal5           | Metal5 is off-grid                                                                               |
+| OffGrid.MIM              | MIM is off-grid                                                                                  |
+| OffGrid.Vmim             | Vmim is off-grid                                                                                 |
+| OffGrid.TopVia1          | TopVia1 is off-grid                                                                              |
+| OffGrid.TopMetal1        | TopMetal1 is off-grid                                                                            |
+| OffGrid.TopVia2          | TopVia2 is off-grid                                                                              |
+| OffGrid.TopMetal2        | TopMetal2 is off-grid                                                                            |
+| OffGrid.Passiv           | Passiv is off-grid                                                                               |
+| OffGrid.Metal1_filler    | Metal1_filler is off-grid                                                                        |
+| OffGrid.Metal2_filler    | Metal2_filler is off-grid                                                                        |
+| OffGrid.Metal3_filler    | Metal3_filler is off-grid                                                                        |
+| OffGrid.Metal4_filler    | Metal4_filler is off-grid                                                                        |
+| OffGrid.Metal5_filler    | Metal5_filler is off-grid                                                                        |
+| OffGrid.TopMetal1_filler | TopMetal1_filler is off-grid                                                                     |
+| OffGrid.TopMetal2_filler | TopMetal2_filler is off-grid                                                                     |
+| OffGrid.Metal1_nofill    | Metal1_nofill is off-grid                                                                        |
+| OffGrid.Metal2_nofill    | Metal2_nofill is off-grid                                                                        |
+| OffGrid.Metal3_nofill    | Metal3_nofill is off-grid                                                                        |
+| OffGrid.Metal4_nofill    | Metal4_nofill is off-grid                                                                        |
+| OffGrid.Metal5_nofill    | Metal5_nofill is off-grid                                                                        |
+| OffGrid.TopMetal1_nofill | TopMetal1_nofill is off-grid                                                                     |
+| OffGrid.TopMetal2_nofill | TopMetal2_nofill is off-grid                                                                     |
+| OffGrid.NoMetFiller      | NoMetFiller is off-grid                                                                          |
+| OffGrid.Metal1_slit      | Metal1_slit is off-grid                                                                          |
+| OffGrid.Metal2_slit      | Metal2_slit is off-grid                                                                          |
+| OffGrid.Metal3_slit      | Metal3_slit is off-grid                                                                          |
+| OffGrid.Metal4_slit      | Metal4_slit is off-grid                                                                          |
+| OffGrid.Metal5_slit      | Metal5_slit is off-grid                                                                          |
+| OffGrid.TopMetal1_slit   | TopMetal1_slit is off-grid                                                                       |
+| OffGrid.TopMetal2_slit   | TopMetal2_slit is off-grid                                                                       |
+| OffGrid.EdgeSeal         | EdgeSeal is off-grid                                                                             |
+| OffGrid.EmWind           | EmWind is off-grid                                                                               |
+| OffGrid.dfpad            | dfpad is off-grid                                                                                |
+| OffGrid.Polimide         | Polimide is off-grid                                                                             |
+| OffGrid.TRANS            | TRANS is off-grid                                                                                |
+| OffGrid.IND              | IND is off-grid                                                                                  |
+| OffGrid.RES              | RES is off-grid                                                                                  |
+| OffGrid.RFMEM            | RFMEM is off-grid                                                                                |
+| OffGrid.Recog_diode      | Recog_diode is off-grid                                                                          |
+| OffGrid.Recog_esd        | Recog_esd is off-grid                                                                            |
+| OffGrid.DigiBnd          | DigiBnd is off-grid                                                                              |
+| OffGrid.DigiSub          | DigiSub is off-grid                                                                              |
+| OffGrid.SRAM             | SRAM is off-grid                                                                                 |
+| OffGrid.dfpad_pillar     | dfpad_pillar is off-grid                                                                         |
+| OffGrid.dfpad_sbump      | dfpad_sbump is off-grid                                                                          |
+| OffGrid.DeepVia          | DeepVia is off-grid                                                                              |
+| OffGrid.LBE              | LBE is off-grid                                                                                  |
+| OffGrid.PolyRes          | PolyRes is off-grid                                                                              |

--- a/ihp-sg13g2/libs.tech/klayout/tech/drc/sg13g2_maximal.lydrc
+++ b/ihp-sg13g2/libs.tech/klayout/tech/drc/sg13g2_maximal.lydrc
@@ -132,10 +132,100 @@ else
     $sanityRules = true
 end
 
+class AbuttingEdges &lt; RBA::EdgePairToEdgeOperator
+    def initialize
+        self.is_isotropic_and_scale_invariant
+    end
+
+    def process(edge_pair)
+        if edge_pair.first.coincident?(edge_pair.second)
+            if edge_pair.first.length &lt; edge_pair.second.length
+                return [ edge_pair.first ]
+            else
+                return [ edge_pair.second ]
+            end
+        else
+            return []
+        end
+    end
+end
+
+class IntersectingEdgeErrorFilter &lt; RBA::EdgePairOperator
+    def initialize(abutting_edges)
+        @abutting_edges = abutting_edges
+    end
+
+    def process(edge_pair)
+        ip = nil
+        if edge_pair.first.p1 == edge_pair.second.p1 or
+           edge_pair.first.p1 == edge_pair.second.p2
+            ip = edge_pair.first.p1
+        elsif edge_pair.first.p2 == edge_pair.second.p1 or
+              edge_pair.first.p2 == edge_pair.second.p2
+            ip = edge_pair.first.p2
+        end
+        if ip and not edge_pair.first.coincident?(edge_pair.second)
+            edges = RBA::Edges::new([ edge_pair.first, edge_pair.second ])
+            region = @abutting_edges.extents(1)
+            interacting_edges = edges.interacting(region)
+            if interacting_edges.count == 2
+                ep = edge_pair.normalized
+                v1 = ep.first.swapped_points.d
+                v2 = ep.second.d
+                angle = Math.acos((v1*v2)/(v1.length*v2.length))/Math::PI*180
+                if angle &gt;= 90
+                    return []
+                end
+            end
+        end
+        return [ edge_pair ]
+    end
+end
+
+class IntersectingEdgeErrorAngleFilter &lt; RBA::EdgePairOperator
+    def initialize(min_angle, max_angle, include_min_angle, include_max_angle)
+        self.is_isotropic_and_scale_invariant
+        @min_angle = min_angle
+        @max_angle = max_angle
+        if include_min_angle
+            @min_angle -= 1e-6
+        else
+            @min_angle += 1e-6
+        end
+        if include_max_angle
+            @max_angle += 1e-6
+        else
+            @max_angle -= 1e-6
+        end
+    end
+
+    def process(edge_pair)
+        ip = nil
+        if edge_pair.first.p1 == edge_pair.second.p1 or
+           edge_pair.first.p1 == edge_pair.second.p2
+            ip = edge_pair.first.p1
+        elsif edge_pair.first.p2 == edge_pair.second.p1 or
+              edge_pair.first.p2 == edge_pair.second.p2
+            ip = edge_pair.first.p2
+        end
+        if ip
+            ep = edge_pair.normalized
+            v1 = ep.first.swapped_points.d
+            v2 = ep.second.d
+            angle = Math.acos((v1*v2)/(v1.length*v2.length))/Math::PI*180
+            if (angle &lt; @min_angle) or (angle &gt; @max_angle)
+                return []
+            end
+        end
+        return [ edge_pair ]
+    end
+end
+
 class DRC::DRCEngine
     def find_intersecting_edges_errors(dbu_value,
                                        error_edge_pairs_90,
                                        error_edge_pairs_180,
+                                       error_edge_pairs_90_180 = nil,
                                        inverse_error_edge_pairs_90 = nil,
                                        inverse_error_edge_pairs_180 = nil,
                                        options = {})
@@ -149,7 +239,7 @@ class DRC::DRCEngine
         area_of_right_angle = dbu_value**2/2
         errors_ep = RBA::EdgePairs::new()
         touch_point_errors_ep = RBA::EdgePairs::new()
-        intersecting_edges_errors_ep = RBA::EdgePairs::new()
+        abutting_edges_errors_ep = RBA::EdgePairs::new()
         intersecting_edges_error_candidates = Hash.new()
         no_touch_point_error = Hash.new()
         error_edge_pairs_90.data.each do |edge_pair|
@@ -160,18 +250,13 @@ class DRC::DRCEngine
             elsif edge_pair.first.p2 == edge_pair.second.p1 or
                   edge_pair.first.p2 == edge_pair.second.p2
                 ip = edge_pair.first.p2
-            else
-                ip = edge_pair.first.intersection_point(edge_pair.second)
             end
-            if ip
-                intersecting_edges_error_candidates[ip] = edge_pair
-                if !edge_pair.first.is_degenerate? and !edge_pair.second.is_degenerate?
-                    if (edge_pair.first.contains?(edge_pair.second.p1) and
-                       edge_pair.first.contains?(edge_pair.second.p2)) or
-                       (edge_pair.second.contains?(edge_pair.first.p1) and
-                       edge_pair.second.contains?(edge_pair.first.p2))
-                        no_touch_point_error[ip] = true
-                    end
+            if ip and !edge_pair.first.is_degenerate? and !edge_pair.second.is_degenerate?
+                if (edge_pair.first.contains?(edge_pair.second.p1) and
+                   edge_pair.first.contains?(edge_pair.second.p2)) or
+                   (edge_pair.second.contains?(edge_pair.first.p1) and
+                   edge_pair.second.contains?(edge_pair.first.p2))
+                    no_touch_point_error[ip] = true
                 end
             end
         end
@@ -192,7 +277,10 @@ class DRC::DRCEngine
                 end
             end
             touch_point_candidates = Hash.new()
-            (error_edge_pairs_90 + error_edge_pairs_180).data.each do |edge_pair|
+            if !error_edge_pairs_90_180
+                error_edge_pairs_90_180 = error_edge_pairs_90 + error_edge_pairs_180
+            end
+            error_edge_pairs_90_180.data.each do |edge_pair|
                 ip = nil
                 if edge_pair.first.p1 == edge_pair.second.p1 or
                    edge_pair.first.p1 == edge_pair.second.p2
@@ -200,11 +288,11 @@ class DRC::DRCEngine
                 elsif edge_pair.first.p2 == edge_pair.second.p1 or
                       edge_pair.first.p2 == edge_pair.second.p2
                     ip = edge_pair.first.p2
+                elsif edge_pair.first.intersection_point(edge_pair.second)
+                    abutting_edges_errors_ep.insert(edge_pair)
                 end
-                if ip
-                    if edge_pair.area == area_of_right_angle or max_angle == 180
-                        intersecting_edges_error_candidates[ip] = edge_pair
-                    end
+                if ip and !edge_pair.first.is_degenerate? and !edge_pair.second.is_degenerate?
+                    intersecting_edges_error_candidates[ip] = edge_pair
                     if touch_point_errors[ip]
                         touch_point_errors_ep.insert(edge_pair)
                         intersecting_edges_error_candidates.delete(ip)
@@ -219,11 +307,11 @@ class DRC::DRCEngine
                 end
             end
             if consider_intersecting_edges
-                intersecting_edges_errors_ep = RBA::EdgePairs::new(intersecting_edges_error_candidates.values)
-                if max_angle != 180
-                    intersecting_edges_errors_ep = intersecting_edges_errors_ep.with_internal_angle(min_angle, max_angle, false, include_min_angle, include_max_angle)
+                errors_ep = RBA::EdgePairs::new(intersecting_edges_error_candidates.values)
+                errors_ep.process(IntersectingEdgeErrorAngleFilter::new(min_angle, max_angle, include_min_angle, include_max_angle))
+                if min_angle == 0 and include_min_angle
+                    errors_ep = errors_ep + abutting_edges_errors_ep
                 end
-                errors_ep = errors_ep + intersecting_edges_errors_ep
             end
         end
         if ignore_non_axis_aligned_edges
@@ -439,12 +527,112 @@ class DRC::DRCLayer
         return output_layer
     end
 
-    def ext_fast_enclosed(other, value, polygon_output: false)
+    def ext_enclosed_at_intersecting_edges(other,
+                                           value,
+                                           metric=RBA::Region::Euclidian,
+                                           consider_intersecting_edges=false,
+                                           consider_touch_points=false,
+                                           ignore_non_axis_aligned_edges=false,
+                                           min_angle=0,
+                                           max_angle=90,
+                                           include_min_angle=true,
+                                           include_max_angle=false,
+                                           polygons=false)
         self_min_coherence_state = self.data.min_coherence?
         other_min_coherence_state =  other.data.min_coherence?
         self.data.min_coherence = true
         other.data.min_coherence = true
-        output_layer = self.enclosed(other, value, @engine.projection)
+        if metric.is_a?(DRC::DRCMetrics)
+            metric = metric.value
+        end
+        if value.is_a? Float
+            dbu_value = (value/1.dbu).round
+        else
+            dbu_value = value
+        end
+        error_edge_pairs_90 = DRC::DRCLayer::new(@engine,
+            self.data.enclosed_check(other.data, dbu_value, false, metric, 90, 1, nil))
+        error_edge_pairs_90_180 = DRC::DRCLayer::new(@engine,
+            self.data.enclosed_check(other.data, dbu_value, false, metric, 180, nil, nil))
+        enclosed_errors = @engine.find_intersecting_edges_errors(
+            dbu_value,
+            error_edge_pairs_90,
+            nil,
+            error_edge_pairs_90_180,
+            nil,
+            nil,
+            {
+                consider_intersecting_edges: consider_intersecting_edges,
+                consider_touch_points: consider_touch_points,
+                ignore_non_axis_aligned_edges: ignore_non_axis_aligned_edges,
+                min_angle: min_angle,
+                max_angle: max_angle,
+                include_min_angle: include_min_angle,
+                include_max_angle: include_max_angle
+            }
+        )
+        self.data.min_coherence = self_min_coherence_state
+        other.data.min_coherence = other_min_coherence_state
+        if polygons
+            return enclosed_errors.polygons.merge(true, 0)
+        else
+            return enclosed_errors
+        end
+    end
+
+    def ext_enclosed(other,
+                     value,
+                     metric: @engine.euclidian,
+                     consider_intersecting_edges: true,
+                     consider_touch_points: true,
+                     consider_overlaps_as_errors: false,
+                     ignore_non_axis_aligned_edges: false,
+                     min_angle: 0,
+                     max_angle: 90,
+                     include_min_angle: true,
+                     include_max_angle: false,
+                     polygon_output: false)
+        self_min_coherence_state = self.data.min_coherence?
+        other_min_coherence_state =  other.data.min_coherence?
+        self.data.min_coherence = true
+        other.data.min_coherence = true
+        metric = @engine.projection
+        if consider_overlaps_as_errors
+            output_layer = self.enclosed(other, value, metric,
+                                         @engine.angle_limit(180), @engine.without_touching_corners)
+            abutting_edges = output_layer.data.processed(AbuttingEdges::new)
+            output_layer.data.process(IntersectingEdgeErrorFilter::new(abutting_edges))
+        else
+            angle_limit = max_angle
+            if include_max_angle
+                angle_limit += 1e-6
+            end
+            output_layer = self.enclosed(other, value, metric, @engine.angle_limit(angle_limit))
+            if !consider_intersecting_edges and !consider_touch_points
+                output_layer = output_layer.without_distance(0)
+                if ignore_non_axis_aligned_edges
+                    output_layer = output_layer.with_angle(@engine.ortho, @engine.both)
+                end
+            elsif (consider_intersecting_edges ^ consider_touch_points) or
+                  !(min_angle==0 and max_angle==90 and include_min_angle and !include_max_angle)
+                intersecting_edges_errors = output_layer.with_distance(0).edges
+                candidate_layer1 = self.interacting(intersecting_edges_errors)
+                candidate_layer2 = other.interacting(intersecting_edges_errors)
+                output_layer = output_layer.without_distance(0)
+                output_layer = output_layer + candidate_layer1.ext_enclosed_at_intersecting_edges(
+                    candidate_layer2,
+                    value,
+                    metric,
+                    consider_intersecting_edges,
+                    consider_touch_points,
+                    ignore_non_axis_aligned_edges,
+                    min_angle,
+                    max_angle,
+                    include_min_angle,
+                    include_max_angle,
+                    false)
+            end
+        end
         self.data.min_coherence = self_min_coherence_state
         other.data.min_coherence = other_min_coherence_state
         if polygon_output
@@ -499,8 +687,8 @@ class DRC::DRCLayer
         end
         error_edge_pairs_90 = DRC::DRCLayer::new(@engine,
             self.data.separation_check(other.data, dbu_value, false, metric, 90, 1, nil))
-        error_edge_pairs_180 = DRC::DRCLayer::new(@engine,
-            self.data.separation_check(other.data, dbu_value, false, metric, 180, nil, 1))
+        error_edge_pairs_90_180 = DRC::DRCLayer::new(@engine,
+            self.data.separation_check(other.data, dbu_value, false, metric, 180))
         width_error_edge_pairs_90 = DRC::DRCLayer::new(@engine,
             self.data.width_check(dbu_value, false, metric, 90, 1, nil) +
             other.data.width_check(dbu_value, false, metric, 90, 1, nil))
@@ -510,7 +698,8 @@ class DRC::DRCLayer
         separation_errors = @engine.find_intersecting_edges_errors(
             dbu_value,
             error_edge_pairs_90,
-            error_edge_pairs_180,
+            nil,
+            error_edge_pairs_90_180,
             width_error_edge_pairs_90,
             width_error_edge_pairs_180,
             {
@@ -532,44 +721,57 @@ class DRC::DRCLayer
         end
     end
 
-    def ext_fast_separation(other,
-                            value,
-                            metric: @engine.euclidian,
-                            consider_intersecting_edges: true,
-                            consider_touch_points: true,
-                            ignore_non_axis_aligned_edges: false,
-                            min_angle: 0,
-                            max_angle: 90,
-                            include_min_angle: true,
-                            include_max_angle: false,
-                            polygon_output: false)
+    def ext_separation(other,
+                       value,
+                       metric: @engine.euclidian,
+                       consider_intersecting_edges: true,
+                       consider_touch_points: true,
+                       consider_overlaps_as_errors: false,
+                       ignore_non_axis_aligned_edges: false,
+                       min_angle: 0,
+                       max_angle: 90,
+                       include_min_angle: true,
+                       include_max_angle: false,
+                       polygon_output: false)
         self_min_coherence_state = self.data.min_coherence?
         other_min_coherence_state =  other.data.min_coherence?
         self.data.min_coherence = true
         other.data.min_coherence = true
-        output_layer = self.separation(other, value, metric, @engine.angle_limit(max_angle))
-        if !consider_intersecting_edges and !consider_touch_points
-            output_layer = output_layer.with_distance(1, nil)
-            if ignore_non_axis_aligned_edges
-                output_layer = output_layer.with_angle(@engine.ortho, @engine.both)
+        if consider_overlaps_as_errors
+            output_layer = self.separation(other, value, metric,
+                                           @engine.angle_limit(180), @engine.without_touching_corners)
+            abutting_edges = output_layer.data.processed(AbuttingEdges::new)
+            output_layer.data.process(IntersectingEdgeErrorFilter::new(abutting_edges))
+        else
+            angle_limit = max_angle
+            if include_max_angle
+                angle_limit += 1e-6
             end
-        elsif consider_intersecting_edges ^ consider_touch_points
-            intersecting_edges_errors = output_layer.with_distance(0).edges
-            candidate_layer1 = self.interacting(intersecting_edges_errors)
-            candidate_layer2 = other.interacting(intersecting_edges_errors)
-            output_layer = output_layer.with_distance(1, nil)
-            output_layer = output_layer + candidate_layer1.ext_separation_at_intersecting_edges(
-                candidate_layer2,
-                value,
-                metric,
-                consider_intersecting_edges,
-                consider_touch_points,
-                ignore_non_axis_aligned_edges,
-                min_angle,
-                max_angle,
-                include_min_angle,
-                include_max_angle,
-                false)
+            output_layer = self.separation(other, value, metric, @engine.angle_limit(angle_limit))
+            if !consider_intersecting_edges and !consider_touch_points
+                output_layer = output_layer.without_distance(0)
+                if ignore_non_axis_aligned_edges
+                    output_layer = output_layer.with_angle(@engine.ortho, @engine.both)
+                end
+            elsif (consider_intersecting_edges ^ consider_touch_points) or
+                  !(min_angle==0 and max_angle==90 and include_min_angle and !include_max_angle)
+                intersecting_edges_errors = output_layer.with_distance(0).edges
+                candidate_layer1 = self.interacting(intersecting_edges_errors)
+                candidate_layer2 = other.interacting(intersecting_edges_errors)
+                output_layer = output_layer.without_distance(0)
+                output_layer = output_layer + candidate_layer1.ext_separation_at_intersecting_edges(
+                    candidate_layer2,
+                    value,
+                    metric,
+                    consider_intersecting_edges,
+                    consider_touch_points,
+                    ignore_non_axis_aligned_edges,
+                    min_angle,
+                    max_angle,
+                    include_min_angle,
+                    include_max_angle,
+                    false)
+            end
         end
         self.data.min_coherence = self_min_coherence_state
         other.data.min_coherence = other_min_coherence_state
@@ -659,6 +861,7 @@ class DRC::DRCLayer
             error_edge_pairs_180,
             nil,
             nil,
+            nil,
             {
                 consider_intersecting_edges: consider_intersecting_edges,
                 consider_touch_points: consider_touch_points,
@@ -678,17 +881,17 @@ class DRC::DRCLayer
         end
     end
 
-    def ext_fast_overlap(other,
-                         value,
-                         metric: @engine.euclidian,
-                         consider_intersecting_edges: true,
-                         consider_touch_points: true,
-                         ignore_non_axis_aligned_edges: false,
-                         min_angle: 0,
-                         max_angle: 90,
-                         include_min_angle: true,
-                         include_max_angle: false,
-                         polygon_output: false)
+    def ext_overlap(other,
+                    value,
+                    metric: @engine.euclidian,
+                    consider_intersecting_edges: true,
+                    consider_touch_points: true,
+                    ignore_non_axis_aligned_edges: false,
+                    min_angle: 0,
+                    max_angle: 90,
+                    include_min_angle: true,
+                    include_max_angle: false,
+                    polygon_output: false)
         if self.polygons?
             self_min_coherence_state = self.data.min_coherence?
             self.data.min_coherence = true
@@ -872,6 +1075,7 @@ class DRC::DRCLayer
             dbu_value,
             error_edge_pairs_90,
             error_edge_pairs_180,
+            nil,
             width_error_edge_pairs_90,
             width_error_edge_pairs_180,
             {
@@ -892,16 +1096,16 @@ class DRC::DRCLayer
         end
     end
 
-    def ext_fast_space(value,
-                       metric: @engine.euclidian,
-                       consider_intersecting_edges: true,
-                       consider_touch_points: true,
-                       ignore_non_axis_aligned_edges: false,
-                       min_angle: 0,
-                       max_angle: 90,
-                       include_min_angle: true,
-                       include_max_angle: false,
-                       polygon_output: false)
+    def ext_space(value,
+                  metric: @engine.euclidian,
+                  consider_intersecting_edges: true,
+                  consider_touch_points: true,
+                  ignore_non_axis_aligned_edges: false,
+                  min_angle: 0,
+                  max_angle: 90,
+                  include_min_angle: true,
+                  include_max_angle: false,
+                  polygon_output: false)
         self_min_coherence_state = self.data.min_coherence?
         self.data.min_coherence = true
         output_layer = self.space(value, metric, @engine.angle_limit(max_angle))
@@ -961,6 +1165,7 @@ class DRC::DRCLayer
             dbu_value,
             error_edge_pairs_90,
             error_edge_pairs_180,
+            nil,
             space_error_edge_pairs_90,
             space_error_edge_pairs_180,
             {
@@ -981,16 +1186,16 @@ class DRC::DRCLayer
         end
     end
 
-    def ext_fast_width(value,
-                       metric: @engine.euclidian,
-                       consider_intersecting_edges: true,
-                       consider_touch_points: true,
-                       ignore_non_axis_aligned_edges: false,
-                       min_angle: 0,
-                       max_angle: 90,
-                       include_min_angle: true,
-                       include_max_angle: false,
-                       polygon_output: false)
+    def ext_width(value,
+                  metric: @engine.euclidian,
+                  consider_intersecting_edges: true,
+                  consider_touch_points: true,
+                  ignore_non_axis_aligned_edges: false,
+                  min_angle: 0,
+                  max_angle: 90,
+                  include_min_angle: true,
+                  include_max_angle: false,
+                  polygon_output: false)
         if self.polygons?
             self_min_coherence_state = self.data.min_coherence?
             self.data.min_coherence = true
@@ -1227,7 +1432,7 @@ if $sanityRules
 	Flash = source.polygons("71/0")
 end
 
-Activ_Act_a = Activ.ext_fast_width(0.15.um)
+Activ_Act_a = Activ.ext_width(0.15.um)
 Activ_Act_d = Activ.ext_with_area([["&lt;", 0.122.um2]])
 nmosi_relevant_activ = Activ.ext_or(Activ_mask)
 Act_density = Activ.ext_or(Activ_filler)
@@ -1244,7 +1449,7 @@ Passiv_Pad_a1 = Passiv.drc((width(projection) &gt; 150.0.um).polygons)
 X2 = nSD_block.ext_or(pSD)
 pSD_not_nSD = nSD.ext_not(pSD)
 subst_tie_hole = (pSD.holes - pSD.with_holes).without_holes
-pSD_pSD_a = pSD.ext_fast_width(0.31.um)
+pSD_pSD_a = pSD.ext_width(0.31.um)
 pSD_pSD_k = pSD.ext_with_area([["&lt;", 0.25.um2]])
 Act_Nsram = Activ.ext_not(SRAM)
 pSD_Nsram = pSD.ext_not(SRAM)
@@ -1258,13 +1463,14 @@ V2_Nsram = Via2.ext_not(SRAM)
 M3_Nsram = Metal3.ext_not(SRAM)
 M3_SRAM = Metal3.ext_and(SRAM)
 Act_NWell = Activ.ext_and(NWell)
-NWell_NW_a = NWell.ext_fast_width(0.62.um)
+NWell_Nsram = NWell.ext_not(SRAM)
+NWell_NW_a = NWell.ext_width(0.62.um)
 NWell_nBuLay = NWell.ext_and(nBuLay)
 isoPWell = nBuLay.ext_not(NWell)
-nBuLay_block_NBLB_a = nBuLay_block.ext_fast_width(1.5.um)
-nBuLay_nBuLay_block_enc_tmp = nBuLay_block.ext_fast_enclosed(nBuLay, 1.0.um, polygon_output: true)
+nBuLay_block_NBLB_a = nBuLay_block.ext_width(1.5.um)
+nBuLay_nBuLay_block_enc_tmp = nBuLay_block.ext_enclosed(nBuLay, 1.0.um, consider_touch_points: false, polygon_output: true)
 nBuLay_nBuLay_block_enc_tmp2 = nBuLay_block.ext_overlapping(nBuLay)
-MIM_Mim_a = MIM.ext_fast_width(1.14.um, consider_intersecting_edges: false, polygon_output: true)
+MIM_Mim_a = MIM.ext_width(1.14.um, consider_intersecting_edges: false, polygon_output: true)
 MIM_Mim_f = MIM.ext_with_area([["&lt;", 1.3.um2]])
 sealring = EdgeSeal.with_holes
 Act_EdgeSeal = Activ.ext_and(EdgeSeal)
@@ -1286,11 +1492,11 @@ Passiv_dfpad = Passiv.ext_and(dfpad)
 pad = dfpad.not_outside(Passiv)
 cupPad_candidat = Passiv.ext_and(dfpad_pillar)
 dfpad_all = dfpad.ext_or(dfpad_pillar, dfpad_sbump)
-ThickGateOx_TGO_e = ThickGateOx.ext_fast_space(0.86.um, consider_intersecting_edges: false, polygon_output: true)
-ThickGateOx_TGO_f = ThickGateOx.ext_fast_width(0.86.um, consider_intersecting_edges: false, polygon_output: true)
+ThickGateOx_TGO_e = ThickGateOx.ext_space(0.86.um, consider_intersecting_edges: false, polygon_output: true)
+ThickGateOx_TGO_f = ThickGateOx.ext_width(0.86.um, consider_intersecting_edges: false, polygon_output: true)
 X1 = NWell.ext_or(PWell_block)
-PWell_block_PWB_a = PWell_block.ext_fast_width(0.62.um)
-PWell_block_PWB_b = PWell_block.ext_fast_space(0.62.um, consider_intersecting_edges: false, polygon_output: true)
+PWell_block_PWB_a = PWell_block.ext_width(0.62.um)
+PWell_block_PWB_b = PWell_block.ext_space(0.62.um, consider_intersecting_edges: false, polygon_output: true)
 V3_Nsram = Via3.ext_not(SRAM)
 Via3_edgC1_in = Via3.ext_and(EdgeSeal)
 Via3_edgC1_out = Via3.ext_not(EdgeSeal)
@@ -1306,7 +1512,7 @@ M5_SRAM = Metal5.ext_and(SRAM)
 belowTopMetaln_dfpad = Metal5.ext_and(dfpad)
 Metal5_edgA1_in = Metal5.ext_and(EdgeSeal)
 Metal5_outside_EdgeSeal = Metal5.outside(EdgeSeal)
-Metal5_slit_MIM_Slt_g_M5_sep_tmp1 = Metal5_slit.ext_fast_separation(MIM, 0.6.um, consider_intersecting_edges: false, consider_touch_points: false, polygon_output: true)
+Metal5_slit_MIM_Slt_g_M5_sep_tmp1 = Metal5_slit.ext_separation(MIM, 0.6.um, consider_intersecting_edges: false, consider_touch_points: false, polygon_output: true)
 Metal5_slit_MIM_Slt_g_M5_sep_tmp2 = MIM.ext_coincident_edges(Metal5_slit, outside: true, consider_touch_points: true)
 Metal5_slit_MIM_Slt_g_M5_sep_tmp5 = Metal5_slit.ext_and(MIM)
 scr1 = Recog_esd.ext_interacting_with_text(TEXT_0, "scr1")
@@ -1316,7 +1522,7 @@ Rhigh_recognition_0 = EXTBlock.ext_and(pSD)
 TopVia1_edgC1_in = TopVia1.ext_and(EdgeSeal)
 TopVia1_edgC1_out = TopVia1.ext_not(EdgeSeal)
 TopMetal1_edgA1_in = TopMetal1.ext_and(EdgeSeal)
-TopMetal1_slit_MIM_Slt_g_TM1_sep_tmp1 = TopMetal1_slit.ext_fast_separation(MIM, 0.6.um, consider_intersecting_edges: false, consider_touch_points: false, polygon_output: true)
+TopMetal1_slit_MIM_Slt_g_TM1_sep_tmp1 = TopMetal1_slit.ext_separation(MIM, 0.6.um, consider_intersecting_edges: false, consider_touch_points: false, polygon_output: true)
 TopMetal1_slit_MIM_Slt_g_TM1_sep_tmp2 = MIM.ext_coincident_edges(TopMetal1_slit, outside: true, consider_touch_points: true)
 TopMetal1_slit_MIM_Slt_g_TM1_sep_tmp5 = TopMetal1_slit.ext_and(MIM)
 GatPoly_res = GatPoly.ext_or(PolyRes)
@@ -1343,6 +1549,7 @@ TM2_density = TopMetal2.ext_or(TopMetal2_filler).ext_not(TopMetal2_slit)
 GP_mosHV = Gate.not_outside(ThickGateOx)
 GP_out_ThickGateOx = Gate.outside(ThickGateOx)
 size_Cont = Cont.ext_enlarge_inside(Act_connect, 6.0.um, 0.21.um)
+Cont_GP = Cont_SQ.ext_and(GatPoly)
 Cont_Act = Cont_SQ.ext_and(Activ)
 Cont_not_M1 = Cont_SQ.ext_not(Metal1)
 Cont_Act_GP = Cont_SQ.ext_and(Gate)
@@ -1358,11 +1565,12 @@ nSD_not_pSD = pSD_not_nSD.dup
 subst_tie_hole_w_npn = subst_tie_hole.ext_interacting_with_text(TEXT_0, "npn*")
 pSDL_enc_area = subst_tie_hole.ext_not(pSD)
 Act_SRAM = Activ.ext_not(Act_Nsram)
+Act_Nsram_or_Activ_mask = Act_Nsram.ext_or(Activ_mask)
 pSD_SRAM = pSD.ext_not(pSD_Nsram)
 pSDHV_Nsram = pSD_Nsram.inside(ThickGateOx)
 GP_SRAM = GatPoly.ext_not(GP_Nsram)
-GP_Nsram_Gat_a = GP_Nsram.ext_fast_width(0.13.um, consider_intersecting_edges: false, polygon_output: true)
-GP_Nsram_Gat_b = GP_Nsram.ext_fast_space(0.18.um, consider_intersecting_edges: false, polygon_output: true)
+GP_Nsram_Gat_a = GP_Nsram.ext_width(0.13.um, consider_intersecting_edges: false, polygon_output: true)
+GP_Nsram_Gat_b = GP_Nsram.ext_space(0.18.um, consider_intersecting_edges: false, polygon_output: true)
 Cont_SRAM = Cont.ext_not(Cont_Nsram)
 V1_SRAM = Via1.ext_not(V1_Nsram)
 V1_Nsram_outside_EdgeSeal = V1_Nsram.outside(EdgeSeal)
@@ -1370,6 +1578,7 @@ M1_SRAM = Metal1.ext_not(M1_Nsram)
 npnMPA_0 = nBuLay.ext_and(Activ.ext_and(SalBlock.ext_and(nSD_block)))
 V2_SRAM = Via2.ext_not(V2_Nsram)
 V2_Nsram_outside_EdgeSeal = V2_Nsram.outside(EdgeSeal)
+NWell_SRAM = NWell.ext_not(NWell_Nsram)
 nBuLay_nBuLay_block_enc_tmp3 = nBuLay_nBuLay_block_enc_tmp + nBuLay_nBuLay_block_enc_tmp2
 Act_EdgeSeal_not_HRACT = Act_EdgeSeal.ext_not(Recog)
 Activ_edgA1_in = Act_EdgeSeal.dup
@@ -1404,14 +1613,14 @@ transG2C = TRANS.ext_interacting_with_text(TEXT_0, "npn13G2C").ext_covering(emi2
 transG2L = TRANS.ext_interacting_with_text(TEXT_0, "npn13G2L").ext_covering(emi2Pin)
 transG2V = TRANS.ext_interacting_with_text(TEXT_0, "npn13G2V").ext_covering(emi2Pin)
 nBuLayGen = nBuLayGen_sized.ext_not(nBuLay_block)
-ThickGateOx_Act_out_ThickGateOx_TGO_b_sep_tmp1 = ThickGateOx.ext_fast_separation(Act_out_ThickGateOx, 0.27.um, consider_intersecting_edges: false, consider_touch_points: false, polygon_output: true)
+ThickGateOx_Act_out_ThickGateOx_TGO_b_sep_tmp1 = ThickGateOx.ext_separation(Act_out_ThickGateOx, 0.27.um, consider_intersecting_edges: false, consider_touch_points: false, polygon_output: true)
 ThickGateOx_Act_out_ThickGateOx_TGO_b_sep_tmp2 = Act_out_ThickGateOx.ext_coincident_edges(ThickGateOx, outside: true, consider_touch_points: true)
 ThickGateOx_Act_out_ThickGateOx_TGO_b_sep_tmp5 = ThickGateOx.ext_and(Act_out_ThickGateOx)
 PWellBlock_relatedNWell = PWellBlock_relatedNWell_0.ext_or(NWell.inside(PWell_block))
 Rppd_0 = GatPoly_res.ext_and(pSD).ext_and(SalBlock_not_nSDBlock_not_esd)
 tsv_fill = DeepVia.ext_or(tsv_tmp2).ext_not(bad_tsv)
-GP_mosHV_Gat_b1 = GP_mosHV.ext_fast_space(0.25.um, consider_intersecting_edges: false, polygon_output: true)
-ThickGateOx_GP_out_ThickGateOx_TGO_d_sep_tmp1 = ThickGateOx.ext_fast_separation(GP_out_ThickGateOx, 0.34.um, consider_intersecting_edges: false, consider_touch_points: false, polygon_output: true)
+GP_mosHV_Gat_b1 = GP_mosHV.ext_space(0.25.um, consider_intersecting_edges: false, polygon_output: true)
+ThickGateOx_GP_out_ThickGateOx_TGO_d_sep_tmp1 = ThickGateOx.ext_separation(GP_out_ThickGateOx, 0.34.um, consider_intersecting_edges: false, consider_touch_points: false, polygon_output: true)
 ThickGateOx_GP_out_ThickGateOx_TGO_d_sep_tmp2 = GP_out_ThickGateOx.ext_coincident_edges(ThickGateOx, outside: true, consider_touch_points: true)
 ThickGateOx_GP_out_ThickGateOx_TGO_d_sep_tmp5 = ThickGateOx.ext_and(GP_out_ThickGateOx)
 dschottky_2 = dschottky_1.sized(1.12.um, acute_limit)
@@ -1420,8 +1629,8 @@ dpin_1 = dpin_0.sized(1.12.um, acute_limit)
 pSD_not_nSD_or_nSD_not_pSD = nSD_not_pSD.ext_or(pSD_not_nSD)
 pSDL_enc_area_pSD_l = pSDL_enc_area.ext_with_area([["&lt;", 0.25.um2]])
 DigiBnd_hole = DigiBnd.ext_or(DigiBnd_ring.holes.merge)
-GP_SRAM_Gat_a_SRAM = GP_SRAM.ext_fast_width(0.13.um, consider_intersecting_edges: false, polygon_output: true)
-GP_SRAM_Gat_b_SRAM = GP_SRAM.ext_fast_space(0.149.um, consider_intersecting_edges: false, polygon_output: true)
+GP_SRAM_Gat_a_SRAM = GP_SRAM.ext_width(0.069.um, consider_intersecting_edges: false, polygon_output: true)
+GP_SRAM_Gat_b_SRAM = GP_SRAM.ext_space(0.149.um, consider_intersecting_edges: false, polygon_output: true)
 V1_SRAM_outside_EdgeSeal = V1_SRAM.outside(EdgeSeal)
 M1_SRAM_outside_EdgeSeal = M1_SRAM.outside(EdgeSeal)
 npnMPA = npnMPA_0.ext_interacting_with_text(TEXT_0, "npnMPA")
@@ -1455,7 +1664,7 @@ schottky_nbl_rec = isoPWell.not_outside(SalBlock).not_outside(nSD_block).not_out
 ThickGateOx_Act_out_ThickGateOx_TGO_b_sep_tmp3 = ThickGateOx.ext_with_coincident_edges(ThickGateOx_Act_out_ThickGateOx_TGO_b_sep_tmp2)
 PWellBlock_unrelatedNWell = NWell.ext_not(PWellBlock_relatedNWell)
 tsvOutRing = tsv_fill.ext_extents
-tsv_fill_TSV_G_d = tsv_fill.ext_fast_space(25.0.um, consider_intersecting_edges: false, polygon_output: true)
+tsv_fill_TSV_G_d = tsv_fill.ext_space(25.0.um, consider_intersecting_edges: false, polygon_output: true)
 ThickGateOx_GP_out_ThickGateOx_TGO_d_sep_tmp3 = ThickGateOx.ext_with_coincident_edges(ThickGateOx_GP_out_ThickGateOx_TGO_d_sep_tmp2)
 dschottky_3 = dschottky_2.ext_and(PWell_block)
 dpin = dpin_1.ext_and(PWell_block)
@@ -1472,19 +1681,21 @@ PAct_connect = Act_connect.ext_not(NAct)
 NActLV = NAct.ext_not(ThickGateOx)
 NAct_NWell = NAct.ext_and(X1)
 sal_nActiv = NAct.ext_not(SalBlock)
+Cont_NAct = Cont_SQ.ext_and(NAct)
 ContBar_NAct = ContBar.ext_and(NAct)
 Cont_not_outside_NAct = Cont.not_outside(NAct)
-nBuLayGen_nBuLay_NBL_a = nBuLayGen_nBuLay.ext_fast_width(1.0.um)
+nBuLayGen_nBuLay_NBL_a = nBuLayGen_nBuLay.ext_width(1.0.um)
 ThickGateOx_Act_out_ThickGateOx_TGO_b_sep_tmp4 = ThickGateOx_Act_out_ThickGateOx_TGO_b_sep_tmp1 + ThickGateOx_Act_out_ThickGateOx_TGO_b_sep_tmp3
 rfcmim = PWell_block.not_outside(rfcmim_a).sized(0.65.um, acute_limit)
-PWell_block_tsvOutRing_enc_tmp = tsvOutRing.ext_fast_enclosed(PWell_block, 2.5.um, polygon_output: true)
+PWell_block_tsvOutRing_enc_tmp = tsvOutRing.ext_enclosed(PWell_block, 2.5.um, consider_touch_points: false, polygon_output: true)
 PWell_block_tsvOutRing_enc_tmp2 = tsvOutRing.ext_overlapping(PWell_block)
-Metal1_tsvOutRing_enc_tmp = tsvOutRing.ext_fast_enclosed(Metal1, 1.5.um, polygon_output: true)
+Metal1_tsvOutRing_enc_tmp = tsvOutRing.ext_enclosed(Metal1, 1.5.um, consider_touch_points: false, polygon_output: true)
 Metal1_tsvOutRing_enc_tmp2 = tsvOutRing.ext_overlapping(Metal1)
 ThickGateOx_GP_out_ThickGateOx_TGO_d_sep_tmp4 = ThickGateOx_GP_out_ThickGateOx_TGO_d_sep_tmp1 + ThickGateOx_GP_out_ThickGateOx_TGO_d_sep_tmp3
 dschottky = dschottky_3.ext_not(dpin)
+GP_Rppd_extended = GatPoly_res.ext_covering(Rppd_all)
 SalBlock_Rppd = SalBlock.ext_and(Rppd_all)
-Rppd_all_enclosure_pSD = Rppd_all.ext_fast_enclosed(pSD, 0.18.um, polygon_output: true)
+Rppd_all_enclosure_pSD = Rppd_all.ext_enclosed(pSD, 0.18.um)
 Rhigh_a = GatPoly_res.ext_and(pSD_nSD).ext_and(SalBlock_not_nSDBlock_not_esd)
 schottky_nbl1_nw = NWell.ext_interacting(NWell.holes.merge.ext_covering(schottky_nbl_rec))
 schottky_nw1_rect = NWell.not_outside(nSD_block).ext_interacting(schottky_nbl_rec, inverted: true).ext_and(Recog_diode)
@@ -1493,10 +1704,13 @@ Rhigh_identical_nsd_psd = pSD_not_nSD_or_nSD_not_pSD.ext_with_coincident_edges(R
 TopMetal1_slit_MIM_Slt_g_TM1_sep_tmp9 = TopMetal1_slit_MIM_Slt_g_TM1_sep_tmp6.dup
 Rsil = Rsil_all_not_interact_NWell.ext_interacting(nBuLay, inverted: true)
 PGate = Gate.outside(NGate)
+PActLV = PAct.ext_not(ThickGateOx)
 PAct_NWell = PAct.ext_and(X1)
+Cont_PAct = Cont_SQ.ext_and(PAct)
 ContBar_PAct = ContBar.ext_and(PAct)
 Cont_not_outside_PAct = Cont.not_outside(PAct)
 NActHV = NAct.ext_not(NActLV)
+NAct_NWellLV = NAct_NWell.ext_not(ThickGateOx)
 NAct_PWell = NAct.ext_not(NAct_NWell)
 WellContDev = NAct_NWell.ext_interacting_with_text(TEXT_0, "well")
 NAct_NWell_not_Gate = NAct_NWell.ext_not(Gate)
@@ -1514,10 +1728,12 @@ schottky_nbl1 = schottky_nbl1_nw.sized(1.36.um, acute_limit)
 Metal5_slit_MIM_Slt_g_M5_sep_tmp11 = Metal5_slit_MIM_Slt_g_M5_sep_tmp9.dup
 TopMetal1_slit_MIM_Slt_g_TM1_sep_tmp11 = TopMetal1_slit_MIM_Slt_g_TM1_sep_tmp9.dup
 GP_Rsil_extended = GatPoly_res.ext_covering(Rsil)
+PActHV = PAct.ext_not(PActLV)
 PAct_PWell = PAct.ext_not(PAct_NWell)
 Abut_NWell_Tie_Edge = NAct_NWell.ext_coincident_part(PAct_NWell, outside: true)
 MVaricap = PWell_block.ext_and(NWell.sized(1.0.um, acute_limit)).not_outside(GatPoly).not_outside(nBuLay).not_outside(PAct).not_outside(NAct).ext_interacting_with_text(TEXT_0, "MVaricap")
 NActHV_digi = NActHV.not_outside(DigiBnd_hole)
+NAct_NWellHV = NAct_NWell.ext_not(NAct_NWellLV)
 abut_tie_edge_NWell = NAct_NWell_not_Gate.ext_coincident_part(PAct_NWell, outside: true)
 ntaparea = sal_nactive.ext_and(NWell)
 Rhigh_Cont = EXTBlock.ext_covering(Rhigh_a).ext_and(Cont)
@@ -1536,8 +1752,9 @@ schottky_contbar = schottky_nbl1.ext_and(ContBar)
 scr1_or_schottky_nbl1 = schottky_nbl1.ext_or(scr1)
 Metal5_slit_MIM_Slt_g_M5_sep = Metal5_slit_MIM_Slt_g_M5_sep_tmp11.dup
 TopMetal1_slit_MIM_Slt_g_TM1_sep = TopMetal1_slit_MIM_Slt_g_TM1_sep_tmp11.dup
-GP_Rsil_extended_external_pSD = GP_Rsil_extended.ext_fast_separation(pSD, 0.18.um)
+GP_Rsil_extended_external_pSD = GP_Rsil_extended.ext_separation(pSD, 0.18.um)
 SVaricap_text = Activ.not_outside(SVaricap_gate_0).ext_interacting_with_text(TEXT_0, "SVaricap")
+PActHV_digi = PActHV.not_outside(DigiBnd_hole)
 PAct_PWellLV = PAct_PWell.ext_not(ThickGateOx)
 cmim_tie = PAct_PWell.not_outside(rfcmim)
 Abut_PWell_Tie_Edge = PAct_PWell.ext_coincident_part(NAct_PWell, outside: true)
@@ -1545,6 +1762,7 @@ BJT_ring_a = PAct_PWell.with_holes
 PAct_PWell_not_Gate = PAct_PWell.ext_not(Gate)
 Abut_NWell_Tie = NAct_NWell.ext_with_coincident_edges(Abut_NWell_Tie_Edge)
 NActHV_ana = NActHV.ext_not(NActHV_digi)
+NAct_NWellHV_digi = NAct_NWellHV.not_outside(DigiBnd_hole)
 soft_n_tie = n_tie.ext_not(hard_n_tie)
 schottky_nbl1_b = PAct_connect.not_outside(schottky_nbl1).ext_not(schottky_nbl1)
 schottky_nw1 = schottky_nw1_sized.ext_interacting_with_text(TEXT_0, "schottky_nw1")
@@ -1557,10 +1775,12 @@ SubContDev_basic = PAct_PWell.ext_interacting_with_text(TEXT_0, "sub!").ext_not(
 NwellRing_innermost = NWell_Tie.holes.merge.outside(NWell_Tie)
 ntap = ntaparea.ext_covering(Cont.ext_and(ntaparea))
 SVaricap = NWell.not_outside(SVaricap_text)
+PActHV_ana = PActHV.ext_not(PActHV_digi)
 PAct_PWellHV = PAct_PWell.ext_not(PAct_PWellLV)
 Abut_PWell_Tie = PAct_PWell.ext_with_coincident_edges(Abut_PWell_Tie_Edge)
 abut_tie_edge_PWell = PAct_PWell_not_Gate.ext_coincident_part(NAct_PWell, outside: true)
 Abut_NWell_Tie_PAct = PAct.ext_interacting(Abut_NWell_Tie)
+NAct_NWellHV_ana = NAct_NWellHV.ext_not(NAct_NWellHV_digi)
 nsdb_exlcDev = dschottky.ext_or(schottky_nbl1, schottky_nw1, trans_bip)
 schottky_nbl1_or_schottky_nw1 = schottky_nbl1.ext_or(schottky_nw1)
 ThickGateOx_Act_out_ThickGateOx_TGO_b_sep = ThickGateOx_Act_out_ThickGateOx_TGO_b_sep_tmp11.dup
@@ -1575,11 +1795,16 @@ pSD_c_tmp1 = pSD.outside(SVaricap)
 devExclud = Recog_diode.ext_or(SVaricap, nmoscl_2, nmoscl_4, npnMPA, schottky_nbl1, scr1, subst_tie_hole_w_npn, trans_bip)
 SVaricap_or_schottky_nbl1 = SVaricap.ext_or(schottky_nbl1)
 NGate_outside_SVaricap = NGate.outside(SVaricap)
+SVaricap_or_trans_bip = SVaricap.ext_or(trans_bip)
+Cont_PAct_not_SVaricap = Cont_PAct.ext_not(SVaricap)
 PAct_PWellHV_digi = PAct_PWellHV.not_outside(DigiBnd_hole)
 Abut_PWell_Tie_NAct = NAct.ext_interacting(Abut_PWell_Tie)
 Abut_NWell_Tie_Cont = Cont.inside(Abut_NWell_Tie_PAct)
 SVaricap_Tie = PAct_PWell.not_outside(Activ.not_outside(SVaricap))
+lNw_c = PActLV.ext_not(PActLV.ext_interacting(SVaricap))
 NwellRing = NWell_Tie.ext_with_coincident_edges(NwellRing_edge)
+nw_outDev = NAct_NWellHV_ana.outside(SVaricap.ext_or(schottky_nbl1_or_schottky_nw1))
+temp_layer_4 = Cont_SQ.ext_not(SVaricap_or_trans_bip)
 PAct_PWellHV_ana = PAct_PWellHV.ext_not(PAct_PWellHV_digi)
 Abut_PWell_Tie_Cont = Cont.inside(Abut_PWell_Tie_NAct)
 PWell_Tie_w_rf = PAct_PWell.ext_not(Recog_esd.ext_or(SalBlock, SubContDev, SubContDev_iso, cmim_tie, schottky_nbl1, schottky_nbl1_b, schottky_nw1, schottky_nw1_b))
@@ -1606,15 +1831,30 @@ PWell_Tie_wo_varicap_abut = PAct_PWell.ext_interacting(Abut_PWell_Tie.ext_or(BJT
     NWell_NW_a.dup
 end.().output("NW.a", "Min. NWell width = 0.62")
 -&gt; do
-    NWell.ext_fast_separation(NActHV_ana, 0.62.um)
+    lNw_c.ext_enclosed(NWell_Nsram, 0.31.um, consider_overlaps_as_errors: true)
+end.().output("NW.c", "Min. NWell enclosure of P+Activ not inside ThickGateOx = 0.31")
+-&gt; do
+    PActHV_ana.outside(SVaricap_or_schottky_nbl1).ext_enclosed(NWell, 0.62.um, consider_overlaps_as_errors: true)
+end.().output("NW.c1", "Min. NWell enclosure of P+Activ inside ThickGateOx = 0.62")
+-&gt; do
+    NWell_Nsram.ext_separation(NActLV, 0.31.um, consider_overlaps_as_errors: true)
+end.().output("NW.d", "Min. NWell space to external N+Activ not inside ThickGateOx = 0.31")
+-&gt; do
+    NWell.ext_separation(NActHV_ana, 0.62.um)
 end.().output("NW.d1", "Min. NWell space to external N+Activ inside ThickGateOx = 0.62")
+-&gt; do
+    NAct_NWellLV.ext_not(nw_outDev).ext_enclosed(NWell, 0.24.um, consider_overlaps_as_errors: true)
+end.().output("NW.e", "Min. NWell enclosure of NWell tie surrounded entirely by NWell in N+Activ not inside ThickGateOx = 0.24")
+-&gt; do
+    NAct_NWellHV_ana.outside(SVaricap.ext_or(schottky_nbl1, schottky_nw1, scr1)).ext_enclosed(NWell, 0.62.um, consider_overlaps_as_errors: true)
+end.().output("NW.e1", "Min. NWell enclosure of NWell tie surrounded entirely by NWell in N+Activ inside ThickGateOx = 0.62")
 -&gt; (;x, y) do
     x = PAct_PWellLV.ext_coincident_edges(SVaricap, outside: true)
     y = PAct_PWellLV.ext_with_coincident_edges(x)
-    NWell.ext_fast_separation(PAct_PWellLV.ext_not(y), 0.24.um)
+    NWell.ext_separation(PAct_PWellLV.ext_not(y), 0.24.um)
 end.().output("NW.f", "Min. NWell space to substrate tie in P+Activ not inside ThickGateOx = 0.24")
 -&gt; do
-    NWell.ext_fast_separation(PAct_PWellHV_ana.ext_interacting(SVaricap, inverted: true), 0.62.um)
+    NWell.ext_separation(PAct_PWellHV_ana.ext_interacting(SVaricap, inverted: true), 0.62.um)
 end.().output("NW.f1", "Min. NWell space to substrate tie in P+Activ inside ThickGateOx = 0.62")
 -&gt; do
     PWell_block_PWB_a.dup
@@ -1623,7 +1863,7 @@ end.().output("PWB.a", "Min. PWell:block width = 0.62")
     PWell_block_PWB_b.dup
 end.().output("PWB.b", "Min. PWell:block space or notch = 0.62")
 -&gt; do
-    PWellBlock_unrelatedNWell.ext_fast_separation(PWell_block, 0.62.um, consider_touch_points: false, include_min_angle: false)
+    PWellBlock_unrelatedNWell.ext_separation(PWell_block, 0.62.um, consider_touch_points: false, include_min_angle: false)
 end.().output("PWB.c", "Min. PWell:block space to unrelated NWell = 0.62")
 -&gt; do
     nBuLayGen_nBuLay_NBL_a.dup
@@ -1632,20 +1872,23 @@ end.().output("NBL.a", "Min. nBuLay width = 1.00")
     nBuLay_block_NBLB_a.dup
 end.().output("NBLB.a", "Min. nBuLay:block width = 1.50")
 -&gt; do
-    nBuLay_block.ext_fast_space(1.0.um)
+    nBuLay_block.ext_space(1.0.um)
 end.().output("NBLB.b", "Min. nBuLay:block space or notch = 1.00")
 -&gt; do
     nBuLay_nBuLay_block_enc.dup
 end.().output("NBLB.c", "Min. nBuLay enclosure of nBuLay:block = 1.00")
 -&gt; do
-    nBuLay_block.ext_fast_separation(nBuLay, 1.5.um, consider_touch_points: false)
+    nBuLay_block.ext_separation(nBuLay, 1.5.um, consider_touch_points: false)
 end.().output("NBLB.d", "Min. nBuLay:block space to unrelated nBuLay = 1.50")
 -&gt; do
     Activ_Act_a.dup
 end.().output("Act.a", "Min. Activ width = 0.15")
 -&gt; do
-    Act_Nsram.ext_fast_space(0.21.um)
+    Act_Nsram.ext_space(0.21.um)
 end.().output("Act.b", "Min. Activ space or notch = 0.21")
+-&gt; do
+    GatPoly.ext_enclosed(Act_Nsram, 0.23.um, metric: projection)
+end.().output("Act.c", "Min. Activ drain/source extension = 0.23")
 -&gt; do
     Activ_Act_d.dup
 end.().output("Act.d", "Min. Activ area (µm²) = 0.122")
@@ -1658,10 +1901,10 @@ if $filler
 	    Activ_filler.drc((width(projection) &gt; 5.0.um).polygons)
 	end.().output("AFil.a", "Max. Activ:filler width = 5.00")
 	-&gt; do
-	    Activ_filler.ext_fast_width(1.0.um)
+	    Activ_filler.ext_width(1.0.um)
 	end.().output("AFil.a1", "Min. Activ:filler width = 1.00")
 	-&gt; do
-	    Activ_filler.ext_fast_space(0.42.um)
+	    Activ_filler.ext_space(0.42.um)
 	end.().output("AFil.b", "Min. Activ:filler space = 0.42")
 end
 
@@ -1681,14 +1924,21 @@ if $density
 	end.().output("AFil.g3", "Max. Activ coverage ratio for any 800 x 800 µm² chip area [%] = 65.00")
 end
 
+
+if $filler
+	-&gt; do
+	    Activ_filler.outside(PWell_block).ext_separation(PWell_block, 1.5.um, min_angle: 90, max_angle: 180, include_min_angle: false)
+	end.().output("AFil.i", "Min. Activ:filler space to edges of PWell:block = 1.50")
+end
+
 -&gt; do
-    Activ.ext_fast_enclosed(ThickGateOx, 0.27.um, polygon_output: true)
+    Activ.ext_enclosed(ThickGateOx, 0.27.um)
 end.().output("TGO.a", "Min. ThickGateOx extension over Activ = 0.27")
 -&gt; do
     ThickGateOx_Act_out_ThickGateOx_TGO_b_sep.dup
 end.().output("TGO.b", "Min. space between ThickGateOx and Activ outside thick gate oxide region = 0.27")
 -&gt; (;a) do
-    a = Gate.ext_fast_enclosed(ThickGateOx, 0.34.um, polygon_output: true)
+    a = Gate.ext_enclosed(ThickGateOx, 0.34.um, include_min_angle: false, polygon_output: true)
     a.ext_and(Activ)
 end.().output("TGO.c", "Min. ThickGateOx extension over GatPoly over Activ = 0.34")
 -&gt; do
@@ -1704,11 +1954,11 @@ end.().output("TGO.f", "Min. ThickGateOx width = 0.86")
     GP_Nsram_Gat_a.dup
 end.().output("Gat.a", "Min. GatPoly width = 0.13")
 -&gt; (;a) do
-    a = Activ.ext_not(nmosHV).ext_interacting(nmosHV).ext_fast_space(0.45.um, metric: projection, consider_touch_points: false, include_max_angle: true, polygon_output: true)
+    a = Activ.ext_not(nmosHV).ext_interacting(nmosHV).ext_space(0.45.um, metric: projection, consider_touch_points: false, polygon_output: true)
     a.ext_and(Activ).outside(nmoscl.ext_or(scr1))
 end.().output("Gat.a3", "Min. GatPoly width for channel length of 3.3 V NFET = 0.45")
 -&gt; (;b) do
-    b = Activ.ext_not(pmosHV).ext_interacting(pmosHV).ext_fast_space(0.4.um, metric: projection, consider_touch_points: false, include_max_angle: true, polygon_output: true)
+    b = Activ.ext_not(pmosHV).ext_interacting(pmosHV).ext_space(0.4.um, metric: projection, consider_touch_points: false, polygon_output: true)
     b.ext_and(Activ)
 end.().output("Gat.a4", "Min. GatPoly width for channel length of 3.3 V PFET = 0.4")
 -&gt; do
@@ -1718,13 +1968,13 @@ end.().output("Gat.b", "Min. GatPoly space or notch = 0.18")
     GP_mosHV_Gat_b1.dup
 end.().output("Gat.b1", "Min. space between unrelated 3.3 V GatPoly over Activ regions = 0.25")
 -&gt; do
-    [ Activ.ext_fast_enclosed(GP_Nsram, 0.18.um, polygon_output: true),
-      Activ.ext_fast_enclosed(GatPoly_filler, 0.18.um, polygon_output: true),
+    [ Activ.ext_enclosed(GP_Nsram, 0.18.um),
+      Activ.ext_enclosed(GatPoly_filler, 0.18.um),
       GatPoly.inside(Activ)
     ].each { |result| result.output("Gat.c", "Min. GatPoly extension over Activ (end cap) = 0.18") }
 end.()
 -&gt; do
-    GP_Nsram.ext_fast_separation(Act_Nsram, 0.07.um)
+    GP_Nsram.ext_separation(Act_Nsram, 0.07.um)
 end.().output("Gat.d", "Min. GatPoly space to Activ = 0.07")
 -&gt; do
     GatPoly_Gat_e.dup
@@ -1738,31 +1988,31 @@ if $filler
 	    GatPoly_filler.drc((width(projection) &gt; 5.0.um).polygons)
 	end.().output("GFil.a", "Max. GatPoly:filler width = 5.00")
 	-&gt; do
-	    GatPoly_filler.ext_fast_width(0.7.um, consider_touch_points: false)
+	    GatPoly_filler.ext_width(0.7.um, consider_touch_points: false)
 	end.().output("GFil.b", "Min. GatPoly:filler width = 0.70")
 	-&gt; do
-	    GatPoly_filler.ext_fast_space(0.8.um)
+	    GatPoly_filler.ext_space(0.8.um)
 	end.().output("GFil.c", "Min. GatPoly:filler space = 0.80")
 	-&gt; do
-	    Activ.ext_fast_separation(GatPoly_filler, 1.1.um, max_angle: 180)
+	    Activ.ext_separation(GatPoly_filler, 1.1.um, max_angle: 180)
 	end.().output("GFil.d.Activ", "Min. GatPoly:filler space to Activ = 1.10")
 	-&gt; do
-	    GatPoly.ext_fast_separation(GatPoly_filler, 1.1.um, max_angle: 180)
+	    GatPoly.ext_separation(GatPoly_filler, 1.1.um, max_angle: 180)
 	end.().output("GFil.d.GatPoly", "Min. GatPoly:filler space to GatPoly = 1.10")
 	-&gt; do
-	    Cont.ext_fast_separation(GatPoly_filler, 1.1.um, max_angle: 180)
+	    Cont.ext_separation(GatPoly_filler, 1.1.um, max_angle: 180)
 	end.().output("GFil.d.Cont", "Min. GatPoly:filler space to Cont = 1.10")
 	-&gt; do
-	    pSD.ext_fast_separation(GatPoly_filler, 1.1.um, max_angle: 180)
+	    pSD.ext_separation(GatPoly_filler, 1.1.um, max_angle: 180)
 	end.().output("GFil.d.pSD", "Min. GatPoly:filler space to pSD = 1.10")
 	-&gt; do
-	    nSD_block.ext_fast_separation(GatPoly_filler, 1.1.um, max_angle: 180)
+	    nSD_block.ext_separation(GatPoly_filler, 1.1.um, max_angle: 180)
 	end.().output("GFil.d.nSD_block", "Min. GatPoly:filler space to nSD:block = 1.10")
 	-&gt; do
-	    SalBlock.ext_fast_separation(GatPoly_filler, 1.1.um, max_angle: 180)
+	    SalBlock.ext_separation(GatPoly_filler, 1.1.um, max_angle: 180)
 	end.().output("GFil.d.SalBlock", "Min. GatPoly:filler space to SalBlock = 1.10")
 	-&gt; do
-	    GatPoly_filler.ext_fast_separation(TRANS, 1.1.um)
+	    GatPoly_filler.ext_separation(TRANS, 1.1.um)
 	end.().output("GFil.f", "Min. GatPoly:filler space to TRANS = 1.10")
 end
 
@@ -1776,7 +2026,7 @@ end
 
 if $filler
 	-&gt; do
-	    GatPoly_nofill.ext_fast_space(20.um)
+	    GatPoly_nofill.ext_space(18.um)
 	end.().output("GFil.j", "Min. GatPoly:filler extension over Activ:filler (end cap) = 0.18")
 end
 
@@ -1784,27 +2034,27 @@ end
     pSD_pSD_a.dup
 end.().output("pSD.a", "Min. pSD width = 0.31")
 -&gt; do
-    pSD.ext_fast_space(0.31.um)
+    pSD.ext_space(0.31.um)
 end.().output("pSD.b", "Min. pSD space or notch (Note 1) = 0.31")
 -&gt; do
-    Act_NWell.ext_fast_enclosed(pSD_c_tmp1, 0.18.um, polygon_output: true)
+    Act_NWell.ext_enclosed(pSD_c_tmp1, 0.18.um)
 end.().output("pSD.c", "Min. pSD enclosure of P+Activ in NWell = 0.18")
 -&gt; do
-    pSD.ext_fast_separation(NAct_PWell, 0.18.um, consider_intersecting_edges: false)
+    pSD.ext_separation(NAct_PWell, 0.18.um, consider_intersecting_edges: false)
 end.().output("pSD.d", "Min. pSD space to unrelated N+Activ in PWell = 0.18")
 -&gt; do
-    pSD.ext_fast_separation(NAct_NWell, 0.03.um, consider_intersecting_edges: false)
+    pSD.ext_separation(NAct_NWell, 0.03.um, consider_intersecting_edges: false)
 end.().output("pSD.d1", "Min. pSD space to N+Activ in NWell = 0.03")
 -&gt; (;layA, layB, layC, layD) do
     layA = Act_Nsram.not_inside(pSD).ext_interacting(pSD)
     layB = layA.ext_and(pSD).outside(SVaricap)
-    layC = layB.ext_fast_width(0.3.um, metric: projection, consider_intersecting_edges: false, consider_touch_points: false, polygon_output: true)
+    layC = layB.ext_width(0.3.um, metric: projection, consider_intersecting_edges: false, consider_touch_points: false, polygon_output: true)
     layD = layC.ext_covering(layB)
     layD.dup
 end.().output("pSD.e", "Min. pSD overlap of Activ at one position when forming abutted substrate tie (Note 2) = 0.30")
 -&gt; (;abuttedNTAP, bad_region, good_region) do
     abuttedNTAP = NAct_NWell.ext_interacting(PAct_NWell)
-    bad_region = abuttedNTAP.ext_coincident_part(PAct_NWell, outside: true).ext_fast_overlap(NAct_NWell, 0.3.um, metric: projection, consider_intersecting_edges: false, consider_touch_points: false, polygon_output: true)
+    bad_region = abuttedNTAP.ext_coincident_part(PAct_NWell, outside: true).ext_overlap(NAct_NWell, 0.3.um, metric: projection, consider_intersecting_edges: false, consider_touch_points: false, polygon_output: true)
     good_region = abuttedNTAP.ext_not(bad_region)
     abuttedNTAP.outside(good_region)
 end.().output("pSD.f", "Min. Activ extension over pSD at one position when forming abutted NWell tie (Note 2) = 0.30")
@@ -1816,16 +2066,16 @@ end.().output("pSD.f", "Min. Activ extension over pSD at one position when formi
     ].each { |result| result.output("pSD.g", "Min. N+Activ or P+Activ area (µm²) when forming abutted tie (Note 2) = 0.09") }
 end.()
 -&gt; do
-    PGate.ext_fast_enclosed(pSD_Nsram, 0.3.um, polygon_output: true)
+    PGate.ext_enclosed(pSD_Nsram, 0.3.um)
 end.().output("pSD.i", "Min. pSD enclosure of PFET gate not inside ThickGateOx = 0.30")
 -&gt; do
-    PGate.ext_fast_enclosed(pSDHV_Nsram, 0.4.um, polygon_output: true)
+    PGate.ext_enclosed(pSDHV_Nsram, 0.4.um)
 end.().output("pSD.i1", "Min. pSD enclosure of PFET gate inside ThickGateOx = 0.40")
 -&gt; do
-    pSD_Nsram.ext_fast_separation(NGate_outside_SVaricap, 0.3.um)
+    pSD_Nsram.ext_separation(NGate_outside_SVaricap, 0.3.um)
 end.().output("pSD.j", "Min. pSD space to NFET gate not inside ThickGateOx = 0.30")
 -&gt; do
-    pSD_Nsram.ext_fast_separation(NGate_outside_SVaricap.inside(ThickGateOx), 0.4.um)
+    pSD_Nsram.ext_separation(NGate_outside_SVaricap.inside(ThickGateOx), 0.4.um)
 end.().output("pSD.j1", "Min. pSD space to NFET gate inside ThickGateOx = 0.40")
 -&gt; do
     pSD_pSD_k.dup
@@ -1840,50 +2090,50 @@ end.().output("pSD.m", "Min. pSD space to n-type poly resistors = 0.18")
     Rppd_all_enclosure_pSD.dup
 end.().output("pSD.n", "Min. pSD enclosure of p-type poly resistors = 0.18")
 -&gt; do
-    nSD_block.ext_fast_width(0.31.um)
+    nSD_block.ext_width(0.31.um)
 end.().output("nSDB.a", "Min. nSD:block width = 0.31")
 -&gt; do
-    nSD_block.ext_fast_space(0.31.um)
+    nSD_block.ext_space(0.31.um)
 end.().output("nSDB.b", "Min. nSD:block space or notch = 0.31")
 -&gt; do
-    nSD_block.ext_fast_separation(pSD.ext_interacting(nSD_block, inverted: true), 0.31.um, consider_touch_points: false)
+    nSD_block.ext_separation(pSD.ext_interacting(nSD_block, inverted: true), 0.31.um, consider_touch_points: false)
 end.().output("nSDB.c", "Min. nSD:block space to unrelated pSD = 0.31")
 -&gt; do
     Cont.outside(nsdb_exlcDev).ext_and(nSD_block)
 end.().output("nSDB.e", "Min. nSD:block space to Cont (Note 2) = 0.00")
 -&gt; do
-    EXTBlock.ext_fast_width(0.31.um)
+    EXTBlock.ext_width(0.31.um)
 end.().output("EXT.a", "Min. EXTBlock width = 0.31")
 -&gt; do
-    EXTBlock.ext_fast_space(0.31.um)
+    EXTBlock.ext_space(0.31.um)
 end.().output("EXT.b", "Min. EXTBlock space or notch = 0.31")
 -&gt; do
-    EXTBlock.ext_fast_separation(pSD, 0.31.um)
+    EXTBlock.ext_separation(pSD, 0.31.um)
 end.().output("EXT.c", "Min. EXTBlock space to pSD = 0.31")
 -&gt; do
-    SalBlock.ext_fast_width(0.42.um)
+    SalBlock.ext_width(0.42.um)
 end.().output("Sal.a", "Min. SalBlock width = 0.42")
 -&gt; do
-    SalBlock.ext_fast_space(0.42.um)
+    SalBlock.ext_space(0.42.um)
 end.().output("Sal.b", "Min. SalBlock space or notch = 0.42")
 -&gt; do
-    [ GatPoly_res.ext_fast_enclosed(SalBlock, 0.2.um, polygon_output: true),
-      Activ.ext_fast_enclosed(SalBlock, 0.2.um, polygon_output: true)
+    [ GatPoly_res.ext_enclosed(SalBlock, 0.2.um),
+      Activ.ext_enclosed(SalBlock, 0.2.um)
     ].each { |result| result.output("Sal.c", "Min. SalBlock extension over Activ or GatPoly = 0.20") }
 end.()
 -&gt; do
-    [ SalBlock.ext_fast_separation(GatPoly_res, 0.2.um, consider_touch_points: false),
-      SalBlock.ext_fast_separation(nmosi_relevant_activ, 0.2.um, consider_touch_points: false)
+    [ SalBlock.ext_separation(GatPoly_res, 0.2.um, consider_touch_points: false),
+      SalBlock.ext_separation(nmosi_relevant_activ, 0.2.um, consider_touch_points: false)
     ].each { |result| result.output("Sal.d", "Min. SalBlock space to unrelated Activ or GatPoly = 0.20") }
 end.()
 -&gt; do
-    SalBlock.ext_fast_separation(Cont, 0.2.um)
+    SalBlock.ext_separation(Cont, 0.2.um)
 end.().output("Sal.e", "Min. SalBlock space to Cont = 0.20")
 -&gt; do
     Cont_outside_EdgeSeal.ext_not(ContBar.ext_or(Cont_SQ))
 end.().output("Cnt.a", "Min. and max. Cont width = 0.16")
 -&gt; do
-    Cont_outside_EdgeSeal.ext_fast_space(0.18.um, consider_intersecting_edges: false)
+    Cont_outside_EdgeSeal.ext_space(0.18.um, consider_intersecting_edges: false)
 end.().output("Cnt.b", "Min. Cont space = 0.18")
 -&gt; (;x1, viaLargeArray, viaInLargeArray, viaInLargeArray_error, badViaLine) do
     x1 = Cont.sized((0.20*0.5).um, acute_limit).sized(-(0.20*0.5).um, acute_limit)
@@ -1894,11 +2144,26 @@ end.().output("Cnt.b", "Min. Cont space = 0.18")
     badViaLine.ext_rectangles(inverted: true)
 end.().output("Cnt.b1", "Min. Cont space in a contact array of more than 4 rows and more then 4 columns (Note 1) = 0.20")
 -&gt; do
-    Cont_Act.ext_not(SVaricap).ext_fast_separation(GP_Nsram, 0.11.um)
+    temp_layer_4.ext_enclosed(Act_Nsram_or_Activ_mask.ext_not(DigiBnd), 0.07.um, consider_overlaps_as_errors: true)
+end.().output("Cnt.c", "Min. Activ enclosure of Cont = 0.07")
+-&gt; do
+    Cont_SQ.ext_enclosed(GP_Nsram, 0.07.um, consider_overlaps_as_errors: true)
+end.().output("Cnt.d", "Min. GatPoly enclosure of Cont = 0.07")
+-&gt; do
+    Cont_GP.ext_not(SVaricap).ext_separation(Activ, 0.14.um, consider_intersecting_edges: false, consider_touch_points: false)
+end.().output("Cnt.e", "Min. Cont on GatPoly space to Activ = 0.14")
+-&gt; do
+    Cont_Act.ext_not(SVaricap).ext_separation(GP_Nsram, 0.11.um)
 end.().output("Cnt.f", "Min. Cont on Activ space to GatPoly = 0.11")
 -&gt; do
     Cont_not_Act_GP.dup
 end.().output("Cnt.g", "Cont must be within Activ or GatPoly")
+-&gt; do
+    pSD.ext_separation(Cont_NAct.ext_not(SVaricap), 0.09.um, consider_intersecting_edges: false, consider_touch_points: false)
+end.().output("Cnt.g1", "Min. pSD space to Cont on nSD-Activ = 0.09")
+-&gt; do
+    Cont_PAct_not_SVaricap.ext_enclosed(pSD_Nsram, 0.09.um, consider_intersecting_edges: false, consider_touch_points: false)
+end.().output("Cnt.g2", "Min. pSD overlap of Cont on pSD-Activ = 0.09")
 -&gt; do
     Cont_not_M1.dup
 end.().output("Cnt.h", "Cont must be covered with Metal1")
@@ -1906,7 +2171,7 @@ end.().output("Cnt.h", "Cont must be covered with Metal1")
     Cont_Act_GP.ext_not(SVaricap)
 end.().output("Cnt.j", "Cont on GatPoly over Activ is not allowed")
 -&gt; do
-    [ ContBar.outside(EdgeSeal).ext_not(schottky_nbl1_or_schottky_nw1).ext_fast_width(0.16.um),
+    [ ContBar.outside(EdgeSeal).ext_not(schottky_nbl1_or_schottky_nw1).ext_width(0.16.um),
       Cont_outside_EdgeSeal.ext_not(schottky_nbl1_or_schottky_nw1).drc((width(projection) &gt; 0.16.um).polygons)
     ].each { |result| result.output("CntB.a", "Min. and max. ContBar width = 0.16") }
 end.()
@@ -1914,25 +2179,31 @@ end.()
     CntB_a1_error.dup
 end.().output("CntB.a1", "Min. ContBar length = 0.34")
 -&gt; do
-    ContBar_outside_TRANS.ext_fast_space(0.28.um)
+    ContBar_outside_TRANS.ext_space(0.28.um)
 end.().output("CntB.b", "Min. ContBar space = 0.28")
 -&gt; do
-    ContBar.ext_fast_separation(Cont_SQ, 0.22.um)
+    ContBar.ext_separation(Cont_SQ, 0.22.um)
 end.().output("CntB.b2", "Min. ContBar space to Cont = 0.22")
 -&gt; do
-    ContBar_GP.ext_fast_separation(Activ, 0.14.um)
+    ContBar.outside(trans_bip).ext_enclosed(nmosi_relevant_activ, 0.07.um, consider_overlaps_as_errors: true)
+end.().output("CntB.c", "Min. Activ enclosure of ContBar = 0.07")
+-&gt; do
+    ContBar.ext_enclosed(GatPoly, 0.07.um, consider_overlaps_as_errors: true)
+end.().output("CntB.d", "Min. GatPoly enclosure of ContBar = 0.07")
+-&gt; do
+    ContBar_GP.ext_separation(Activ, 0.14.um)
 end.().output("CntB.e", "Min. ContBar on GatPoly space to Activ = 0.14")
 -&gt; do
-    ContBar_Act.ext_fast_separation(GatPoly, 0.11.um)
+    ContBar_Act.ext_separation(GatPoly, 0.11.um)
 end.().output("CntB.f", "Min. ContBar on Activ space to GatPoly = 0.11")
 -&gt; do
     ContBar_not_Act_GP.dup
 end.().output("CntB.g", "ContBar must be within Activ or GatPoly")
 -&gt; do
-    pSD.ext_fast_separation(ContBar_NAct, 0.09.um, max_angle: 0, include_max_angle: true, polygon_output: true)
+    pSD.ext_separation(ContBar_NAct, 0.09.um, max_angle: 0, include_max_angle: true, polygon_output: true)
 end.().output("CntB.g1", "Min. pSD space to ContBar on nSD-Activ = 0.09")
 -&gt; do
-    ContBar_PAct.ext_fast_enclosed(pSD, 0.09.um, polygon_output: true)
+    ContBar_PAct.ext_enclosed(pSD, 0.09.um)
 end.().output("CntB.g2", "Min. pSD overlap of ContBar on pSD-Activ = 0.09")
 -&gt; do
     ContBar_not_M1.dup
@@ -1941,10 +2212,10 @@ end.().output("CntB.h", "ContBar must be covered with Metal1")
     ContBar_Act_GP.dup
 end.().output("CntB.j", "ContBar on GatPoly over Activ is not allowed")
 -&gt; do
-    Metal1.ext_fast_width(0.16.um)
+    Metal1.ext_width(0.16.um)
 end.().output("M1.a", "Min. Metal1 width = 0.16")
 -&gt; do
-    M1_Nsram.ext_fast_space(0.18.um, consider_intersecting_edges: false, ignore_non_axis_aligned_edges: true)
+    M1_Nsram.ext_space(0.18.um, consider_intersecting_edges: false, ignore_non_axis_aligned_edges: true)
 end.().output("M1.b", "Min. Metal1 space or notch = 0.18")
 -&gt; do
     Cont_Nsram.ext_not(M1_Nsram)
@@ -1969,13 +2240,13 @@ if $density
 end
 
 -&gt; do
-    Metal2.ext_fast_width(0.2.um)
+    Metal2.ext_width(0.2.um)
 end.().output("M2.a", "Min. Metal2 width = 0.20")
 -&gt; do
-    M2_Nsram.ext_fast_space(0.21.um, consider_intersecting_edges: false, ignore_non_axis_aligned_edges: true)
+    M2_Nsram.ext_space(0.21.um, consider_intersecting_edges: false, ignore_non_axis_aligned_edges: true)
 end.().output("M2.b", "Min. Metal2 space or notch = 0.21")
 -&gt; do
-    Via1.outside(EdgeSeal).ext_fast_enclosed(Metal2_outside_EdgeSeal, 0.005.um, polygon_output: true)
+    Via1.outside(EdgeSeal).ext_enclosed(Metal2_outside_EdgeSeal, 0.005.um, max_angle: 180)
 end.().output("M2.c", "Min. Metal2 enclosure of Via1 = 0.005")
 -&gt; do
     V1_Nsram_outside_EdgeSeal.drc(if_any(
@@ -1997,13 +2268,13 @@ if $density
 end
 
 -&gt; do
-    Metal3.ext_fast_width(0.2.um)
+    Metal3.ext_width(0.2.um)
 end.().output("M3.a", "Min. Metal3 width = 0.20")
 -&gt; do
-    M3_Nsram.ext_fast_space(0.21.um, consider_intersecting_edges: false, ignore_non_axis_aligned_edges: true)
+    M3_Nsram.ext_space(0.21.um, consider_intersecting_edges: false, ignore_non_axis_aligned_edges: true)
 end.().output("M3.b", "Min. Metal3 space or notch = 0.21")
 -&gt; do
-    Via2.outside(EdgeSeal).ext_fast_enclosed(Metal3_outside_EdgeSeal, 0.005.um, polygon_output: true)
+    Via2.outside(EdgeSeal).ext_enclosed(Metal3_outside_EdgeSeal, 0.005.um, max_angle: 180)
 end.().output("M3.c", "Min. Metal3 enclosure of Via2 = 0.005")
 -&gt; do
     V2_Nsram_outside_EdgeSeal.drc(if_any(
@@ -2025,13 +2296,13 @@ if $density
 end
 
 -&gt; do
-    Metal4.ext_fast_width(0.2.um)
+    Metal4.ext_width(0.2.um)
 end.().output("M4.a", "Min. Metal4 width = 0.20")
 -&gt; do
-    M4_Nsram.ext_fast_space(0.21.um, consider_intersecting_edges: false, ignore_non_axis_aligned_edges: true)
+    M4_Nsram.ext_space(0.21.um, consider_intersecting_edges: false, ignore_non_axis_aligned_edges: true)
 end.().output("M4.b", "Min. Metal4 space or notch = 0.21")
 -&gt; do
-    Via3.outside(EdgeSeal).ext_fast_enclosed(Metal4_outside_EdgeSeal, 0.005.um, polygon_output: true)
+    Via3.outside(EdgeSeal).ext_enclosed(Metal4_outside_EdgeSeal, 0.005.um, max_angle: 180)
 end.().output("M4.c", "Min. Metal4 enclosure of Via3 = 0.005")
 -&gt; do
     V3_Nsram_outside_EdgeSeal.drc(if_any(
@@ -2053,13 +2324,13 @@ if $density
 end
 
 -&gt; do
-    Metal5.ext_fast_width(0.2.um)
+    Metal5.ext_width(0.2.um)
 end.().output("M5.a", "Min. Metal5 width = 0.20")
 -&gt; do
-    M5_Nsram.ext_fast_space(0.21.um, consider_intersecting_edges: false, ignore_non_axis_aligned_edges: true)
+    M5_Nsram.ext_space(0.21.um, consider_intersecting_edges: false, ignore_non_axis_aligned_edges: true)
 end.().output("M5.b", "Min. Metal5 space or notch = 0.21")
 -&gt; do
-    Via4.outside(EdgeSeal).ext_fast_enclosed(Metal5_outside_EdgeSeal, 0.005.um, polygon_output: true)
+    Via4.outside(EdgeSeal).ext_enclosed(Metal5_outside_EdgeSeal, 0.005.um, max_angle: 180)
 end.().output("M5.c", "Min. Metal5 enclosure of Via4 = 0.005")
 -&gt; do
     V4_Nsram_outside_EdgeSeal.drc(if_any(
@@ -2083,16 +2354,16 @@ end
 
 if $filler
 	-&gt; do
-	    Metal1_filler.ext_fast_width(1.0.um)
+	    Metal1_filler.ext_width(1.0.um)
 	end.().output("M1Fil.a1", "Min. Metal1:filler width = 1.00")
 	-&gt; do
-	    Metal1_filler.ext_fast_space(0.6.um)
+	    Metal1_filler.ext_space(0.42.um)
 	end.().output("M1Fil.b", "Min. Metal1:filler space = 0.42")
 	-&gt; do
-	    Metal1_filler.ext_fast_separation(Metal1, 0.42.um)
+	    Metal1_filler.ext_separation(Metal1, 0.42.um)
 	end.().output("M1Fil.c", "Min. Metal1:filler space to Metal1 = 0.42")
 	-&gt; do
-	    Metal1_filler.ext_fast_separation(TRANS, 1.0.um)
+	    Metal1_filler.ext_separation(TRANS, 1.0.um)
 	end.().output("M1Fil.d", "Min. Metal1:filler space to TRANS = 1.00")
 end
 
@@ -2109,16 +2380,16 @@ end
 
 if $filler
 	-&gt; do
-	    Metal2_filler.ext_fast_width(1.0.um)
+	    Metal2_filler.ext_width(1.0.um)
 	end.().output("M2Fil.a1", "Min. Metal2:filler width = 1.00")
 	-&gt; do
-	    Metal2_filler.ext_fast_space(0.6.um)
+	    Metal2_filler.ext_space(0.42.um)
 	end.().output("M2Fil.b", "Min. Metal2:filler space = 0.42")
 	-&gt; do
-	    Metal2_filler.ext_fast_separation(Metal2, 0.42.um)
+	    Metal2_filler.ext_separation(Metal2, 0.42.um)
 	end.().output("M2Fil.c", "Min. Metal2:filler space to Metal2 = 0.42")
 	-&gt; do
-	    Metal2_filler.ext_fast_separation(TRANS, 1.0.um)
+	    Metal2_filler.ext_separation(TRANS, 1.0.um)
 	end.().output("M2Fil.d", "Min. Metal2:filler space to TRANS = 1.00")
 end
 
@@ -2135,16 +2406,16 @@ end
 
 if $filler
 	-&gt; do
-	    Metal3_filler.ext_fast_width(1.0.um)
+	    Metal3_filler.ext_width(1.0.um)
 	end.().output("M3Fil.a1", "Min. Metal3:filler width = 1.00")
 	-&gt; do
-	    Metal3_filler.ext_fast_space(0.6.um)
+	    Metal3_filler.ext_space(0.42.um)
 	end.().output("M3Fil.b", "Min. Metal3:filler space = 0.42")
 	-&gt; do
-	    Metal3_filler.ext_fast_separation(Metal3, 0.42.um)
+	    Metal3_filler.ext_separation(Metal3, 0.42.um)
 	end.().output("M3Fil.c", "Min. Metal3:filler space to Metal3 = 0.42")
 	-&gt; do
-	    Metal3_filler.ext_fast_separation(TRANS, 1.0.um)
+	    Metal3_filler.ext_separation(TRANS, 1.0.um)
 	end.().output("M3Fil.d", "Min. Metal3:filler space to TRANS = 1.00")
 end
 
@@ -2161,16 +2432,16 @@ end
 
 if $filler
 	-&gt; do
-	    Metal4_filler.ext_fast_width(1.0.um)
+	    Metal4_filler.ext_width(1.0.um)
 	end.().output("M4Fil.a1", "Min. Metal4:filler width = 1.00")
 	-&gt; do
-	    Metal4_filler.ext_fast_space(0.6.um)
+	    Metal4_filler.ext_space(0.42.um)
 	end.().output("M4Fil.b", "Min. Metal4:filler space = 0.42")
 	-&gt; do
-	    Metal4_filler.ext_fast_separation(Metal4, 0.42.um)
+	    Metal4_filler.ext_separation(Metal4, 0.42.um)
 	end.().output("M4Fil.c", "Min. Metal4:filler space to Metal4 = 0.42")
 	-&gt; do
-	    Metal4_filler.ext_fast_separation(TRANS, 1.0.um)
+	    Metal4_filler.ext_separation(TRANS, 1.0.um)
 	end.().output("M4Fil.d", "Min. Metal4:filler space to TRANS = 1.00")
 end
 
@@ -2187,16 +2458,16 @@ end
 
 if $filler
 	-&gt; do
-	    Metal5_filler.ext_fast_width(1.0.um)
+	    Metal5_filler.ext_width(1.0.um)
 	end.().output("M5Fil.a1", "Min. Metal5:filler width = 1.00")
 	-&gt; do
-	    Metal5_filler.ext_fast_space(0.6.um)
+	    Metal5_filler.ext_space(0.42.um)
 	end.().output("M5Fil.b", "Min. Metal5:filler space = 0.42")
 	-&gt; do
-	    Metal5_filler.ext_fast_separation(Metal5, 0.42.um)
+	    Metal5_filler.ext_separation(Metal5, 0.42.um)
 	end.().output("M5Fil.c", "Min. Metal5:filler space to Metal5 = 0.42")
 	-&gt; do
-	    Metal5_filler.ext_fast_separation(TRANS, 1.0.um)
+	    Metal5_filler.ext_separation(TRANS, 1.0.um)
 	end.().output("M5Fil.d", "Min. Metal5:filler space to TRANS = 1.00")
 end
 
@@ -2214,7 +2485,7 @@ end
     Via1_edgC1_out.outside(transG2L).ext_rectangles(false, false, [["==", 0.19.um]], [["==", 0.19.um]], nil, inverted: true)
 end.().output("V1.a", "Min. and max. Via1 width = 0.19")
 -&gt; do
-    Via1_edgC1_out.ext_fast_space(0.22.um, consider_intersecting_edges: false)
+    Via1_edgC1_out.ext_space(0.22.um, consider_intersecting_edges: false)
 end.().output("V1.b", "Min. Via1 space = 0.22")
 -&gt; (;via1NoES, x1, via1Array, via1In, via1BigArray, via1SepErr_1, via1SepErr_2) do
     via1NoES = Via1_edgC1_out.dup
@@ -2237,7 +2508,7 @@ end.().output("V1.c1", "Min. Metal1 endcap enclosure of Via1 (Note 2) = 0.05")
     Via2_edgC1_out.outside(transG2L).ext_rectangles(false, false, [["==", 0.19.um]], [["==", 0.19.um]], nil, inverted: true)
 end.().output("V2.a", "Min. and max. Via2 width = 0.19")
 -&gt; do
-    Via2_edgC1_out.ext_fast_space(0.22.um, consider_intersecting_edges: false)
+    Via2_edgC1_out.ext_space(0.22.um, consider_intersecting_edges: false)
 end.().output("V2.b", "Min. Via2 space = 0.22")
 -&gt; (;via2NoES, x1, via2Array, via2In, via2BigArray, via2SepErr_1, via2SepErr_2) do
     via2NoES = Via2_edgC1_out.dup
@@ -2260,7 +2531,7 @@ end.().output("V2.c1", "Min. Metal2 endcap enclosure of Via2 (Note 2) = 0.05")
     Via3_edgC1_out.outside(transG2L).ext_rectangles(false, false, [["==", 0.19.um]], [["==", 0.19.um]], nil, inverted: true)
 end.().output("V3.a", "Min. and max. Via3 width = 0.19")
 -&gt; do
-    Via3_edgC1_out.ext_fast_space(0.22.um, consider_intersecting_edges: false)
+    Via3_edgC1_out.ext_space(0.22.um, consider_intersecting_edges: false)
 end.().output("V3.b", "Min. Via3 space = 0.22")
 -&gt; (;via3NoES, x1, via3Array, via3In, via3BigArray, via3SepErr_1, via3SepErr_2) do
     via3NoES = Via3_edgC1_out.dup
@@ -2283,7 +2554,7 @@ end.().output("V3.c1", "Min. Metal3 endcap enclosure of Via3 (Note 2) = 0.05")
     Via4_edgC1_out.outside(transG2L).ext_rectangles(false, false, [["==", 0.19.um]], [["==", 0.19.um]], nil, inverted: true)
 end.().output("V4.a", "Min. and max. Via4 width = 0.19")
 -&gt; do
-    Via4_edgC1_out.ext_fast_space(0.22.um, consider_intersecting_edges: false)
+    Via4_edgC1_out.ext_space(0.22.um, consider_intersecting_edges: false)
 end.().output("V4.b", "Min. Via4 space = 0.22")
 -&gt; (;via4NoES, x1, via4Array, via4In, via4BigArray, via4SepErr_1, via4SepErr_2) do
     via4NoES = Via4_edgC1_out.dup
@@ -2306,13 +2577,13 @@ end.().output("V4.c1", "Min. Metal4 endcap enclosure of Via4 (Note 2) = 0.05")
     TopVia1_edgC1_out.ext_or(Vmim).ext_rectangles(false, false, [["==", 0.42.um]], [["==", 0.42.um]], nil, inverted: true)
 end.().output("TV1.a", "Min. and max. TopVia1 width = 0.42")
 -&gt; do
-    TopVia1_or_Vmim.ext_fast_space(0.42.um)
+    TopVia1_or_Vmim.ext_space(0.42.um)
 end.().output("TV1.b", "Min. TopVia1 space = 0.42")
 -&gt; do
-    TopMetal1.ext_fast_width(1.64.um)
+    TopMetal1.ext_width(1.64.um)
 end.().output("TM1.a", "Min. TopMetal1 width = 1.64")
 -&gt; do
-    TopMetal1.ext_fast_space(1.64.um)
+    TopMetal1.ext_space(1.64.um)
 end.().output("TM1.b", "Min. TopMetal1 space or notch = 1.64")
 
 if $density
@@ -2327,16 +2598,16 @@ end
 
 if $filler
 	-&gt; do
-	    TopMetal1_filler.ext_fast_width(5.0.um)
+	    TopMetal1_filler.ext_width(5.0.um)
 	end.().output("TM1Fil.a", "Min. TopMetal1:filler width = 5.00")
 	-&gt; do
-	    TopMetal1_filler.ext_fast_space(3.0.um)
+	    TopMetal1_filler.ext_space(3.0.um)
 	end.().output("TM1Fil.b", "Min. TopMetal1:filler space = 3.00")
 	-&gt; do
-	    TopMetal1_filler.ext_fast_separation(TopMetal1, 3.0.um)
+	    TopMetal1_filler.ext_separation(TopMetal1, 3.0.um)
 	end.().output("TM1Fil.c", "Min. TopMetal1:filler space to TopMetal1 = 3.00")
 	-&gt; do
-	    TopMetal1_filler.ext_fast_separation(TRANS, 4.9.um)
+	    TopMetal1_filler.ext_separation(TRANS, 4.9.um)
 	end.().output("TM1Fil.d", "Min. TopMetal1:filler space to TRANS = 4.90")
 end
 
@@ -2344,13 +2615,13 @@ end
     TopVia2_edgC1_out.ext_rectangles(false, false, [["==", 0.9.um]], [["==", 0.9.um]], nil, inverted: true)
 end.().output("TV2.a", "Min. and max. TopVia2 width = 0.90")
 -&gt; do
-    TopVia2.ext_fast_space(1.06.um)
+    TopVia2.ext_space(1.06.um)
 end.().output("TV2.b", "Min. TopVia2 space = 1.06")
 -&gt; do
-    TopMetal2.ext_fast_width(2.0.um)
+    TopMetal2.ext_width(2.0.um)
 end.().output("TM2.a", "Min. TopMetal2 width = 2.00")
 -&gt; do
-    TopMetal2.ext_fast_space(2.0.um)
+    TopMetal2.ext_space(2.0.um)
 end.().output("TM2.b", "Min. TopMetal2 space or notch = 2.00")
 
 if $density
@@ -2365,24 +2636,24 @@ end
 
 if $filler
 	-&gt; do
-	    TopMetal2_filler.ext_fast_width(5.0.um)
+	    TopMetal2_filler.ext_width(5.0.um)
 	end.().output("TM2Fil.a", "Min. TopMetal2:filler width = 5.00")
 	-&gt; do
-	    TopMetal2_filler.ext_fast_space(3.0.um)
+	    TopMetal2_filler.ext_space(3.0.um)
 	end.().output("TM2Fil.b", "Min. TopMetal2:filler space = 3.00")
 	-&gt; do
-	    TopMetal2_filler.ext_fast_separation(TopMetal2, 3.0.um)
+	    TopMetal2_filler.ext_separation(TopMetal2, 3.0.um)
 	end.().output("TM2Fil.c", "Min. TopMetal2:filler space to TopMetal2 = 3.00")
 	-&gt; do
-	    TopMetal2_filler.ext_fast_separation(TRANS, 4.9.um)
+	    TopMetal2_filler.ext_separation(TRANS, 4.9.um)
 	end.().output("TM2Fil.d", "Min. TopMetal2:filler space to TRANS = 4.90")
 end
 
 -&gt; do
-    Passiv.ext_fast_width(2.1.um)
+    Passiv.ext_width(2.1.um)
 end.().output("Pas.a", "Min. Passiv width = 2.10")
 -&gt; do
-    Passiv.ext_fast_space(3.5.um)
+    Passiv.ext_space(3.5.um)
 end.().output("Pas.b", "Min. Passiv space or notch = 3.50")
 -&gt; do
     emit_npn13G2.ext_with_length([["&gt;", 0.07.um], ["&lt;", 0.9.um]])
@@ -2400,87 +2671,93 @@ end.().output("npn13G2V.a", "Min. npn13G2V emitter length = 1.00")
     emit_npn13G2V.ext_with_length([["&gt;", 5.0.um]])
 end.().output("npn13G2V.b", "Max. npn13G2V emitter length = 5.00")
 -&gt; do
-    Rsil_all.ext_fast_width(0.5.um)
+    Rsil_all.ext_width(0.5.um)
 end.().output("Rsil.a", "Min. GatPoly width = 0.50")
 -&gt; do
-    RES.ext_fast_separation(Cont, 0.12.um)
+    RES.ext_separation(Cont, 0.12.um)
 end.().output("Rsil.b", "Min. RES space to Cont = 0.12")
 -&gt; (;x) do
-    x = rsil_gatpoly.ext_fast_enclosed(RES, 1.0.um, polygon_output: true)
+    x = rsil_gatpoly.ext_enclosed(RES, 1.0.um, consider_intersecting_edges: false, consider_touch_points: false, polygon_output: true)
     x.outside(Cont)
 end.().output("Rsil.c", "Min. RES extension over GatPoly = 0.00")
 -&gt; do
     GP_Rsil_extended_external_pSD.dup
 end.().output("Rsil.d", "Min. pSD space to GatPoly = 0.18")
 -&gt; do
-    GP_Rsil_extended.ext_fast_enclosed(EXTBlock, 0.18.um, polygon_output: true)
+    GP_Rsil_extended.ext_enclosed(EXTBlock, 0.18.um)
 end.().output("Rsil.e", "Min. EXTBlock enclosure of GatPoly = 0.18")
 -&gt; do
-    RES.ext_fast_width(0.5.um)
+    RES.ext_width(0.5.um)
 end.().output("Rsil.f", "Min. RES length = 0.50")
 -&gt; do
-    Rppd_all.ext_fast_width(0.5.um)
+    Rppd_all.ext_width(0.5.um)
 end.().output("Rppd.a", "Min. GatPoly width = 0.50")
 -&gt; do
     Rppd_all_enclosure_pSD.dup
 end.().output("Rppd.b", "Min. pSD enclosure of GatPoly = 0.18")
 -&gt; (;x) do
     x = SalBlock_Rppd.ext_extended(0.2.um, 0.2.um)
-    [ Rppd_Cont.ext_fast_separation(SalBlock_Rppd, 0.2.um),
+    [ Rppd_Cont.ext_separation(SalBlock_Rppd, 0.2.um),
       Rppd_Cont.ext_interacting(x, inverted: true)
     ].each { |result| result.output("Rppd.c", "Min. and max. SalBlock space to Cont = 0.20") }
 end.()
 -&gt; do
-    SalBlock_Rppd.ext_fast_width(0.5.um)
+    GP_Rppd_extended.ext_enclosed(EXTBlock, 0.18.um, consider_intersecting_edges: false, consider_touch_points: false)
+end.().output("Rppd.d", "Min. EXTBlock enclosure of GatPoly = 0.18")
+-&gt; do
+    SalBlock_Rppd.ext_width(0.5.um)
 end.().output("Rppd.e", "Min. SalBlock length = 0.50")
 -&gt; do
-    Rhigh_a.ext_fast_width(0.5.um)
+    Rhigh_a.ext_width(0.5.um)
 end.().output("Rhi.a", "Min. GatPoly width = 0.50")
 -&gt; do
     Rhigh_identical_nsd_psd.dup
 end.().output("Rhi.b", "pSD and nSD are identical (Note 1)")
 -&gt; do
-    GP_Rhigh_extended.ext_fast_enclosed(pSD_nSD, 0.18.um, polygon_output: true)
+    GP_Rhigh_extended.ext_enclosed(pSD_nSD, 0.18.um)
 end.().output("Rhi.c", "Min. pSD and nSD enclosure of GatPoly = 0.18")
 -&gt; (;x) do
     x = SalBlock_Rhigh.ext_extended(0.2.um, 0.2.um)
-    [ Rhigh_Cont.ext_fast_separation(SalBlock_Rhigh, 0.2.um),
+    [ Rhigh_Cont.ext_separation(SalBlock_Rhigh, 0.2.um),
       Rhigh_Cont.ext_interacting(x, inverted: true)
     ].each { |result| result.output("Rhi.d", "Min. and max. SalBlock space to Cont = 0.20") }
 end.()
 -&gt; do
-    SalBlock_Rhigh.ext_fast_width(0.5.um)
+    GP_Rhigh_extended.ext_enclosed(EXTBlock, 0.18.um, consider_intersecting_edges: false, consider_touch_points: false)
+end.().output("Rhi.e", "Min. EXTBlock enclosure of GatPoly = 0.18")
+-&gt; do
+    SalBlock_Rhigh.ext_width(0.5.um)
 end.().output("Rhi.f", "Min. SalBlock length = 0.50")
 -&gt; do
-    Iso_PWell_Act.outside(schottky_nbl1).ext_fast_enclosed(nBuLay, 1.24.um, polygon_output: true)
+    Iso_PWell_Act.outside(schottky_nbl1).ext_enclosed(nBuLay, 1.24.um)
 end.().output("nmosi.b", "Min. nBuLay enclosure of Iso-PWell-Activ (Note 1) = 1.24")
 -&gt; do
-    Iso_PWell_Act.ext_not(scr1_or_schottky_nbl1).ext_fast_separation(NWell.with_holes, 0.39.um, max_angle: 180)
+    Iso_PWell_Act.ext_not(scr1_or_schottky_nbl1).ext_separation(NWell.with_holes, 0.39.um, max_angle: 180)
 end.().output("nmosi.c", "Min. NWell space to Iso-PWell-Activ = 0.39")
 -&gt; do
-    NWell_nBuLay.ext_fast_width(0.62.um)
+    NWell_nBuLay.ext_width(0.62.um)
 end.().output("nmosi.d", "Min. NWell-nBuLay width forming an unbroken ring around any Iso-PWell-Activ (Note 2) = 0.62")
 -&gt; do
-    nSDBlock_Iso_PWell_Act.ext_fast_width(0.62.um)
+    nSDBlock_Iso_PWell_Act.ext_width(0.62.um)
 end.().output("nmosi.f", "Min. nSD:block width to separate ptap in nmosi = 0.62")
 -&gt; (;tmp, x1) do
     tmp = SalBlock_Iso_PWell_Act.ext_not(scr1_or_schottky_nbl1)
-    x1 = nSDBlock_Iso_PWell_Act.ext_fast_enclosed(tmp.ext_not(tmp.ext_covering(npnMPA)), 0.15.um, polygon_output: true)
+    x1 = nSDBlock_Iso_PWell_Act.ext_enclosed(tmp.ext_not(tmp.ext_covering(npnMPA)), 0.15.um, polygon_output: true)
     x1.ext_and(Activ)
 end.().output("nmosi.g", "Min. SalBlock overlap of nSD:block over Activ = 0.15")
 -&gt; do
-    schottky_contbar.ext_fast_enclosed(schottky_pwb, 0.25.um, polygon_output: true)
+    schottky_contbar.ext_enclosed(schottky_pwb, 0.25.um)
 end.().output("Sdiod.a", "Min. and max. PWell:block enclosure of ContBar = 0.25")
 -&gt; do
-    schottky_contbar.ext_fast_enclosed(schottky_nSDBlock, 0.4.um, polygon_output: true)
+    schottky_contbar.ext_enclosed(schottky_nSDBlock, 0.4.um)
 end.().output("Sdiod.b", "Min. and max. nSD:block enclosure of ContBar = 0.40")
 -&gt; do
-    schottky_contbar.ext_fast_enclosed(schottky_salblock, 0.45.um, polygon_output: true)
+    schottky_contbar.ext_enclosed(schottky_salblock, 0.45.um)
 end.().output("Sdiod.c", "Min. and max. SalBlock enclosure of ContBar = 0.45")
 
 if not $noRecommendedRules
 	-&gt; do
-	    Passiv_dfpad.ext_fast_width(30.0.um)
+	    Passiv_dfpad.ext_width(30.0.um)
 	end.().output("Pad.aR", "Min. recommended Pad width = 30.00")
 end
 
@@ -2490,23 +2767,23 @@ end.().output("Pad.a1", "Max. Pad width = 150.00")
 
 if not $noRecommendedRules
 	-&gt; do
-	    Passiv_dfpad.ext_fast_space(8.4.um)
+	    Passiv_dfpad.ext_space(8.4.um)
 	end.().output("Pad.bR", "Min. recommended Pad space = 8.40")
 end
 
 -&gt; do
-    Passiv_dfpad.ext_fast_separation(Act_EdgeSeal_not_HRACT, 7.5.um)
+    Passiv_dfpad.ext_separation(Act_EdgeSeal_not_HRACT, 7.5.um)
 end.().output("Pad.d", "Min. Pad space to EdgeSeal = 7.50")
 
 if not $noRecommendedRules
 	-&gt; do
-	    Passiv_dfpad.ext_fast_separation(Act_EdgeSeal_not_HRACT, 25.0.um)
+	    Passiv_dfpad.ext_separation(Act_EdgeSeal_not_HRACT, 25.0.um)
 	end.().output("Pad.dR", "Min. recommended Pad to EdgeSeal space (Note 1) = 25.00")
 	-&gt; do
-	    Passiv_dfpad.ext_fast_separation(Act_Not_EdgeSeal, 11.2.um)
+	    Passiv_dfpad.ext_separation(Act_Not_EdgeSeal, 11.2.um)
 	end.().output("Pad.d1R", "Min. recommended Pad to Activ (inside chip area) space = 11.20")
 	-&gt; do
-	    TopVia2.ext_fast_enclosed(belowTopMetaln_dfpad, 1.4.um, polygon_output: true)
+	    TopVia2.ext_enclosed(belowTopMetaln_dfpad, 1.4.um)
 	end.().output("Pad.gR", "TopMetal1 (within dfpad) enclosure of TopVia2 = 1.40")
 	-&gt; do
 	    [ MIM.ext_and(Passiv_dfpad),
@@ -2519,84 +2796,84 @@ if not $noRecommendedRules
 end
 
 -&gt; do
-    cupPad_candidat.ext_fast_space(45.0.um, polygon_output: true)
+    cupPad_candidat.ext_space(45.0.um, polygon_output: true)
 end.().output("Padc.b", "Min. CuPillarPad space = Table 6.1")
 -&gt; do
-    cupPad_candidat.ext_fast_separation(Act_EdgeSeal_not_HRACT, 30.0.um, consider_touch_points: false, polygon_output: true)
+    cupPad_candidat.ext_separation(Act_EdgeSeal_not_HRACT, 30.0.um, consider_touch_points: false, polygon_output: true)
 end.().output("Padc.d", "Min. CuPillarPad space to EdgeSeal = 30.00")
 -&gt; do
-    Activ_edgA1_in.ext_fast_width(3.5.um, metric: projection, include_max_angle: true)
+    Activ_edgA1_in.ext_width(3.5.um, metric: projection)
 end.().output("Seal.a_Activ", "Min. EdgeSeal-Activ width = 3.50")
 -&gt; do
-    pSD_edgA1_in.ext_fast_width(3.5.um, metric: projection, include_max_angle: true)
+    pSD_edgA1_in.ext_width(3.5.um, metric: projection)
 end.().output("Seal.a_pSD", "Min. EdgeSeal-pSD width = 3.50")
 -&gt; do
-    Metal1_edgA1_in.ext_fast_width(3.5.um, metric: projection, include_max_angle: true)
+    Metal1_edgA1_in.ext_width(3.5.um, metric: projection)
 end.().output("Seal.a_Metal1", "Min. EdgeSeal-Metal1 width = 3.50")
 -&gt; do
-    Metal2_edgA1_in.ext_fast_width(3.5.um, metric: projection, include_max_angle: true)
+    Metal2_edgA1_in.ext_width(3.5.um, metric: projection)
 end.().output("Seal.a_Metal2", "Min. EdgeSeal-Metal2 width = 3.50")
 -&gt; do
-    Metal3_edgA1_in.ext_fast_width(3.5.um, metric: projection, include_max_angle: true)
+    Metal3_edgA1_in.ext_width(3.5.um, metric: projection)
 end.().output("Seal.a_Metal3", "Min. EdgeSeal-Metal3 width = 3.50")
 -&gt; do
-    Metal4_edgA1_in.ext_fast_width(3.5.um, metric: projection, include_max_angle: true)
+    Metal4_edgA1_in.ext_width(3.5.um, metric: projection)
 end.().output("Seal.a_Metal4", "Min. EdgeSeal-Metal4 width = 3.50")
 -&gt; do
-    Metal5_edgA1_in.ext_fast_width(3.5.um, metric: projection, include_max_angle: true)
+    Metal5_edgA1_in.ext_width(3.5.um, metric: projection)
 end.().output("Seal.a_Metal5", "Min. EdgeSeal-Metal5 width = 3.50")
 -&gt; do
-    TopMetal1_edgA1_in.ext_fast_width(3.5.um, metric: projection, include_max_angle: true)
+    TopMetal1_edgA1_in.ext_width(3.5.um, metric: projection)
 end.().output("Seal.a_TopMetal1", "Min. EdgeSeal-TopMetal1 width = 3.50")
 -&gt; do
-    TopMetal2_edgA1_in.ext_fast_width(3.5.um, metric: projection, include_max_angle: true)
+    TopMetal2_edgA1_in.ext_width(3.5.um, metric: projection)
 end.().output("Seal.a_TopMetal2", "Min. EdgeSeal-TopMetal2 width = 3.50")
 -&gt; do
-    [ Cont_edgC1_in.ext_fast_width(0.16.um),
+    [ Cont_edgC1_in.ext_width(0.16.um),
       Cont_edgC1_in.drc((width(projection) &gt; 0.16.um).polygons)
     ].each { |result| result.output("Seal.c", "EdgeSeal-Cont ring width = 0.16") }
 end.()
 -&gt; do
-    [ Via1_edgC1_in.ext_fast_width(0.19.um),
+    [ Via1_edgC1_in.ext_width(0.19.um),
       Via1_edgC1_in.drc((width(projection) &gt; 0.19.um).polygons)
     ].each { |result| result.output("Seal.c1.Via1", "EdgeSeal-Via1 ring width = 0.19") }
 end.()
 -&gt; do
-    [ Via2_edgC1_in.ext_fast_width(0.19.um),
+    [ Via2_edgC1_in.ext_width(0.19.um),
       Via2_edgC1_in.drc((width(projection) &gt; 0.19.um).polygons)
     ].each { |result| result.output("Seal.c1.Via2", "EdgeSeal-Via2 ring width = 0.19") }
 end.()
 -&gt; do
-    [ Via3_edgC1_in.ext_fast_width(0.19.um),
+    [ Via3_edgC1_in.ext_width(0.19.um),
       Via3_edgC1_in.drc((width(projection) &gt; 0.19.um).polygons)
     ].each { |result| result.output("Seal.c1.Via3", "EdgeSeal-Via3 ring width = 0.19") }
 end.()
 -&gt; do
-    [ Via4_edgC1_in.ext_fast_width(0.19.um),
+    [ Via4_edgC1_in.ext_width(0.19.um),
       Via4_edgC1_in.drc((width(projection) &gt; 0.19.um).polygons)
     ].each { |result| result.output("Seal.c1.Via4", "EdgeSeal-Via4 ring width = 0.19") }
 end.()
 -&gt; do
-    [ TopVia1_edgC1_in.ext_fast_width(0.42.um),
+    [ TopVia1_edgC1_in.ext_width(0.42.um),
       TopVia1_edgC1_in.drc((width(projection) &gt; 0.42.um).polygons)
     ].each { |result| result.output("Seal.c2", "EdgeSeal-TopVia1 ring width = 0.42") }
 end.()
 -&gt; do
-    [ TopVia2_edgC1_in.ext_fast_width(0.9.um),
+    [ TopVia2_edgC1_in.ext_width(0.9.um),
       TopVia2_edgC1_in.drc((width(projection) &gt; 0.9.um).polygons)
     ].each { |result| result.output("Seal.c3", "EdgeSeal-TopVia2 ring width = 0.90") }
 end.()
 -&gt; do
-    seal_passiv.ext_fast_width(4.2.um)
+    seal_passiv.ext_width(4.2.um)
 end.().output("Seal.e", "Min. Passiv ring width outside of sealring = 4.20")
 -&gt; do
     MIM_Mim_a.dup
 end.().output("MIM.a", "Min. MIM width = 1.14")
 -&gt; do
-    MIM.ext_fast_space(0.6.um)
+    MIM.ext_space(0.6.um)
 end.().output("MIM.b", "Min. MIM space = 0.60")
 -&gt; do
-    TopMetal1.ext_fast_separation(MIM, 0.6.um)
+    TopMetal1.ext_separation(MIM, 0.6.um)
 end.().output("MIM.e", "Min. TopMetal1 space to MIM = 0.60")
 -&gt; do
     MIM_Mim_f.dup
@@ -2639,7 +2916,7 @@ end.().output("LU.d", "Max. extension of NWell tie Activ tie beyond Cont = 6.00"
     drcErrA.ext_with_coincident_edges(drcErrA_Edge)
 end.().output("LU.d1", "Max. extension of an substrate tie Activ beyond Cont = 6.00")
 -&gt; do
-    Metal1_slit_not_pad.ext_fast_width(2.8.um)
+    Metal1_slit_not_pad.ext_width(2.8.um)
 end.().output("Slt.a.M1", "Min. Metal1:slit width = 2.80")
 -&gt; (;tmp) do
     tmp = Metal1_slit_not_pad.ext_with_length([["&gt;", 20.0.um]])
@@ -2655,15 +2932,15 @@ end.().output("Slt.c.M1", "Max. Metal1 width without requiring a slit = 30.00")
     Metal1_slit.ext_and(pad)
 end.().output("Slt.e.M1", "No slits required on bond pads")
 -&gt; do
-    Metal1_slit_not_pad.ext_fast_enclosed(Metal1, 1.0.um, polygon_output: true)
+    Metal1_slit_not_pad.ext_enclosed(Metal1, 1.0.um)
 end.().output("Slt.f.M1", "Min. Metal1 enclosure of Metal1:slit = 1.00")
 -&gt; do
-    [ Metal1_slit_not_pad.ext_fast_separation(Cont, 0.3.um),
-      Metal1_slit_not_pad.ext_fast_separation(Via1, 0.3.um)
+    [ Metal1_slit_not_pad.ext_separation(Cont, 0.3.um),
+      Metal1_slit_not_pad.ext_separation(Via1, 0.3.um)
     ].each { |result| result.output("Slt.h1", "Min. Metal1:slit space to Cont and Via1 = 0.30") }
 end.()
 -&gt; do
-    Metal2_slit_not_pad.ext_fast_width(2.8.um)
+    Metal2_slit_not_pad.ext_width(2.8.um)
 end.().output("Slt.a.M2", "Min. Metal2:slit width = 2.80")
 -&gt; (;tmp) do
     tmp = Metal2_slit_not_pad.ext_with_length([["&gt;", 20.0.um]])
@@ -2679,15 +2956,15 @@ end.().output("Slt.c.M2", "Max. Metal2 width without requiring a slit = 30.00")
     Metal2_slit.ext_and(pad)
 end.().output("Slt.e.M2", "No slits required on bond pads")
 -&gt; do
-    Metal2_slit_not_pad.ext_fast_enclosed(Metal2, 1.0.um, polygon_output: true)
+    Metal2_slit_not_pad.ext_enclosed(Metal2, 1.0.um)
 end.().output("Slt.f.M2", "Min. Metal2 enclosure of Metal2:slit = 1.00")
 -&gt; do
-    [ Metal2_slit_not_pad.ext_fast_separation(Via1, 0.3.um),
-      Metal2_slit_not_pad.ext_fast_separation(Via2, 0.3.um)
+    [ Metal2_slit_not_pad.ext_separation(Via1, 0.3.um),
+      Metal2_slit_not_pad.ext_separation(Via2, 0.3.um)
     ].each { |result| result.output("Slt.h2.M2", "Min. Metal2:slit space to Via1 and Via2 = 0.30") }
 end.()
 -&gt; do
-    Metal3_slit_not_pad.ext_fast_width(2.8.um)
+    Metal3_slit_not_pad.ext_width(2.8.um)
 end.().output("Slt.a.M3", "Min. Metal3:slit width = 2.80")
 -&gt; (;tmp) do
     tmp = Metal3_slit_not_pad.ext_with_length([["&gt;", 20.0.um]])
@@ -2703,15 +2980,15 @@ end.().output("Slt.c.M3", "Max. Metal3 width without requiring a slit = 30.00")
     Metal3_slit.ext_and(pad)
 end.().output("Slt.e.M3", "No slits required on bond pads")
 -&gt; do
-    Metal3_slit_not_pad.ext_fast_enclosed(Metal3, 1.0.um, polygon_output: true)
+    Metal3_slit_not_pad.ext_enclosed(Metal3, 1.0.um)
 end.().output("Slt.f.M3", "Min. Metal3 enclosure of Metal2:slit = 1.00")
 -&gt; do
-    [ Metal3_slit_not_pad.ext_fast_separation(Via2, 0.3.um),
-      Metal3_slit_not_pad.ext_fast_separation(Via3, 0.3.um)
+    [ Metal3_slit_not_pad.ext_separation(Via2, 0.3.um),
+      Metal3_slit_not_pad.ext_separation(Via3, 0.3.um)
     ].each { |result| result.output("Slt.h2.M3", "Min. Metal3:slit space to Via2 and Via3 = 0.30") }
 end.()
 -&gt; do
-    Metal4_slit_not_pad.ext_fast_width(2.8.um)
+    Metal4_slit_not_pad.ext_width(2.8.um)
 end.().output("Slt.a.M4", "Min. Metal4:slit width = 2.80")
 -&gt; (;tmp) do
     tmp = Metal4_slit_not_pad.ext_with_length([["&gt;", 20.0.um]])
@@ -2727,15 +3004,15 @@ end.().output("Slt.c.M4", "Max. Metal4 width without requiring a slit = 30.00")
     Metal4_slit.ext_and(pad)
 end.().output("Slt.e.M4", "No slits required on bond pads")
 -&gt; do
-    Metal4_slit_not_pad.ext_fast_enclosed(Metal4, 1.0.um, polygon_output: true)
+    Metal4_slit_not_pad.ext_enclosed(Metal4, 1.0.um)
 end.().output("Slt.f.M4", "Min. Metal4 enclosure of Metal4:slit = 1.00")
 -&gt; do
-    [ Metal4_slit_not_pad.ext_fast_separation(Via3, 0.3.um),
-      Metal4_slit_not_pad.ext_fast_separation(Via4, 0.3.um)
+    [ Metal4_slit_not_pad.ext_separation(Via3, 0.3.um),
+      Metal4_slit_not_pad.ext_separation(Via4, 0.3.um)
     ].each { |result| result.output("Slt.h2.M4", "Min. Metal4:slit space to Via3 and Via4 = 0.30") }
 end.()
 -&gt; do
-    Metal5_slit_not_pad.ext_fast_width(2.8.um)
+    Metal5_slit_not_pad.ext_width(2.8.um)
 end.().output("Slt.a.M5", "Min. Metal5:slit width = 2.80")
 -&gt; (;tmp) do
     tmp = Metal5_slit_not_pad.ext_with_length([["&gt;", 20.0.um]])
@@ -2751,18 +3028,18 @@ end.().output("Slt.c.M5", "Max. Metal5 width without requiring a slit = 30.00")
     Metal5_slit.ext_and(pad)
 end.().output("Slt.e.M5", "No slits required on bond pads")
 -&gt; do
-    Metal5_slit_not_pad.ext_fast_enclosed(Metal5, 1.0.um, polygon_output: true)
+    Metal5_slit_not_pad.ext_enclosed(Metal5, 1.0.um)
 end.().output("Slt.f.M5", "Min. Metal5 enclosure of Metal5:slit = 1.00")
 -&gt; do
     Metal5_slit_MIM_Slt_g_M5_sep.dup
 end.().output("Slt.g.M5", "Min. Metal5:slit and TopMetal1:slit space to MIM = 0.60")
 -&gt; do
-    [ Metal5_slit_not_pad.ext_fast_separation(Via4, 0.3.um),
-      Metal5_slit_not_pad.ext_fast_separation(TopVia1, 0.3.um)
+    [ Metal5_slit_not_pad.ext_separation(Via4, 0.3.um),
+      Metal5_slit_not_pad.ext_separation(TopVia1, 0.3.um)
     ].each { |result| result.output("Slt.h2.M5", "Min. Metal5:slit space to Via4 and Via5 = 0.30") }
 end.()
 -&gt; do
-    TopMetal1_slit_not_pad.ext_fast_width(2.8.um)
+    TopMetal1_slit_not_pad.ext_width(2.8.um)
 end.().output("Slt.a.TM1", "Min. TopMetal1:slit width = 2.80")
 -&gt; (;tmp) do
     tmp = TopMetal1_slit_not_pad.ext_with_length([["&gt;", 20.0.um]])
@@ -2778,16 +3055,16 @@ end.().output("Slt.c.TM1", "Max. TopMetal1 width without requiring a slit = 30.0
     TopMetal1_slit.ext_and(pad)
 end.().output("Slt.e.TM1", "No slits required on bond pads")
 -&gt; do
-    TopMetal1_slit_not_pad.ext_fast_enclosed(TopMetal1, 1.0.um, polygon_output: true)
+    TopMetal1_slit_not_pad.ext_enclosed(TopMetal1, 1.0.um)
 end.().output("Slt.f.TM1", "Min. TopMetal1 enclosure of TopMetal1:slit = 1.00")
 -&gt; do
     TopMetal1_slit_MIM_Slt_g_TM1_sep.dup
 end.().output("Slt.g.TM1", "Min. Metal5:slit and TopMetal1:slit space to MIM = 0.60")
 -&gt; do
-    TopMetal1_slit_not_pad.ext_fast_separation(TopVia1, 1.0.um)
+    TopMetal1_slit_not_pad.ext_separation(TopVia1, 1.0.um)
 end.().output("Slt.h3", "Min. TopMetal1:slit space to TopVia1 and TopVia2 = 1.00")
 -&gt; do
-    TopMetal2_slit_not_pad.ext_fast_width(2.8.um)
+    TopMetal2_slit_not_pad.ext_width(2.8.um)
 end.().output("Slt.a.TM2", "Min. TopMetal2:slit width = 2.80")
 -&gt; (;tmp) do
     tmp = TopMetal2_slit_not_pad.ext_with_length([["&gt;", 20.0.um]])
@@ -2803,10 +3080,10 @@ end.().output("Slt.c.TM2", "Max. TopMetal2 width without requiring a slit = 30.0
     TopMetal2_slit.ext_and(pad)
 end.().output("Slt.e.TM2", "No slits required on bond pads")
 -&gt; do
-    TopMetal2_slit_not_pad.ext_fast_enclosed(TopMetal2, 1.0.um, polygon_output: true)
+    TopMetal2_slit_not_pad.ext_enclosed(TopMetal2, 1.0.um)
 end.().output("Slt.f.TM2", "Min. TopMetal2 enclosure of TopMetal2:slit = 1.00")
 -&gt; do
-    TopMetal2_slit_not_pad.ext_fast_separation(TopVia2, 1.0.um)
+    TopMetal2_slit_not_pad.ext_separation(TopVia2, 1.0.um)
 end.().output("Slt.h4", "Min. TopMetal2:slit space to TopVia2 = 1.00")
 
 if $sanityRules
@@ -2840,11 +3117,29 @@ if $sanityRules
 end
 
 -&gt; do
-    NWell.ext_fast_separation(NActHV_digi, 0.31.um)
+    PActHV_digi.outside(SVaricap_or_schottky_nbl1).ext_enclosed(NWell, 0.31.um, consider_overlaps_as_errors: true)
+end.().output("NW.c1.dig", "Min. NWell enclosure of P+Activ inside ThickGateOx = 0.31")
+-&gt; do
+    NWell.ext_separation(NActHV_digi, 0.31.um)
 end.().output("NW.d1.dig", "Min. NWell space to external N+Activ inside ThickGateOx = 0.31")
 -&gt; do
-    NWell.ext_fast_separation(PAct_PWellHV_digi, 0.24.um)
+    NAct_NWellHV_digi.ext_enclosed(NWell, 0.24.um, consider_overlaps_as_errors: true)
+end.().output("NW.e1.dig", "Min. NWell enclosure of NWell tie surrounded entirely by NWell in N+Activ inside ThickGateOx = 0.24")
+-&gt; do
+    NWell.ext_separation(PAct_PWellHV_digi, 0.24.um)
 end.().output("NW.f1.dig", "Min. NWell space to substrate tie in P+Activ inside ThickGateOx = 0.24")
+-&gt; do
+    Cont_SQ.ext_not(SVaricap_or_trans_bip).ext_enclosed(Act_Nsram_or_Activ_mask.ext_and(DigiBnd), 0.05.um, consider_overlaps_as_errors: true)
+end.().output("Cnt.c.Digi", "Min. Activ enclosure of Cont = 0.05")
+-&gt; do
+    PActLV.ext_enclosed(NWell_SRAM, 0.149.um, consider_overlaps_as_errors: true)
+end.().output("NW.c.SRAM", "Min. NWell enclosure of P+Activ not inside ThickGateOx = 0.149")
+-&gt; do
+    NWell_SRAM.ext_separation(NActLV, 0.24.um, consider_overlaps_as_errors: true)
+end.().output("NW.d.SRAM", "Min. NWell space to external N+Activ not inside ThickGateOx = 0.24")
+-&gt; do
+    GatPoly.ext_enclosed(Act_SRAM, 0.189.um, metric: projection)
+end.().output("Act.c.SRAM", "Min. Activ drain/source extension = 0.189")
 -&gt; do
     GP_SRAM_Gat_a_SRAM.dup
 end.().output("Gat.a.SRAM", "Min. GatPoly width = 0.069")
@@ -2852,15 +3147,15 @@ end.().output("Gat.a.SRAM", "Min. GatPoly width = 0.069")
     GP_SRAM_Gat_b_SRAM.dup
 end.().output("Gat.b.SRAM", "Min. GatPoly space or notch = 0.149")
 -&gt; do
-    Activ.ext_fast_enclosed(GP_SRAM, 0.079.um, polygon_output: true)
+    Activ.ext_enclosed(GP_SRAM, 0.079.um)
 end.().output("Gat.c.SRAM", "Min. GatPoly extension over Activ (end cap) = 0.079")
 -&gt; do
-    GP_SRAM.ext_fast_separation(Act_SRAM, 0.029.um)
+    GP_SRAM.ext_separation(Act_SRAM, 0.029.um)
 end.().output("Gat.d.SRAM", "Min. GatPoly space to Activ = 0.029")
 -&gt; (;layA, layB, layC, layD) do
     layA = Activ.ext_and(SRAM).not_inside(pSD).ext_interacting(pSD)
     layB = layA.ext_and(pSD)
-    layC = layB.ext_fast_width(0.28.um, metric: projection, consider_intersecting_edges: false, consider_touch_points: false, polygon_output: true)
+    layC = layB.ext_width(0.28.um, metric: projection, consider_intersecting_edges: false, consider_touch_points: false, polygon_output: true)
     layD = layC.ext_covering(layB)
     layD.dup
 end.().output("pSD.e.SRAM", "Min. pSD overlap of Activ when forming abutted substrate tie = 0.28")
@@ -2872,16 +3167,25 @@ end.().output("pSD.e.SRAM", "Min. pSD overlap of Activ when forming abutted subs
     ].each { |result| result.output("pSD.g.SRAM", "Min. N+Activ or P+Activ width when forming abutted tie = 0.15") }
 end.()
 -&gt; do
-    PGate.ext_fast_enclosed(pSD_SRAM, 0.068.um, polygon_output: true)
+    PGate.ext_enclosed(pSD_SRAM, 0.068.um)
 end.().output("pSD.i.SRAM", "Min. pSD enclosure of PFET gate not inside ThickGateOx = 0.068")
 -&gt; do
-    pSD_SRAM.ext_fast_separation(NGate_outside_SVaricap, 0.239.um)
+    pSD_SRAM.ext_separation(NGate_outside_SVaricap, 0.239.um)
 end.().output("pSD.j.SRAM", "Min. pSD space to NFET gate not inside ThickGateOx = 0.239")
 -&gt; do
-    Cont_Act.ext_fast_separation(GP_SRAM, 0.059.um)
+    Cont.ext_enclosed(Act_SRAM, 0.006.um, consider_overlaps_as_errors: true)
+end.().output("Cnt.c.SRAM", "Min. Activ enclosure of Cont = 0.006")
+-&gt; do
+    Cont.ext_enclosed(GP_SRAM, 0.009.um, consider_overlaps_as_errors: true)
+end.().output("Cnt.d.SRAM", "Min. GatPoly enclosure of Cont = 0.009")
+-&gt; do
+    Cont_Act.ext_separation(GP_SRAM, 0.059.um)
 end.().output("Cnt.f.SRAM", "Min. Cont on Activ space to GatPoly = 0.059")
 -&gt; do
-    M1_SRAM.ext_fast_space(0.159.um, consider_intersecting_edges: false, ignore_non_axis_aligned_edges: true)
+    Cont_PAct_not_SVaricap.ext_enclosed(pSD_SRAM, 0.075.um, consider_intersecting_edges: false, consider_touch_points: false)
+end.().output("Cnt.g2.SRAM", "Min. pSD overlap of Cont on pSD-Activ = 0.075")
+-&gt; do
+    M1_SRAM.ext_space(0.159.um, consider_intersecting_edges: false, ignore_non_axis_aligned_edges: true)
 end.().output("M1.b.SRAM", "Min. Metal1 space or notch = 0.159")
 -&gt; do
     Cont_SRAM.outside(EdgeSeal).drc(if_any(
@@ -2890,7 +3194,7 @@ end.().output("M1.b.SRAM", "Min. Metal1 space or notch = 0.159")
         ((enclosed(M1_SRAM_outside_EdgeSeal, projection, whole_edges, one_side_allowed, two_opposite_sides_allowed) &lt; 0.005.um))))
 end.().output("M1.c1.SRAM", "Min. Metal1 endcap enclosure of Cont = 0.005")
 -&gt; do
-    M2_SRAM.ext_fast_space(0.169.um, consider_intersecting_edges: false, ignore_non_axis_aligned_edges: true)
+    M2_SRAM.ext_space(0.169.um, consider_intersecting_edges: false, ignore_non_axis_aligned_edges: true)
 end.().output("M2.b.SRAM", "Min. Metal2 space or notch = 0.169")
 -&gt; do
     V1_SRAM_outside_EdgeSeal.drc(if_any(
@@ -2899,7 +3203,7 @@ end.().output("M2.b.SRAM", "Min. Metal2 space or notch = 0.169")
         ((enclosed(M2_SRAM.outside(EdgeSeal), projection, whole_edges, one_side_allowed, two_opposite_sides_allowed) &lt; 0.02.um))))
 end.().output("M2.c1.SRAM", "Min. Metal2 endcap enclosure of Via1 = 0.02")
 -&gt; do
-    M3_SRAM.ext_fast_space(0.169.um, consider_intersecting_edges: false, ignore_non_axis_aligned_edges: true)
+    M3_SRAM.ext_space(0.169.um, consider_intersecting_edges: false, ignore_non_axis_aligned_edges: true)
 end.().output("M3.b.SRAM", "Min. Metal3 space or notch = 0.169")
 -&gt; do
     V2_SRAM_outside_EdgeSeal.drc(if_any(
@@ -2908,7 +3212,7 @@ end.().output("M3.b.SRAM", "Min. Metal3 space or notch = 0.169")
         ((enclosed(M3_SRAM.outside(EdgeSeal), projection, whole_edges, one_side_allowed, two_opposite_sides_allowed) &lt; 0.02.um))))
 end.().output("M3.c1.SRAM", "Min. Metal3 endcap enclosure of Via2 = 0.02")
 -&gt; do
-    M4_SRAM.ext_fast_space(0.169.um, consider_intersecting_edges: false, ignore_non_axis_aligned_edges: true)
+    M4_SRAM.ext_space(0.169.um, consider_intersecting_edges: false, ignore_non_axis_aligned_edges: true)
 end.().output("M4.b.SRAM", "Min. Metal4 space or notch = 0.169")
 -&gt; do
     V3_SRAM_outside_EdgeSeal.drc(if_any(
@@ -2917,7 +3221,7 @@ end.().output("M4.b.SRAM", "Min. Metal4 space or notch = 0.169")
         ((enclosed(M4_SRAM.outside(EdgeSeal), projection, whole_edges, one_side_allowed, two_opposite_sides_allowed) &lt; 0.02.um))))
 end.().output("M4.c1.SRAM", "Min. Metal4 endcap enclosure of Via3 = 0.02")
 -&gt; do
-    M5_SRAM.ext_fast_space(0.169.um, consider_intersecting_edges: false, ignore_non_axis_aligned_edges: true)
+    M5_SRAM.ext_space(0.169.um, consider_intersecting_edges: false, ignore_non_axis_aligned_edges: true)
 end.().output("M5.b.SRAM", "Min. Metal5 space or notch = 0.169")
 -&gt; do
     V4_SRAM_outside_EdgeSeal.drc(if_any(
@@ -2926,7 +3230,7 @@ end.().output("M5.b.SRAM", "Min. Metal5 space or notch = 0.169")
         ((enclosed(M5_SRAM.outside(EdgeSeal), projection, whole_edges, one_side_allowed, two_opposite_sides_allowed) &lt; 0.02.um))))
 end.().output("M5.c1.SRAM", "Min. Metal5 endcap enclosure of Via4 = 0.02")
 -&gt; do
-    LBE.ext_fast_width(100.0.um)
+    LBE.ext_width(100.0.um)
 end.().output("LBE.a", "Min. LBE width = 100.00")
 -&gt; do
     LBE.drc((width(projection) &gt; 1500.0.um).polygons)
@@ -2938,20 +3242,20 @@ end.().output("LBE.b1", "Max. LBE area (µm²) = 250000.00")
     LBE.ext_with_area([["&lt;", 250000.0.um2]])
 end.().output("LBE.b2", "Min. LBE area (µm²) = 30000.00")
 -&gt; do
-    LBE.ext_fast_space(100.0.um, consider_intersecting_edges: false, ignore_non_axis_aligned_edges: true)
+    LBE.ext_space(100.0.um, consider_intersecting_edges: false, ignore_non_axis_aligned_edges: true)
 end.().output("LBE.c", "Min. LBE space or notch = 100.00")
 -&gt; (;lbe_in_seal) do
     lbe_in_seal = LBE.inside(EdgeSeal.holes.merge)
-    lbe_in_seal.ext_fast_separation(EdgeSeal, 150.0.um, consider_intersecting_edges: false, ignore_non_axis_aligned_edges: true)
+    lbe_in_seal.ext_separation(EdgeSeal, 150.0.um, consider_intersecting_edges: false, ignore_non_axis_aligned_edges: true)
 end.().output("LBE.d", "Min. LBE space to inner edge of EdgeSeal = 150.00")
 -&gt; do
-    LBE.ext_fast_separation(dfpad, 50.0.um, consider_intersecting_edges: false, ignore_non_axis_aligned_edges: true)
+    LBE.ext_separation(dfpad, 50.0.um, consider_intersecting_edges: false, ignore_non_axis_aligned_edges: true)
 end.().output("LBE.e.dfPad", "Min. LBE space to dfpad and Passiv = 50.00")
 -&gt; do
-    LBE.ext_fast_separation(Passiv, 50.0.um, consider_intersecting_edges: false, ignore_non_axis_aligned_edges: true)
+    LBE.ext_separation(Passiv, 50.0.um, consider_intersecting_edges: false, ignore_non_axis_aligned_edges: true)
 end.().output("LBE.e.Passiv", "Min. LBE space to dfpad and Passiv = 50.00")
 -&gt; do
-    LBE.ext_fast_separation(Activ, 30.0.um, consider_intersecting_edges: false, ignore_non_axis_aligned_edges: true)
+    LBE.ext_separation(Activ, 30.0.um, consider_intersecting_edges: false, ignore_non_axis_aligned_edges: true)
 end.().output("LBE.f", "Min. LBE space to Activ = 30.00")
 -&gt; do
     LBE.with_holes.dup
@@ -2978,10 +3282,10 @@ end.().output("TSV_G.g", "Min. Metal1 enclosure of DeepVia ring structure = 1.50
 
 if $checkDensityRules
 	-&gt; do
-	    tsv.ext_with_density(0.0 .. 0.0001, 'll')
+	    tsv.ext_with_density(0.01 .. 1.0, 'll')
 	end.().output("TSV_G.i", "Max. global DeepVia density [%] = 1.00")
 	-&gt; do
-	    tsv.ext_with_density(0.001 .. 1.0, 'll')
+	    tsv.ext_with_density(0.1 .. 1.0, 'll')
 	end.().output("TSV_G.j", "Max. DeepVia coverage ratio for any 500.0 x 500.0 µm² chip area [%] = 10.00")
 end
 

--- a/ihp-sg13g2/libs.tech/klayout/tech/drc/sg13g2_minimal.lydrc
+++ b/ihp-sg13g2/libs.tech/klayout/tech/drc/sg13g2_minimal.lydrc
@@ -117,10 +117,100 @@ else
     $sanityRules = true
 end
 
+class AbuttingEdges &lt; RBA::EdgePairToEdgeOperator
+    def initialize
+        self.is_isotropic_and_scale_invariant
+    end
+
+    def process(edge_pair)
+        if edge_pair.first.coincident?(edge_pair.second)
+            if edge_pair.first.length &lt; edge_pair.second.length
+                return [ edge_pair.first ]
+            else
+                return [ edge_pair.second ]
+            end
+        else
+            return []
+        end
+    end
+end
+
+class IntersectingEdgeErrorFilter &lt; RBA::EdgePairOperator
+    def initialize(abutting_edges)
+        @abutting_edges = abutting_edges
+    end
+
+    def process(edge_pair)
+        ip = nil
+        if edge_pair.first.p1 == edge_pair.second.p1 or
+           edge_pair.first.p1 == edge_pair.second.p2
+            ip = edge_pair.first.p1
+        elsif edge_pair.first.p2 == edge_pair.second.p1 or
+              edge_pair.first.p2 == edge_pair.second.p2
+            ip = edge_pair.first.p2
+        end
+        if ip and not edge_pair.first.coincident?(edge_pair.second)
+            edges = RBA::Edges::new([ edge_pair.first, edge_pair.second ])
+            region = @abutting_edges.extents(1)
+            interacting_edges = edges.interacting(region)
+            if interacting_edges.count == 2
+                ep = edge_pair.normalized
+                v1 = ep.first.swapped_points.d
+                v2 = ep.second.d
+                angle = Math.acos((v1*v2)/(v1.length*v2.length))/Math::PI*180
+                if angle &gt;= 90
+                    return []
+                end
+            end
+        end
+        return [ edge_pair ]
+    end
+end
+
+class IntersectingEdgeErrorAngleFilter &lt; RBA::EdgePairOperator
+    def initialize(min_angle, max_angle, include_min_angle, include_max_angle)
+        self.is_isotropic_and_scale_invariant
+        @min_angle = min_angle
+        @max_angle = max_angle
+        if include_min_angle
+            @min_angle -= 1e-6
+        else
+            @min_angle += 1e-6
+        end
+        if include_max_angle
+            @max_angle += 1e-6
+        else
+            @max_angle -= 1e-6
+        end
+    end
+
+    def process(edge_pair)
+        ip = nil
+        if edge_pair.first.p1 == edge_pair.second.p1 or
+           edge_pair.first.p1 == edge_pair.second.p2
+            ip = edge_pair.first.p1
+        elsif edge_pair.first.p2 == edge_pair.second.p1 or
+              edge_pair.first.p2 == edge_pair.second.p2
+            ip = edge_pair.first.p2
+        end
+        if ip
+            ep = edge_pair.normalized
+            v1 = ep.first.swapped_points.d
+            v2 = ep.second.d
+            angle = Math.acos((v1*v2)/(v1.length*v2.length))/Math::PI*180
+            if (angle &lt; @min_angle) or (angle &gt; @max_angle)
+                return []
+            end
+        end
+        return [ edge_pair ]
+    end
+end
+
 class DRC::DRCEngine
     def find_intersecting_edges_errors(dbu_value,
                                        error_edge_pairs_90,
                                        error_edge_pairs_180,
+                                       error_edge_pairs_90_180 = nil,
                                        inverse_error_edge_pairs_90 = nil,
                                        inverse_error_edge_pairs_180 = nil,
                                        options = {})
@@ -134,7 +224,7 @@ class DRC::DRCEngine
         area_of_right_angle = dbu_value**2/2
         errors_ep = RBA::EdgePairs::new()
         touch_point_errors_ep = RBA::EdgePairs::new()
-        intersecting_edges_errors_ep = RBA::EdgePairs::new()
+        abutting_edges_errors_ep = RBA::EdgePairs::new()
         intersecting_edges_error_candidates = Hash.new()
         no_touch_point_error = Hash.new()
         error_edge_pairs_90.data.each do |edge_pair|
@@ -145,18 +235,13 @@ class DRC::DRCEngine
             elsif edge_pair.first.p2 == edge_pair.second.p1 or
                   edge_pair.first.p2 == edge_pair.second.p2
                 ip = edge_pair.first.p2
-            else
-                ip = edge_pair.first.intersection_point(edge_pair.second)
             end
-            if ip
-                intersecting_edges_error_candidates[ip] = edge_pair
-                if !edge_pair.first.is_degenerate? and !edge_pair.second.is_degenerate?
-                    if (edge_pair.first.contains?(edge_pair.second.p1) and
-                       edge_pair.first.contains?(edge_pair.second.p2)) or
-                       (edge_pair.second.contains?(edge_pair.first.p1) and
-                       edge_pair.second.contains?(edge_pair.first.p2))
-                        no_touch_point_error[ip] = true
-                    end
+            if ip and !edge_pair.first.is_degenerate? and !edge_pair.second.is_degenerate?
+                if (edge_pair.first.contains?(edge_pair.second.p1) and
+                   edge_pair.first.contains?(edge_pair.second.p2)) or
+                   (edge_pair.second.contains?(edge_pair.first.p1) and
+                   edge_pair.second.contains?(edge_pair.first.p2))
+                    no_touch_point_error[ip] = true
                 end
             end
         end
@@ -177,7 +262,10 @@ class DRC::DRCEngine
                 end
             end
             touch_point_candidates = Hash.new()
-            (error_edge_pairs_90 + error_edge_pairs_180).data.each do |edge_pair|
+            if !error_edge_pairs_90_180
+                error_edge_pairs_90_180 = error_edge_pairs_90 + error_edge_pairs_180
+            end
+            error_edge_pairs_90_180.data.each do |edge_pair|
                 ip = nil
                 if edge_pair.first.p1 == edge_pair.second.p1 or
                    edge_pair.first.p1 == edge_pair.second.p2
@@ -185,11 +273,11 @@ class DRC::DRCEngine
                 elsif edge_pair.first.p2 == edge_pair.second.p1 or
                       edge_pair.first.p2 == edge_pair.second.p2
                     ip = edge_pair.first.p2
+                elsif edge_pair.first.intersection_point(edge_pair.second)
+                    abutting_edges_errors_ep.insert(edge_pair)
                 end
-                if ip
-                    if edge_pair.area == area_of_right_angle or max_angle == 180
-                        intersecting_edges_error_candidates[ip] = edge_pair
-                    end
+                if ip and !edge_pair.first.is_degenerate? and !edge_pair.second.is_degenerate?
+                    intersecting_edges_error_candidates[ip] = edge_pair
                     if touch_point_errors[ip]
                         touch_point_errors_ep.insert(edge_pair)
                         intersecting_edges_error_candidates.delete(ip)
@@ -204,11 +292,11 @@ class DRC::DRCEngine
                 end
             end
             if consider_intersecting_edges
-                intersecting_edges_errors_ep = RBA::EdgePairs::new(intersecting_edges_error_candidates.values)
-                if max_angle != 180
-                    intersecting_edges_errors_ep = intersecting_edges_errors_ep.with_internal_angle(min_angle, max_angle, false, include_min_angle, include_max_angle)
+                errors_ep = RBA::EdgePairs::new(intersecting_edges_error_candidates.values)
+                errors_ep.process(IntersectingEdgeErrorAngleFilter::new(min_angle, max_angle, include_min_angle, include_max_angle))
+                if min_angle == 0 and include_min_angle
+                    errors_ep = errors_ep + abutting_edges_errors_ep
                 end
-                errors_ep = errors_ep + intersecting_edges_errors_ep
             end
         end
         if ignore_non_axis_aligned_edges
@@ -323,8 +411,8 @@ class DRC::DRCLayer
         end
         error_edge_pairs_90 = DRC::DRCLayer::new(@engine,
             self.data.separation_check(other.data, dbu_value, false, metric, 90, 1, nil))
-        error_edge_pairs_180 = DRC::DRCLayer::new(@engine,
-            self.data.separation_check(other.data, dbu_value, false, metric, 180, nil, 1))
+        error_edge_pairs_90_180 = DRC::DRCLayer::new(@engine,
+            self.data.separation_check(other.data, dbu_value, false, metric, 180))
         width_error_edge_pairs_90 = DRC::DRCLayer::new(@engine,
             self.data.width_check(dbu_value, false, metric, 90, 1, nil) +
             other.data.width_check(dbu_value, false, metric, 90, 1, nil))
@@ -334,7 +422,8 @@ class DRC::DRCLayer
         separation_errors = @engine.find_intersecting_edges_errors(
             dbu_value,
             error_edge_pairs_90,
-            error_edge_pairs_180,
+            nil,
+            error_edge_pairs_90_180,
             width_error_edge_pairs_90,
             width_error_edge_pairs_180,
             {
@@ -356,44 +445,57 @@ class DRC::DRCLayer
         end
     end
 
-    def ext_fast_separation(other,
-                            value,
-                            metric: @engine.euclidian,
-                            consider_intersecting_edges: true,
-                            consider_touch_points: true,
-                            ignore_non_axis_aligned_edges: false,
-                            min_angle: 0,
-                            max_angle: 90,
-                            include_min_angle: true,
-                            include_max_angle: false,
-                            polygon_output: false)
+    def ext_separation(other,
+                       value,
+                       metric: @engine.euclidian,
+                       consider_intersecting_edges: true,
+                       consider_touch_points: true,
+                       consider_overlaps_as_errors: false,
+                       ignore_non_axis_aligned_edges: false,
+                       min_angle: 0,
+                       max_angle: 90,
+                       include_min_angle: true,
+                       include_max_angle: false,
+                       polygon_output: false)
         self_min_coherence_state = self.data.min_coherence?
         other_min_coherence_state =  other.data.min_coherence?
         self.data.min_coherence = true
         other.data.min_coherence = true
-        output_layer = self.separation(other, value, metric, @engine.angle_limit(max_angle))
-        if !consider_intersecting_edges and !consider_touch_points
-            output_layer = output_layer.with_distance(1, nil)
-            if ignore_non_axis_aligned_edges
-                output_layer = output_layer.with_angle(@engine.ortho, @engine.both)
+        if consider_overlaps_as_errors
+            output_layer = self.separation(other, value, metric,
+                                           @engine.angle_limit(180), @engine.without_touching_corners)
+            abutting_edges = output_layer.data.processed(AbuttingEdges::new)
+            output_layer.data.process(IntersectingEdgeErrorFilter::new(abutting_edges))
+        else
+            angle_limit = max_angle
+            if include_max_angle
+                angle_limit += 1e-6
             end
-        elsif consider_intersecting_edges ^ consider_touch_points
-            intersecting_edges_errors = output_layer.with_distance(0).edges
-            candidate_layer1 = self.interacting(intersecting_edges_errors)
-            candidate_layer2 = other.interacting(intersecting_edges_errors)
-            output_layer = output_layer.with_distance(1, nil)
-            output_layer = output_layer + candidate_layer1.ext_separation_at_intersecting_edges(
-                candidate_layer2,
-                value,
-                metric,
-                consider_intersecting_edges,
-                consider_touch_points,
-                ignore_non_axis_aligned_edges,
-                min_angle,
-                max_angle,
-                include_min_angle,
-                include_max_angle,
-                false)
+            output_layer = self.separation(other, value, metric, @engine.angle_limit(angle_limit))
+            if !consider_intersecting_edges and !consider_touch_points
+                output_layer = output_layer.without_distance(0)
+                if ignore_non_axis_aligned_edges
+                    output_layer = output_layer.with_angle(@engine.ortho, @engine.both)
+                end
+            elsif (consider_intersecting_edges ^ consider_touch_points) or
+                  !(min_angle==0 and max_angle==90 and include_min_angle and !include_max_angle)
+                intersecting_edges_errors = output_layer.with_distance(0).edges
+                candidate_layer1 = self.interacting(intersecting_edges_errors)
+                candidate_layer2 = other.interacting(intersecting_edges_errors)
+                output_layer = output_layer.without_distance(0)
+                output_layer = output_layer + candidate_layer1.ext_separation_at_intersecting_edges(
+                    candidate_layer2,
+                    value,
+                    metric,
+                    consider_intersecting_edges,
+                    consider_touch_points,
+                    ignore_non_axis_aligned_edges,
+                    min_angle,
+                    max_angle,
+                    include_min_angle,
+                    include_max_angle,
+                    false)
+            end
         end
         self.data.min_coherence = self_min_coherence_state
         other.data.min_coherence = other_min_coherence_state
@@ -494,6 +596,7 @@ class DRC::DRCLayer
             dbu_value,
             error_edge_pairs_90,
             error_edge_pairs_180,
+            nil,
             width_error_edge_pairs_90,
             width_error_edge_pairs_180,
             {
@@ -514,16 +617,16 @@ class DRC::DRCLayer
         end
     end
 
-    def ext_fast_space(value,
-                       metric: @engine.euclidian,
-                       consider_intersecting_edges: true,
-                       consider_touch_points: true,
-                       ignore_non_axis_aligned_edges: false,
-                       min_angle: 0,
-                       max_angle: 90,
-                       include_min_angle: true,
-                       include_max_angle: false,
-                       polygon_output: false)
+    def ext_space(value,
+                  metric: @engine.euclidian,
+                  consider_intersecting_edges: true,
+                  consider_touch_points: true,
+                  ignore_non_axis_aligned_edges: false,
+                  min_angle: 0,
+                  max_angle: 90,
+                  include_min_angle: true,
+                  include_max_angle: false,
+                  polygon_output: false)
         self_min_coherence_state = self.data.min_coherence?
         self.data.min_coherence = true
         output_layer = self.space(value, metric, @engine.angle_limit(max_angle))
@@ -583,6 +686,7 @@ class DRC::DRCLayer
             dbu_value,
             error_edge_pairs_90,
             error_edge_pairs_180,
+            nil,
             space_error_edge_pairs_90,
             space_error_edge_pairs_180,
             {
@@ -603,16 +707,16 @@ class DRC::DRCLayer
         end
     end
 
-    def ext_fast_width(value,
-                       metric: @engine.euclidian,
-                       consider_intersecting_edges: true,
-                       consider_touch_points: true,
-                       ignore_non_axis_aligned_edges: false,
-                       min_angle: 0,
-                       max_angle: 90,
-                       include_min_angle: true,
-                       include_max_angle: false,
-                       polygon_output: false)
+    def ext_width(value,
+                  metric: @engine.euclidian,
+                  consider_intersecting_edges: true,
+                  consider_touch_points: true,
+                  ignore_non_axis_aligned_edges: false,
+                  min_angle: 0,
+                  max_angle: 90,
+                  include_min_angle: true,
+                  include_max_angle: false,
+                  polygon_output: false)
         if self.polygons?
             self_min_coherence_state = self.data.min_coherence?
             self.data.min_coherence = true
@@ -778,7 +882,7 @@ if $sanityRules
 	Flash = source.polygons("71/0")
 end
 
-Activ_Act_a = Activ.ext_fast_width(0.15.um)
+Activ_Act_a = Activ.ext_width(0.15.um)
 Act_density = Activ.ext_or(Activ_filler)
 Gat_density = GatPoly.ext_or(GatPoly_filler)
 Cont_SQ = Cont.ext_rectangles(true, false, [["==", 0.16.um]], [["==", 0.16.um]], nil)
@@ -791,7 +895,7 @@ M3_Nsram = Metal3.ext_not(SRAM)
 Via1_edgC1_out = Via1.ext_not(EdgeSeal)
 Via2_edgC1_out = Via2.ext_not(EdgeSeal)
 Cont_outside_EdgeSeal = Cont.outside(EdgeSeal)
-ThickGateOx_TGO_f = ThickGateOx.ext_fast_width(0.86.um, consider_intersecting_edges: false, polygon_output: true)
+ThickGateOx_TGO_f = ThickGateOx.ext_width(0.86.um, consider_intersecting_edges: false, polygon_output: true)
 Via3_edgC1_out = Via3.ext_not(EdgeSeal)
 M4_Nsram = Metal4.ext_not(SRAM)
 Via4_edgC1_out = Via4.ext_not(EdgeSeal)
@@ -807,14 +911,14 @@ M4_density = Metal4.ext_or(Metal4_filler).ext_not(Metal4_slit)
 M5_density = Metal5.ext_or(Metal5_filler).ext_not(Metal5_slit)
 TM1_density = TopMetal1.ext_or(TopMetal1_filler).ext_not(TopMetal1_slit)
 TM2_density = TopMetal2.ext_or(TopMetal2_filler).ext_not(TopMetal2_slit)
-GP_Nsram_Gat_a = GP_Nsram.ext_fast_width(0.13.um, consider_intersecting_edges: false, polygon_output: true)
-GP_Nsram_Gat_b = GP_Nsram.ext_fast_space(0.18.um, consider_intersecting_edges: false, polygon_output: true)
+GP_Nsram_Gat_a = GP_Nsram.ext_width(0.13.um, consider_intersecting_edges: false, polygon_output: true)
+GP_Nsram_Gat_b = GP_Nsram.ext_space(0.18.um, consider_intersecting_edges: false, polygon_output: true)
 transG2L = TRANS.ext_interacting_with_text(TEXT_0, "npn13G2L").ext_covering(emi2Pin)
 -&gt; do
     Activ_Act_a.dup
 end.().output("Act.a", "Min. Activ width = 0.15")
 -&gt; do
-    Act_Nsram.ext_fast_space(0.21.um)
+    Act_Nsram.ext_space(0.21.um)
 end.().output("Act.b", "Min. Activ space or notch = 0.21")
 
 if $density
@@ -842,7 +946,7 @@ end.().output("Gat.a", "Min. GatPoly width = 0.13")
     GP_Nsram_Gat_b.dup
 end.().output("Gat.b", "Min. GatPoly space or notch = 0.18")
 -&gt; do
-    GP_Nsram.ext_fast_separation(Act_Nsram, 0.07.um)
+    GP_Nsram.ext_separation(Act_Nsram, 0.07.um)
 end.().output("Gat.d", "Min. GatPoly space to Activ = 0.07")
 
 if $density
@@ -855,13 +959,13 @@ end
     Cont_outside_EdgeSeal.ext_not(ContBar.ext_or(Cont_SQ))
 end.().output("Cnt.a", "Min. and max. Cont width = 0.16")
 -&gt; do
-    Cont_outside_EdgeSeal.ext_fast_space(0.18.um, consider_intersecting_edges: false)
+    Cont_outside_EdgeSeal.ext_space(0.18.um, consider_intersecting_edges: false)
 end.().output("Cnt.b", "Min. Cont space = 0.18")
 -&gt; do
-    Metal1.ext_fast_width(0.16.um)
+    Metal1.ext_width(0.16.um)
 end.().output("M1.a", "Min. Metal1 width = 0.16")
 -&gt; do
-    M1_Nsram.ext_fast_space(0.18.um, consider_intersecting_edges: false, ignore_non_axis_aligned_edges: true)
+    M1_Nsram.ext_space(0.18.um, consider_intersecting_edges: false, ignore_non_axis_aligned_edges: true)
 end.().output("M1.b", "Min. Metal1 space or notch = 0.18")
 
 if $density
@@ -874,10 +978,10 @@ if $density
 end
 
 -&gt; do
-    Metal2.ext_fast_width(0.2.um)
+    Metal2.ext_width(0.2.um)
 end.().output("M2.a", "Min. Metal2 width = 0.20")
 -&gt; do
-    M2_Nsram.ext_fast_space(0.21.um, consider_intersecting_edges: false, ignore_non_axis_aligned_edges: true)
+    M2_Nsram.ext_space(0.21.um, consider_intersecting_edges: false, ignore_non_axis_aligned_edges: true)
 end.().output("M2.b", "Min. Metal2 space or notch = 0.21")
 
 if $density
@@ -890,10 +994,10 @@ if $density
 end
 
 -&gt; do
-    Metal3.ext_fast_width(0.2.um)
+    Metal3.ext_width(0.2.um)
 end.().output("M3.a", "Min. Metal3 width = 0.20")
 -&gt; do
-    M3_Nsram.ext_fast_space(0.21.um, consider_intersecting_edges: false, ignore_non_axis_aligned_edges: true)
+    M3_Nsram.ext_space(0.21.um, consider_intersecting_edges: false, ignore_non_axis_aligned_edges: true)
 end.().output("M3.b", "Min. Metal3 space or notch = 0.21")
 
 if $density
@@ -906,10 +1010,10 @@ if $density
 end
 
 -&gt; do
-    Metal4.ext_fast_width(0.2.um)
+    Metal4.ext_width(0.2.um)
 end.().output("M4.a", "Min. Metal4 width = 0.20")
 -&gt; do
-    M4_Nsram.ext_fast_space(0.21.um, consider_intersecting_edges: false, ignore_non_axis_aligned_edges: true)
+    M4_Nsram.ext_space(0.21.um, consider_intersecting_edges: false, ignore_non_axis_aligned_edges: true)
 end.().output("M4.b", "Min. Metal4 space or notch = 0.21")
 
 if $density
@@ -922,10 +1026,10 @@ if $density
 end
 
 -&gt; do
-    Metal5.ext_fast_width(0.2.um)
+    Metal5.ext_width(0.2.um)
 end.().output("M5.a", "Min. Metal5 width = 0.20")
 -&gt; do
-    M5_Nsram.ext_fast_space(0.21.um, consider_intersecting_edges: false, ignore_non_axis_aligned_edges: true)
+    M5_Nsram.ext_space(0.21.um, consider_intersecting_edges: false, ignore_non_axis_aligned_edges: true)
 end.().output("M5.b", "Min. Metal5 space or notch = 0.21")
 
 if $density
@@ -971,37 +1075,37 @@ end
     Via1_edgC1_out.outside(transG2L).ext_rectangles(false, false, [["==", 0.19.um]], [["==", 0.19.um]], nil, inverted: true)
 end.().output("V1.a", "Min. and max. Via1 width = 0.19")
 -&gt; do
-    Via1_edgC1_out.ext_fast_space(0.22.um, consider_intersecting_edges: false)
+    Via1_edgC1_out.ext_space(0.22.um, consider_intersecting_edges: false)
 end.().output("V1.b", "Min. Via1 space = 0.22")
 -&gt; do
     Via2_edgC1_out.outside(transG2L).ext_rectangles(false, false, [["==", 0.19.um]], [["==", 0.19.um]], nil, inverted: true)
 end.().output("V2.a", "Min. and max. Via2 width = 0.19")
 -&gt; do
-    Via2_edgC1_out.ext_fast_space(0.22.um, consider_intersecting_edges: false)
+    Via2_edgC1_out.ext_space(0.22.um, consider_intersecting_edges: false)
 end.().output("V2.b", "Min. Via2 space = 0.22")
 -&gt; do
     Via3_edgC1_out.outside(transG2L).ext_rectangles(false, false, [["==", 0.19.um]], [["==", 0.19.um]], nil, inverted: true)
 end.().output("V3.a", "Min. and max. Via3 width = 0.19")
 -&gt; do
-    Via3_edgC1_out.ext_fast_space(0.22.um, consider_intersecting_edges: false)
+    Via3_edgC1_out.ext_space(0.22.um, consider_intersecting_edges: false)
 end.().output("V3.b", "Min. Via3 space = 0.22")
 -&gt; do
     Via4_edgC1_out.outside(transG2L).ext_rectangles(false, false, [["==", 0.19.um]], [["==", 0.19.um]], nil, inverted: true)
 end.().output("V4.a", "Min. and max. Via4 width = 0.19")
 -&gt; do
-    Via4_edgC1_out.ext_fast_space(0.22.um, consider_intersecting_edges: false)
+    Via4_edgC1_out.ext_space(0.22.um, consider_intersecting_edges: false)
 end.().output("V4.b", "Min. Via4 space = 0.22")
 -&gt; do
     TopVia1_edgC1_out.ext_or(Vmim).ext_rectangles(false, false, [["==", 0.42.um]], [["==", 0.42.um]], nil, inverted: true)
 end.().output("TV1.a", "Min. and max. TopVia1 width = 0.42")
 -&gt; do
-    TopVia1_or_Vmim.ext_fast_space(0.42.um)
+    TopVia1_or_Vmim.ext_space(0.42.um)
 end.().output("TV1.b", "Min. TopVia1 space = 0.42")
 -&gt; do
-    TopMetal1.ext_fast_width(1.64.um)
+    TopMetal1.ext_width(1.64.um)
 end.().output("TM1.a", "Min. TopMetal1 width = 1.64")
 -&gt; do
-    TopMetal1.ext_fast_space(1.64.um)
+    TopMetal1.ext_space(1.64.um)
 end.().output("TM1.b", "Min. TopMetal1 space or notch = 1.64")
 
 if $density
@@ -1017,13 +1121,13 @@ end
     TopVia2_edgC1_out.ext_rectangles(false, false, [["==", 0.9.um]], [["==", 0.9.um]], nil, inverted: true)
 end.().output("TV2.a", "Min. and max. TopVia2 width = 0.90")
 -&gt; do
-    TopVia2.ext_fast_space(1.06.um)
+    TopVia2.ext_space(1.06.um)
 end.().output("TV2.b", "Min. TopVia2 space = 1.06")
 -&gt; do
-    TopMetal2.ext_fast_width(2.0.um)
+    TopMetal2.ext_width(2.0.um)
 end.().output("TM2.a", "Min. TopMetal2 width = 2.00")
 -&gt; do
-    TopMetal2.ext_fast_space(2.0.um)
+    TopMetal2.ext_space(2.0.um)
 end.().output("TM2.b", "Min. TopMetal2 space or notch = 2.00")
 
 if $density
@@ -1036,10 +1140,10 @@ if $density
 end
 
 -&gt; do
-    Passiv.ext_fast_width(2.1.um)
+    Passiv.ext_width(2.1.um)
 end.().output("Pas.a", "Min. Passiv width = 2.10")
 -&gt; do
-    Passiv.ext_fast_space(3.5.um)
+    Passiv.ext_space(3.5.um)
 end.().output("Pas.b", "Min. Passiv space or notch = 3.50")
 
 if $sanityRules
@@ -1073,7 +1177,7 @@ if $sanityRules
 end
 
 -&gt; do
-    LBE.ext_fast_width(100.0.um)
+    LBE.ext_width(100.0.um)
 end.().output("LBE.a", "Min. LBE width = 100.00")
 -&gt; do
     LBE.drc((width(projection) &gt; 1500.0.um).polygons)
@@ -1082,11 +1186,11 @@ end.().output("LBE.b", "Max. LBE width = 1500.00")
     LBE.ext_with_area([["&gt;", 250000.0.um2]])
 end.().output("LBE.b1", "Max. LBE area (µm²) = 250000.00")
 -&gt; do
-    LBE.ext_fast_space(100.0.um, consider_intersecting_edges: false, ignore_non_axis_aligned_edges: true)
+    LBE.ext_space(100.0.um, consider_intersecting_edges: false, ignore_non_axis_aligned_edges: true)
 end.().output("LBE.c", "Min. LBE space or notch = 100.00")
 -&gt; (;lbe_in_seal) do
     lbe_in_seal = LBE.inside(EdgeSeal.holes.merge)
-    lbe_in_seal.ext_fast_separation(EdgeSeal, 150.0.um, consider_intersecting_edges: false, ignore_non_axis_aligned_edges: true)
+    lbe_in_seal.ext_separation(EdgeSeal, 150.0.um, consider_intersecting_edges: false, ignore_non_axis_aligned_edges: true)
 end.().output("LBE.d", "Min. LBE space to inner edge of EdgeSeal = 150.00")
 -&gt; do
     LBE.with_holes.dup


### PR DESCRIPTION
- add support for 25 more DRC rules, e.g.:
    - NW.c
    - NW.c1
    - NW.d
    - NW.e
    - NW.e1
    - Act.c
    - AFil.i
    - Cnt.c
    - Cnt.d
    - Cnt.e
    - Cnt.g1
    - Cnt.g2
    - CntB.c
    - CntB.d
    - Rppd.d
    - Rhi.e