### PR TITLE
provide a switch for vbic NQS effect

### DIFF
--- a/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_hbt_mod.lib
+++ b/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_hbt_mod.lib
@@ -43,6 +43,7 @@
 +Ny=1 le=0.96e-6 we=0.12e-6
 +El=le*1e6
 +selft=0
++sw_nqs=0
 
 Qnpn13G2 c b e s1 t npn13G2_NX_vbic dtemp=dtemp m=1
 
@@ -113,7 +114,7 @@ Qnpn13G2 c b e s1 t npn13G2_NX_vbic dtemp=dtemp m=1
 + vtf = 20.0
 + itf = '0.585*(Nx*0.25)'
 + tr = 3.50E-13
-+ td = '2.80E-13*(Nx*0.25)**0'
++ td = 'sw_nqs*2.80E-13*(Nx*0.25)**0'
 + cth = '1.60E-12*(Nx*0.25)**0.95'
 + rth = '1*selft*3.26E+03*(4/Nx)**0.9'
 + ea = 1.056
@@ -149,6 +150,7 @@ Csub s1 bn C = '2.30E-14-(1.50E-15*Nx)'
 +Ny=1 le=0.96e-6 we=0.12e-6
 +El=le*1e6
 +selft=1
++sw_nqs=0
 
 Qnpn13G2 c b e s1 t npn13G2_NX_vbic dtemp=dtemp m=1
 
@@ -219,7 +221,7 @@ Qnpn13G2 c b e s1 t npn13G2_NX_vbic dtemp=dtemp m=1
 + vtf = 20.0
 + itf = '0.585*(Nx*0.25)'
 + tr = 3.50E-13
-+ td = '2.80E-13*(Nx*0.25)**0'
++ td = 'sw_nqs*2.80E-13*(Nx*0.25)**0'
 + cth = '1.60E-12*(Nx*0.25)**0.95'
 + rth = '1*selft*3.26E+03*(4/Nx)**0.9'
 + ea = 1.056
@@ -276,6 +278,7 @@ Csub s1 bn C = '2.30E-14-(1.50E-15*Nx)'
 +Ny=1 we=0.12e-6
 +El=le*1e6
 +selft=0
++sw_nqs=0
 
 Qnpn13G2l c b e s1 t npn13G2l_NX_vbic dtemp=dtemp m=1
 
@@ -346,7 +349,7 @@ Qnpn13G2l c b e s1 t npn13G2l_NX_vbic dtemp=dtemp m=1
 + vtf = 20.0
 + itf = '1.658*(El/2.5)*(Nx*0.25)'
 + tr = 5.00E-13
-+ td = '2.8e-13*(El/2.5)'
++ td = 'sw_nqs*2.8e-13*(El/2.5)'
 + cth = '4.18E-12*(El/2.5)**0.8*(Nx*0.25)**0.8'
 + rth = 'selft*1.63E+03*(2.5/El)**0.85*(4/Nx)**0.8'
 + ea = 1.045
@@ -380,6 +383,7 @@ Csub s1 bn C = '(1.70E-14-(2.00E-15*Nx))*(El/2.5)**0'
 +Ny=1 we=0.12e-6
 +El=le*1e6
 +selft=1
++sw_nqs=0
 
 Qnpn13G2l c b e s1 t npn13G2l_NX_vbic dtemp=dtemp m=1
 
@@ -450,7 +454,7 @@ Qnpn13G2l c b e s1 t npn13G2l_NX_vbic dtemp=dtemp m=1
 + vtf = 20.0
 + itf = '1.658*(El/2.5)*(Nx*0.25)'
 + tr = 5.00E-13
-+ td = '2.8e-13*(El/2.5)'
++ td = 'sw_nqs*2.8e-13*(El/2.5)'
 + cth = '4.18E-12*(El/2.5)**0.8*(Nx*0.25)**0.8'
 + rth = 'selft*1.63E+03*(2.5/El)**0.85*(4/Nx)**0.8'
 + ea = 1.045
@@ -508,6 +512,7 @@ Rt t 0 R = 1e9
 +Ny=1 we=0.12e-6
 +El=le*1e6
 +selft=0
++sw_nqs=0
 
 Qnpn13G2v c b e s1 t npn13G2v_NX_vbic dtemp=dtemp m=1
 
@@ -578,7 +583,7 @@ Qnpn13G2v c b e s1 t npn13G2v_NX_vbic dtemp=dtemp m=1
 + vtf = 20.0
 + itf = '0.390*(El/2.5)*(Nx*0.25)'
 + tr = 1.50E-12
-+ td = '5.60E-13*(El/2.5)'
++ td = 'sw_nqs*5.60E-13*(El/2.5)'
 + cth = '4.40E-12*(El/2.5)**1*(Nx*0.25)**0.8'
 + rth = 'selft*1.55E+03*(2.5/El)**1*(4/Nx)**0.88'
 + ea = 1.030
@@ -612,6 +617,7 @@ Csub s1 bn C = '(1.70E-14-(2.00E-15*Nx))*(El/2.5)**0'
 +Ny=1 we=0.12e-6
 +El=le*1e6
 +selft=1
++sw_nqs=0
 
 Qnpn13G2v c b e s1 t npn13G2v_NX_vbic dtemp=dtemp m=1
 
@@ -682,7 +688,7 @@ Qnpn13G2v c b e s1 t npn13G2v_NX_vbic dtemp=dtemp m=1
 + vtf = 20.0
 + itf = '0.390*(El/2.5)*(Nx*0.25)'
 + tr = 1.50E-12
-+ td = '5.60E-13*(El/2.5)'
++ td = 'sw_nqs*5.60E-13*(El/2.5)'
 + cth = '4.40E-12*(El/2.5)**1*(Nx*0.25)**0.8'
 + rth = 'selft*1.55E+03*(2.5/El)**1*(4/Nx)**0.88'
 + ea = 1.030


### PR DESCRIPTION
Fixes #309

The switch sw_nqs is a parameter of the npn13G2 subckt. Default is 0 - setting it to 1 enables the NQS model in vbic.
In schematic an appropriate symbol is needed. 
