### PR TITLE
ihp-sg13g2: libs.tech: klayout: tech: macros: Adjust metal filler

### DIFF
--- a/ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_filler_Metal.lym
+++ b/ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_filler_Metal.lym
@@ -112,25 +112,25 @@
 	NoMetFiller = source.input("160/0")
 
 	# Paramter
-	width_m1 = 2
-	height_m1 = 2
+	width_m1 = 2.0
+	height_m1 = 2.0
 	distance_m1 = 1.2
 	
-	width_m2 = 2
-	height_m2 = 2
-	distance_m2 = 1.2
-        
-  width_m3 = 2
-	height_m3 = 2
-	distance_m3 = 1.2
+	width_m2 = 2.0
+	height_m2 = 2.0
+	distance_m2 = 1.0
+
+	width_m3 = 2.0
+	height_m3 = 2.0
+	distance_m3 = 1.8
 	
-	width_m4 = 2
-	height_m4 = 2
-	distance_m4 = 1.2
-        
-  width_m5 = 2.0
+	width_m4 = 2.0
+	height_m4 = 2.0
+	distance_m4 = 1.8
+
+	width_m5 = 2.0
 	height_m5 = 2.0
-	distance_m5 = 1.2
+	distance_m5 = 2.2
 
 	# Create filler cell
 	pattern_m1 = fill_pattern("Met1_FILL_CELL").shape(8, 22,  box(0.0, 0.0, width_m1, height_m1))


### PR DESCRIPTION
Metal fill was a little bit too low for M1 and too high for M3-5.

Fixes #<issue_number_goes_here>

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR
