### PR TITLE
PyCells: Remove unneeded code

### DIFF
--- a/ihp-sg13g2/libs.tech/klayout/python/sg13g2_pycell_lib/__init__.py
+++ b/ihp-sg13g2/libs.tech/klayout/python/sg13g2_pycell_lib/__init__.py
@@ -159,10 +159,6 @@ class PyCellLib(pya.Library):
                 isFirst = False
             print(f'Current process chain: {processChain}')
 
-
-        module = importlib.import_module(f"{__name__}.ihp.pypreprocessor")
-        preProcessor = getattr(module, "preprocessor")
-
         definesSetToPrint = []
 
         for moduleName in moduleNames:

--- a/ihp-sg13g2/libs.tech/klayout/python/sg13g2_pycell_lib/ihp/pypreprocessor.py
+++ b/ihp-sg13g2/libs.tech/klayout/python/sg13g2_pycell_lib/ihp/pypreprocessor.py
@@ -1,1 +1,0 @@
-../../pypreprocessor/pypreprocessor/__init__.py


### PR DESCRIPTION
The variable `preProcessor`  is already defined by the import statement:
```python
from pypreprocessor.pypreprocessor import preprocessor as preProcessor
```
so the later redefinition can be removed. As a result, the symbolic link `pypreprocessor.py` can also be deleted.