### PR TITLE
Annotation of key FET parameters

### DIFF
--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/annotate_fet_params.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/annotate_fet_params.sym
@@ -1,0 +1,12 @@
+v {xschem version=3.4.6 file_version=1.2}
+G {}
+K {type=annotator
+template="name=annot1 ref=M1"}
+V {}
+S {}
+E {}
+L 4 0 -0 0 10 {}
+L 4 -0 -0 10 -0 {}
+T {tcleval([display_fet_params @ref ])} 5 5 0 0 0.2 0.2 {layer=15
+font=Monospace}
+T {@ref} 0 0 2 1 0.2 0.2 {layer=4}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_hv_nmos.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_hv_nmos.sch
@@ -1,5 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
-}
+v {xschem version=3.4.6 file_version=1.2}
 G {}
 K {}
 V {}
@@ -23,7 +22,8 @@ dataset=-1
 unitx=1
 logx=0
 logy=0
-}
+sim_type=dc
+autoload=1}
 N -110 70 -110 90 {
 lab=GND}
 N -110 -0 -110 10 {
@@ -51,10 +51,16 @@ format="tcleval( @value )"
 value="
 .lib cornerMOShv.lib mos_tt
 "}
-C {devices/code_shown.sym} 310 -30 0 0 {name=NGSPICE only_toplevel=true 
+C {devices/code_shown.sym} 270 0 0 0 {name=NGSPICE only_toplevel=true 
 value="
+.options savecurrents
+.include dc_hv_nmos.save
 .param temp=27
 .control 
+save all
+op
+write dc_hv_nmos.raw
+set appendwrite
 dc Vds 0 3.0 0.01 Vgs 0.3 1.5 0.05
 write dc_hv_nmos.raw
 .endc
@@ -66,10 +72,6 @@ C {devices/vsource.sym} 150 0 0 0 {name=Vds value=1.5}
 C {devices/gnd.sym} 150 90 0 0 {name=l3 lab=GND}
 C {devices/gnd.sym} 70 90 0 0 {name=l4 lab=GND}
 C {devices/title.sym} -130 260 0 0 {name=l5 author="Copyright 2023 IHP PDK Authors"}
-C {devices/launcher.sym} -200 -160 0 0 {name=h5
-descr="load waves Ctrl + left click" 
-tclcommand="xschem raw_read $netlist_dir/dc_hv_nmos.raw dc"
-}
 C {devices/ammeter.sym} 80 -70 1 0 {name=Vd}
 C {sg13g2_pr/sg13_hv_nmos.sym} 0 0 2 1 {name=M1
 l=0.45u
@@ -79,3 +81,12 @@ m=1
 model=sg13_hv_nmos
 spiceprefix=X
 }
+C {devices/launcher.sym} 630 -70 0 0 {name=h1
+descr="load waves Ctrl + left click" 
+tclcommand="xschem raw_read $netlist_dir/dc_hv_nmos.raw dc"
+}
+C {devices/launcher.sym} 630 -40 0 0 {name=h2
+descr="OP annotate" 
+tclcommand="xschem annotate_op"
+}
+C {sg13g2_pr/annotate_fet_params.sym} -110 -130 0 0 {name=annot1 ref=M1}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_hv_pmos.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_hv_pmos.sch
@@ -1,5 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
-}
+v {xschem version=3.4.6 file_version=1.2}
 G {}
 K {}
 V {}
@@ -7,14 +6,14 @@ S {}
 E {}
 B 2 150 -510 950 -110 {flags=graph
 y1=-1.1e-05
-y2=-0
+y2=-2.9e-09
 ypos1=0
 ypos2=2
 divy=5
 subdivy=1
 unity=1
-x1=-2
-x2=0
+x1=-2.0308261
+x2=-0.030826141
 divx=5
 subdivx=1
 
@@ -24,7 +23,9 @@ unitx=1
 logx=0
 logy=0
 color=4
-node=i(vd)}
+node=i(vd)
+sim_type=dc
+autoload=1}
 N -110 70 -110 90 {
 lab=GND}
 N -110 -0 -110 10 {
@@ -52,12 +53,16 @@ format="tcleval( @value )"
 value="
 .lib cornerMOShv.lib mos_tt
 "}
-C {devices/code_shown.sym} 290 -10 0 0 {name=NGSPICE only_toplevel=true 
+C {devices/code_shown.sym} 290 -20 0 0 {name=NGSPICE only_toplevel=true 
 value="
 .param temp=27
+.options savecurrents
+.include dc_hv_pmos.save
 .control
 save all
 op 
+write dc_hv_pmos.raw
+set appendwrite
 print I(Vd)
 dc Vds 0 -2 -0.01 Vgs -0.45 -1.1 -0.05
 write dc_hv_pmos.raw
@@ -70,10 +75,6 @@ C {devices/vsource.sym} 150 0 0 0 {name=Vds value=-1.5}
 C {devices/gnd.sym} 150 90 0 0 {name=l3 lab=GND}
 C {devices/gnd.sym} 70 90 0 0 {name=l4 lab=GND}
 C {devices/title.sym} -130 260 0 0 {name=l5 author="Copyright 2023 IHP PDK Authors"}
-C {devices/launcher.sym} -230 -150 0 0 {name=h5
-descr="load waves" 
-tclcommand="xschem raw_read $netlist_dir/dc_hv_pmos.raw dc"
-}
 C {sg13g2_pr/sg13_hv_pmos.sym} 0 0 2 1 {name=M1
 l=0.45u
 w=1.0u
@@ -83,3 +84,12 @@ model=sg13_hv_pmos
 spiceprefix=X
 }
 C {devices/ammeter.sym} 80 -110 1 0 {name=Vd}
+C {devices/launcher.sym} 550 -90 0 0 {name=h1
+descr="load waves Ctrl + left click" 
+tclcommand="xschem raw_read $netlist_dir/dc_hv_pmos.raw dc"
+}
+C {devices/launcher.sym} 550 -60 0 0 {name=h2
+descr="OP annotate" 
+tclcommand="xschem annotate_op"
+}
+C {sg13g2_pr/annotate_fet_params.sym} 30 -250 0 0 {name=annot1 ref=M1}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_lv_nmos.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_lv_nmos.sch
@@ -1,13 +1,12 @@
-v {xschem version=3.4.5 file_version=1.2
-}
+v {xschem version=3.4.6 file_version=1.2}
 G {}
 K {}
 V {}
 S {}
 E {}
-B 2 240 -350 1040 50 {flags=graph
-y1=-6.4e-14
-y2=7.9e-06
+B 2 510 -650 1070 -350 {flags=graph
+y1=-4.6e-12
+y2=0.00025
 ypos1=0
 ypos2=2
 divy=5
@@ -23,60 +22,71 @@ dataset=-1
 unitx=1
 logx=0
 logy=0
-}
-N -110 70 -110 90 {
+sim_type=dc
+autoload=1}
+N 250 -160 250 -140 {
 lab=GND}
-N -110 -0 -110 10 {
+N 250 -250 250 -220 {
+lab=G}
+N 380 -220 380 -160 {
+lab=GND}
+N 510 -220 510 -160 {
+lab=GND}
+N 380 -340 380 -280 {
 lab=#net1}
-N 20 30 20 90 {
+N 510 -340 510 -280 {
+lab=D}
+N 380 -250 450 -250 {
 lab=GND}
-N 150 30 150 90 {
+N 450 -250 450 -160 {
 lab=GND}
-N 20 -70 20 -30 {
-lab=#net2}
-N 150 -70 150 -30 {
-lab=#net3}
-N 20 0 70 0 {
-lab=GND}
-N 70 0 70 90 {
-lab=GND}
-N 20 -70 50 -70 {
-lab=#net2}
-N 110 -70 150 -70 {
-lab=#net3}
-N -110 0 -20 0 {
+N 380 -340 410 -340 {
 lab=#net1}
-C {devices/code_shown.sym} -290 190 0 0 {name=MODEL only_toplevel=true
+N 470 -340 510 -340 {
+lab=D}
+N 250 -250 340 -250 {
+lab=G}
+C {devices/code_shown.sym} 0 -100 0 0 {name=MODEL only_toplevel=true
 format="tcleval( @value )"
 value=".lib cornerMOSlv.lib mos_tt
 "}
-C {devices/code_shown.sym} -300 -320 0 0 {name=NGSPICE only_toplevel=true 
+C {devices/code_shown.sym} 100 -610 0 0 {name=NGSPICE only_toplevel=true 
 value="
+.include dc_lv_nmos.save
 .param temp=27
 .control
 save all 
 op
-dc Vds 0 1.2 0.01 Vgs 0.3 0.5 0.05
+write dc_lv_nmos.raw
+set appendwrite
+dc Vds 0 1.2 0.01 Vgs 0.3 1.0 0.1
 write dc_lv_nmos.raw
 .endc
 "}
-C {devices/gnd.sym} 20 90 0 0 {name=l1 lab=GND}
-C {devices/gnd.sym} -110 90 0 0 {name=l2 lab=GND}
-C {devices/vsource.sym} -110 40 0 0 {name=Vgs value=0.75}
-C {devices/vsource.sym} 150 0 0 0 {name=Vds value=1.5}
-C {devices/gnd.sym} 150 90 0 0 {name=l3 lab=GND}
-C {devices/gnd.sym} 70 90 0 0 {name=l4 lab=GND}
-C {devices/title.sym} -130 260 0 0 {name=l5 author="Copyright 2023 IHP PDK Authors"}
-C {devices/launcher.sym} 310 90 0 0 {name=h5
+C {devices/gnd.sym} 380 -160 0 0 {name=l1 lab=GND}
+C {devices/gnd.sym} 250 -140 0 0 {name=l2 lab=GND}
+C {devices/vsource.sym} 250 -190 0 0 {name=Vgs value=1.2}
+C {devices/vsource.sym} 510 -250 0 0 {name=Vds value=1.5}
+C {devices/gnd.sym} 510 -160 0 0 {name=l3 lab=GND}
+C {devices/gnd.sym} 450 -160 0 0 {name=l4 lab=GND}
+C {devices/title.sym} 160 -30 0 0 {name=l5 author="Copyright 2023 IHP PDK Authors"}
+C {devices/launcher.sym} 710 -330 0 0 {name=h5
 descr="load waves Ctrl + left click" 
 tclcommand="xschem raw_read $netlist_dir/dc_lv_nmos.raw dc"
 }
-C {devices/ammeter.sym} 80 -70 1 0 {name=Vd}
-C {sg13g2_pr/sg13_lv_nmos.sym} 0 0 2 1 {name=M1
+C {devices/ammeter.sym} 440 -340 1 0 {name=Vd}
+C {sg13g2_pr/sg13_lv_nmos.sym} 360 -250 2 1 {name=M1
 l=0.13u
 w=1.0u
 ng=1
 m=1
 model=sg13_lv_nmos
 spiceprefix=X
+}
+C {sg13g2_pr/annotate_fet_params.sym} 260 -380 0 0 {name=annot1 ref=M1}
+C {lab_pin.sym} 250 -250 0 0 {name=p1 sig_type=std_logic lab=G}
+C {lab_pin.sym} 510 -340 0 1 {name=p2 sig_type=std_logic lab=D}
+C {devices/launcher.sym} 710 -300 0 0 {name=h1
+descr="OP annotate" 
+tclcommand="xschem annotate_op"
 }

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_lv_pmos.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_lv_pmos.sch
@@ -1,5 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
-}
+v {xschem version=3.4.6 file_version=1.2}
 G {}
 K {}
 V {}
@@ -23,7 +22,8 @@ dataset=-1
 unitx=1
 logx=0
 logy=0
-}
+sim_type=dc
+autoload=1}
 T {The Vds source is inverted in 
 order to plot positive value of 
 the current, which corresponds 
@@ -57,8 +57,14 @@ value="
 "}
 C {devices/code_shown.sym} 290 -10 0 0 {name=NGSPICE only_toplevel=true 
 value="
+.options savecurrents
+.include dc_lv_pmos.save
 .param temp=27
 .control
+save all
+op
+write dc_lv_pmos.raw
+set appendwrite
 dc Vds 0 -1.2 -0.01 Vgs -0.35 -1.1 -0.05
 write dc_lv_pmos.raw
 .endc
@@ -70,10 +76,6 @@ C {devices/vsource.sym} 150 0 0 0 {name=Vds value=-1.5}
 C {devices/gnd.sym} 150 90 0 0 {name=l3 lab=GND}
 C {devices/gnd.sym} 70 90 0 0 {name=l4 lab=GND}
 C {devices/title.sym} -130 260 0 0 {name=l5 author="Copyright 2023 IHP PDK Authors"}
-C {devices/launcher.sym} -230 -150 0 0 {name=h5
-descr="load waves" 
-tclcommand="xschem raw_read $netlist_dir/dc_lv_pmos.raw dc"
-}
 C {sg13g2_pr/sg13_lv_pmos.sym} 0 0 2 1 {name=M1
 l=0.45u
 w=1.0u
@@ -83,3 +85,12 @@ model=sg13_lv_pmos
 spiceprefix=X
 }
 C {devices/ammeter.sym} 80 -110 1 0 {name=Vd}
+C {devices/launcher.sym} 610 -80 0 0 {name=h1
+descr="load waves Ctrl + left click" 
+tclcommand="xschem raw_read $netlist_dir/dc_lv_pmos.raw dc"
+}
+C {devices/launcher.sym} 610 -50 0 0 {name=h2
+descr="OP annotate" 
+tclcommand="xschem annotate_op"
+}
+C {sg13g2_pr/annotate_fet_params.sym} 10 -270 0 0 {name=annot1 ref=M1}

--- a/ihp-sg13g2/libs.tech/xschem/xschemrc
+++ b/ihp-sg13g2/libs.tech/xschem/xschemrc
@@ -33,7 +33,7 @@ append XSCHEM_LIBRARY_PATH :${XSCHEM_SHAREDIR}/xschem_library
 #### include skywater libraries. Here i use [pwd]. This works if i start xschem from here.
 append XSCHEM_LIBRARY_PATH :[file dirname [info script]]
 #### add ~/.xschem/xschem_library (USER_CONF_DIR is normally ~/.xschem)
-append XSCHEM_LIBRARY_PATH :$USER_CONF_DIR/xschem_library 
+append XSCHEM_LIBRARY_PATH :$USER_CONF_DIR/xschem_library
 
 ###########################################################################
 #### SET CUSTOM COLORS FOR XSCHEM LIBRARIES MATCHING CERTAIN PATTERNS
@@ -50,7 +50,7 @@ set dircolor(devices$) red
 ###########################################################################
 #### DIRECTORY WHERE SIMULATIONS, NETLIST AND SIMULATOR OUTPUTS ARE PLACED
 ###########################################################################
-#### If unset $USER_CONF_DIR/simulations is assumed (normally ~/.xschem/simulations) 
+#### If unset $USER_CONF_DIR/simulations is assumed (normally ~/.xschem/simulations)
 set netlist_dir $env(PWD)/simulations
 #### if this is set to '1' netlists and simulations will go into a simulation/ folder
 #### inside the directory containing the top level schematic. Default: not set (0)
@@ -77,13 +77,13 @@ set netlist_dir $env(PWD)/simulations
 # set nolist_libs {}
 
 ###########################################################################
-#### CHANGE DEFAULT [] WITH SOME OTHER CHARACTERS FOR BUSSED SIGNALS 
-#### IN SPICE NETLISTS (EXAMPLE: DATA[7] --> DATA<7>) 
+#### CHANGE DEFAULT [] WITH SOME OTHER CHARACTERS FOR BUSSED SIGNALS
+#### IN SPICE NETLISTS (EXAMPLE: DATA[7] --> DATA<7>)
 ###########################################################################
 #### default: empty (use xschem default, [ ])
 # set bus_replacement_char {<>}
 #### for XSPICE: replace square brackets as the are used for XSPICE vector nodes.
-# set bus_replacement_char {__} 
+# set bus_replacement_char {__}
 
 ###########################################################################
 #### SOME DEFAULT BEHAVIOR
@@ -135,12 +135,12 @@ set zoom_full_center 1
 # set connect_by_kissing 1
 
 #### if set to 1 automatically join/trim wires while editing
-#### this may slow down on rally big designs. Can be disabled via menu 
+#### this may slow down on rally big designs. Can be disabled via menu
 #### default: 0
 set autotrim_wires 1
 
 #### set widget scaling (mainly for font display), this is useful on 4K displays
-#### default: unset (tk uses its default) > 1.0 ==> bigger 
+#### default: unset (tk uses its default) > 1.0 ==> bigger
 # set tk_scaling 1.7
 
 #### use the tclreadline package if available , Default: 1 (enabled).
@@ -179,7 +179,7 @@ set autotrim_wires 1
 ###########################################################################
 #### EXPORT FORMAT TRANSLATORS, PNG AND PDF
 ###########################################################################
-#### command to translate xpm to png; (assumes command takes source 
+#### command to translate xpm to png; (assumes command takes source
 #### and dest file as arguments, example: gm convert plot.xpm plot.png)
 #### default: {gm convert}
 #### Windows ghostscript uses gswin64c
@@ -197,7 +197,7 @@ set to_pdf {ps2pdf -dAutoRotatePages=/None}
 ###########################################################################
 #### UNDO: SAVE ON DISK OR KEEP IN MEMORY
 ###########################################################################
-#### Alloved: 'disk'or 'memory'. 
+#### Alloved: 'disk'or 'memory'.
 #### Saving undo on disk is safer but slower on extremely big schematics.
 #### In most cases you won't notice any delay. Undo on disk allows previous
 #### state recovery in case of crashes. In-memory undo is extremely fast
@@ -238,7 +238,7 @@ set to_pdf {ps2pdf -dAutoRotatePages=/None}
 #### Scale all fonts by this number
 # set cairo_font_scale 1.0
 
-#### default for following two is 0.85 (xscale) and 0.88 (yscale) to 
+#### default for following two is 0.85 (xscale) and 0.88 (yscale) to
 #### match cairo font spacing
 # set nocairo_font_xscale 1.0
 #### set nocairo_font_yscale 1.0
@@ -272,7 +272,7 @@ set to_pdf {ps2pdf -dAutoRotatePages=/None}
 ###########################################################################
 #### default for linux: xterm
 # set terminal {xterm -geometry 100x35 -fn 9x15 -bg black -fg white -cr white -ms white }
-#### lxterminal is not OK since it will not inherit env vars: 
+#### lxterminal is not OK since it will not inherit env vars:
 #### In order to reduce memory usage and increase the performance, all instances
 #### of the lxterminal are sharing a single process. LXTerminal is part of LXDE
 
@@ -297,7 +297,7 @@ set to_pdf {ps2pdf -dAutoRotatePages=/None}
 ###########################################################################
 #### ALWAYS SHOW ERC INFO WINDOW AFTER NETLIST
 ###########################################################################
-#### default: 0 
+#### default: 0
 # set show_infowindow_after_netlist 0
 
 ###########################################################################
@@ -345,7 +345,7 @@ set toolbar_visible 1
 ###########################################################################
 #### TABBED WINDOWS
 ###########################################################################
-# default: not enabled. Interface can be changed runtime if only one window 
+# default: not enabled. Interface can be changed runtime if only one window
 # or tab is open.
 set tabbed_interface 1
 
@@ -373,7 +373,7 @@ set tabbed_interface 1
 #### SHOW HIDDEN TEXTS
 ###########################################################################
 ## This option shows text objects even if they have attribute 'hide=true' set
-## default: 0 (not set) 
+## default: 0 (not set)
 # set show_hidden_texts 1
 
 ###########################################################################
@@ -395,7 +395,7 @@ if { [info exists env(PDK_ROOT)] && $env(PDK_ROOT) ne {} } {
   }
   set PDK_ROOT $env(PDK_ROOT)
 } else {
-  ## not existing or empty. 
+  ## not existing or empty.
   puts stderr "Warning: PDK_ROOT env. var. not found or empty, trying to find an open_pdks install"
   if {[file isdir /usr/share/pdk]} {set PDK_ROOT /usr/share/pdk
   } elseif {[file isdir /usr/local/share/pdk]} {set PDK_ROOT /usr/local/share/pdk
@@ -441,10 +441,10 @@ proc fet_drc {instance symbol model w l ng } {
   regsub {u$} $l {} l
   # puts "$instance $model $symbol w=$w l=$l nf=$nf"
   if { [string is double $w] && [string is double $l] && [string is integer $ng]} {
-    
-  # calculate finger width 
+
+  # calculate finger width
     set w [expr { double($w) / double($ng)}]
-    
+
     switch -regexp $model {
       {sg13_lv_nmos$} {
         if { $w < 0.13 } {
@@ -499,7 +499,7 @@ proc res_drc {instance symbol model w l } {
   set res {}
   # puts "$instance $model $symbol w=$w l=$l nf=$nf"
   if { [string is double $w] && [string is double $l] } {
-    
+
     if { $w < 0.5e-6 } {
       append res "${instance} ($model): resistor width is too small, w = $w, min. w > 0.5u" \n
     }
@@ -513,18 +513,18 @@ proc res_drc {instance symbol model w l } {
 # IHP SG13G2 MiM capacitor dimension checks
 proc mim_drc {instance symbol model w l } {
   set res {}
-  
+
   if { [string is double $w] && [string is double $l] } {
     set area [expr { double($w) * double($l) * 1.0e+12}]
- 
+
     if { $w < 1.14e-6 } {
       append res "${instance} ($model): MiM capacitor width is too small, w = $w, min. w > 1.14 um" \n
     }
-    
+
     if { $area < 1.3 } {
        append res "${instance} ($model): MiM capacitor area is too small, area = $area, min. area > 1.3 um2" \n
     }
-    
+
     if { $area > 5625.0 } {
        append res "${instance} ($model): MiM capacitor area is too big, area = $area, max. area < 5625.0 um2" \n
     }
@@ -536,8 +536,8 @@ proc hbt_drc {instance symbol model Nx El } {
   set res {}
   # puts "$instance $model $symbol w=$w l=$l nf=$nf"
   if { [string is integer $Nx] || [string is double $El]} {
-    
-    
+
+
     switch -regexp $model {
       {npn13G2$} {
         if { $Nx < 1 } {
@@ -575,7 +575,7 @@ proc hbt_drc {instance symbol model Nx El } {
           append res "${instance} ($model): Emitter length El = $El too big, max. El <= 5 " \n
         }
       }
-      
+
       {npn13G2_5t$} {
         if { $Nx < 1 } {
           append res "${instance} ($model):  Number of emmiters Nx = $Nx must be in range 1-10" \n
@@ -623,7 +623,7 @@ proc diode_drc {instance symbol model w l } {
   regsub {u$} $l {} l
   # puts "$instance $model $symbol w=$w l=$l nf=$nf"
   if { [string is double $w] && [string is double $l]} {
-    
+
     switch -regexp $model {
       {dantenna} {
         if { $w < 0.78 } {
@@ -645,3 +645,183 @@ proc diode_drc {instance symbol model w l } {
   }
   return $res
 }
+
+
+##################### save and display MOSFET parameters #####################
+
+# writes the .save instructions for given FET instance
+proc write_save_lines {type model schpath spiceprefix instname} {
+  global sch_expand
+  if {[regexp {[pn]mos} $type]} {
+    set m n$model
+    set devpath [string tolower @n.$schpath$spiceprefix$instname.$m]
+
+    append sch_expand(savelist) ".save $devpath\[gm\]\n"
+    append sch_expand(savelist) ".save $devpath\[gds\]\n"
+    append sch_expand(savelist) ".save $devpath\[vth\]\n"
+    append sch_expand(savelist) ".save $devpath\[vdss\]\n"
+    append sch_expand(savelist) ".save $devpath\[cgg\]\n"
+    append sch_expand(savelist) ".save $devpath\[cgsol\]\n"
+    append sch_expand(savelist) ".save $devpath\[cgdol\]\n"
+  }
+}
+
+############ sch_expand
+# This proc traverses the hierarchy and prints all instances in design.
+proc sch_expand {{only_subckts 1} {all_hierarchy 1} {pattern {.*}}} {
+  global sch_expand keep_symbols
+  set sch_expand(savelist) {}
+  set sch_expand(only_subckts) $only_subckts
+  set sch_expand(all_hierarchy) $all_hierarchy
+  set sch_expand(startpath) [string length [xschem get sch_path]]
+  set save_keep $keep_symbols
+  set keep_symbols 1
+  xschem unselect_all
+  xschem set no_draw 1 ;# disable screen update
+  xschem set no_undo 1 ;# disable undo
+
+  hier_sch_expand 0 $only_subckts $all_hierarchy $pattern
+
+  xschem set no_draw 0
+  xschem set no_undo 0
+  set keep_symbols $save_keep
+  return {}
+}
+
+# recursive procedure used by sch_expand
+proc hier_sch_expand {{level 0} {only_subckts 0} {all_hierarchy 1} {pattern {.*}}} {
+  global nolist_libs sch_expand
+
+  set schpath [string range [xschem get sch_path] $sch_expand(startpath) end]
+  set instances  [xschem get instances]
+  for {set i 0} { $i < $instances} { incr i} {
+    set instname [xschem getprop instance $i name]
+    # puts "hier_sch_expand: instname=$instname schpath=$schpath"
+    set symbol [xschem getprop instance $i cell::name]
+    set spiceprefix [xschem getprop instance $i spiceprefix]
+    set model [xschem translate $instname @model]
+    set abs_symbol [abs_sym_path $symbol]
+    set type [xschem getprop symbol $symbol type]
+
+    if {$only_subckts && ($type ne {subcircuit})} { continue }
+    set skip 0
+    foreach j $nolist_libs {
+      if {[regexp $j $abs_symbol]} {
+        set skip 1
+        break
+      }
+    }
+    if {$skip} { continue }
+    if {$type ne {subcircuit} && ![regexp $pattern $type]} {
+      continue
+    }
+
+    write_save_lines $type $model $schpath $spiceprefix $instname
+
+    if {$type eq {subcircuit} && $all_hierarchy} {
+      xschem select instance $i fast nodraw
+      # puts "descend: [xschem translate $i @name]"
+      set descended [xschem descend 1 6]
+      if {$descended} {
+        incr level
+        set dp [hier_sch_expand $level $only_subckts 1 $pattern]
+        xschem go_back 1
+        incr level -1
+      }
+    }
+  }
+  return 1
+}
+############ /sch_expand
+
+# generate the .save lines to save all mos parameters
+proc save_fet_params {} {
+  global sch_expand
+  sch_expand 0 1 {[pn]mos}
+  return "* Place this .save file with a .include line in your testbench\n\n$sch_expand(savelist)"
+}
+
+# displays mos parameters simulation data , used in symbol sky130_fd_pr/annotate_fet_params.sym
+proc display_fet_params {instname} {
+  set txt {}
+  set schpath [xschem get sim_sch_path]
+  set symbol [xschem getprop instance $instname cell::name]
+  set spiceprefix [xschem getprop instance $instname spiceprefix]
+  set model [xschem translate $instname @model]
+  set type [xschem getprop symbol $symbol type]
+
+  if {[regexp {[pn]mos} $type]} {
+    set m n$model
+    set devpath [string tolower @n.$schpath$spiceprefix$instname.$m]
+
+    append txt "gm    = [to_eng [xschem raw value $devpath\[gm\] -1]]\n"
+    append txt "gds   = [to_eng [xschem raw value $devpath\[gds\] -1]]\n"
+    append txt "vth   = [to_eng [xschem raw value v($devpath\[vth\]) -1]]\n"
+    append txt "vdss  = [to_eng [xschem raw value v($devpath\[vdss\]) -1]]\n"
+    append txt "cgg   = [to_eng [xschem raw value $devpath\[cgg\] -1]]\n"
+    append txt "cgdol = [to_eng [xschem raw value $devpath\[cgdol\] -1]]\n"
+    append txt "cgsol = [to_eng [xschem raw value $devpath\[cgsol\] -1]]\n"
+    set pi 3.141592654
+    set gm [xschem raw value $devpath\[gm\] -1]
+    set cgg [xschem raw value $devpath\[cgg\] -1]
+    set cgdol [xschem raw value $devpath\[cgdol\] -1]
+    set cgsol [xschem raw value $devpath\[cgsol\] -1]
+    if {[catch { expr $gm / 2 / $pi / ($cgg + $cgdol + $cgsol)} ft]} {
+      set ft {}
+    }
+    append txt "ft    = [to_eng ${ft}]\n"
+  }
+  return $txt
+}
+
+
+# these commands are executed when xschem has completed initialization.
+# add a SKY130 menu entry
+proc menupdk {} {
+  global has_x netlist_dir
+  if { [info exists has_x] } {
+    set topwin [xschem get top_path]
+
+    # insert before the 'Netlist' menu
+    $topwin.menubar insert Netlist cascade -label IHP -menu $topwin.menubar.ihp
+    menu $topwin.menubar.ihp -tearoff 0
+
+    ## Create one entry
+    $topwin.menubar.ihp add command -label {Create FET .save file} -command {
+      write_data [save_fet_params] $netlist_dir/[file rootname [file tail [xschem get current_name]]].save
+      textwindow $netlist_dir/[file rootname [file tail [xschem get current_name]]].save
+    }
+    ## Create one entry
+    $topwin.menubar.ihp add command -label {Add models symbol} -command {
+      xschem place_symbol devices/code_shown.sym {
+name=TT_MODELS
+only_toplevel=true
+value="
+** IHP models
+.lib cornerMOSlv.lib mos_tt
+.lib cornerMOShv.lib mos_tt
+"
+spice_ignore=false
+      }
+    }
+
+    ## Create one entry
+    $topwin.menubar.ihp add command -label {Add FET param annotator} -command {
+      proc get_sel_inst_name {} {
+        set selset [lindex [xschem selected_set] 0]
+        if {$selset ne {}} {
+          set name [xschem getprop instance $selset name]
+          xschem place_symbol sg13g2_pr/annotate_fet_params.sym "name=annot1 ref=$name"
+        } else {
+          xschem place_symbol sg13g2_pr/annotate_fet_params.sym
+        }
+      }
+      get_sel_inst_name
+    }
+  }
+}
+
+# execute menupdk when xschem initialization is completed
+append postinit_commands "menupdk\n"
+
+##################### /save and display MOSFET parameters #####################


### PR DESCRIPTION
Implements @hpretl [request](https://open-source-silicon.slack.com/archives/C017P3RAD42/p1740812343257639?thread_ts=1740791679.438969&cid=C017P3RAD42)

Added symbol: `sg13g2_pr/annotate_fet_params.sym`
Shows `gm, gds, vth, vdss, cgg, cgdol, cgsol` and `ft` (calculated from previous parameters) for the transistor it is linked to (via a `ref=Mx` attribute).

`sg13g2_tests/dc_*v_*mos.sch` test cases changed to use it. 

Helper procedures added to xschemrc

IHP specific menu entry added with 3 entries:

1. **Create FET .save file**: this creates a file with .save instructions, so that all data is available in the raw file. Just add a .include line of the generated file in the testbench. This is done in the `sg13g2_tests/dc_*v_*mos.sch` test cases 
2. **Add models symbol**. This simple entry places a `code_shown.sym` symbol in the schematic with the .lib lines for lv and hv FETS that are needed for simulation.
3. **Add FET param annotator** (`annotate_fet_params.sym`): Places the symbol that shows the above DC / small signal parameters for the linked transistor. After placement you need to set the `ref` attribute to the name of the MOS device it refers to. If this menu is clicked with one MOS selected it will fill in the ref attribute automatically.

All these changes are IHP specific, follow the same additions done on sky130 and do not require changes in the xschem codebase.

The image shows the annotator in action for M1 and the IHP menu entry in the menubar.

The menu addition can later be used to add other new pdk-specific functions. A few lines in the xschemrc file are needed to add other entries.
![1](https://github.com/user-attachments/assets/0afbe02b-7663-40a4-a813-6179ed1e0537)
