### PR TITLE
Ignoring dummy trans from being recognized in LVS

### DIFF
--- a/ihp-sg13g2/libs.tech/klayout/tech/lvs/rule_decks/mos_derivations.lvs
+++ b/ihp-sg13g2/libs.tech/klayout/tech/lvs/rule_decks/mos_derivations.lvs
@@ -29,6 +29,7 @@ mos_exclude = pwell_block.join(nsd_drw).join(trans_drw)
                 .join(activ_mask).join(recog_diode).join(recog_esd)
                 .join(ind_drw).join(ind_pin).join(ind_drw)
                 .join(substrate_drw).join(nsd_block)
+                .join(gatpoly_filler.not_overlapping(cont_drw.and(metal1_drw)))
 
 # ==== General FETs & RF-FETs =====
 


### PR DESCRIPTION
## Ignoring dummy trans from being recognized in LVS

Fix: #271 