### PR TITLE
Corrections to fill pattern generation and density checks in magic.

### DIFF
--- a/ihp-sg13g2/libs.tech/magic/README.md
+++ b/ihp-sg13g2/libs.tech/magic/README.md
@@ -251,3 +251,39 @@ known sheet resistance values.
 |-------------|-----------------------------------------------------|
 | hvpvaractor | parasitic device formed at the ends of SVaricap     |
 | fillfet     | device formed at the junction of fill diff and poly |
+
+## Fill pattern generation
+
+Fill pattern generation is implemented as an alternative "cif ostyle"
+in the magic tech file.  It is only marginally useful in an
+interactive layout session;  generally, it is meant to be used with
+the standalone python script "generate_fill.py".  Running the python
+script (run without arguments to get a usage statement) on a magic or
+GDS database of a chip top level (including seal ring) will produce
+a compressed GDS file containing a overlay cell with the fill
+patterns.  The fill pattern GDS must be integrated with the chip top
+level (the script does not do this) by including the fill patterns
+into the top level layout, with the origins aligned.
+
+If the intention is to pre-fill an area of layout, magic can do this
+with the command "cif ostyle patternfill()", placing the cursor box
+around the area to be filled, and typing, e.g., "cif paint MET1FILL
+met1fill".  Each fill layer must be generated individually.
+
+## Auxiliary DRC checks
+
+Not all DRC rules are implemented directly by magic's DRC checker.
+The two main exceptions are density and antenna rules.  Density rules
+are only meaningful if done on an entire top-level layout, after
+running pattern generation.  If the final design (including fill
+patterns) is saved as a .mag file or GDS file, then the script
+"check_density.py" will perform the entire set of density rule
+checks.
+
+Antenna violations can be checked by extracting the layout and
+then using the command "antennacheck [run]".  It is generally
+preferable to run the command "antennacheck debug" prior to the
+command "antennacheck", so that detailed output for each error is
+printed to the terminal output.  Otherwise, all errors are in the
+form of feedback entries which can be queried with "feedback find"
+or written to a file with "feedback save <filename>".

--- a/ihp-sg13g2/libs.tech/magic/RELEASE_NOTES.md
+++ b/ihp-sg13g2/libs.tech/magic/RELEASE_NOTES.md
@@ -1,8 +1,8 @@
 # IHP SG13G2 Technology files for magic
 
-> version 0.1.2 (alpha pre-release)  
-    December 17, 2024  
-    Efabless Corporation
+> version 0.1.3 (alpha pre-release)  
+    March 25, 2025 
+    Open Circuit Design LLC
 
 Included in this pre-release:
 
@@ -19,15 +19,13 @@ Included in this pre-release:
 2. Technology file for magic with GDS-mapped layers (`ihp-sg13g2-GDS.tech`)
 3. Startup script for magic (`ihp-sg13g2-GDS.magicrc`)
 4. LVS setup for netgen (`../netgen/ihp-sg13g2_setup.tcl`)
+5. Density rule check (`check_density.py`) script
+6. Fill generation (`generate_fill.py`) script 
 
 Not included/completed in this pre-release:
 
 1. Device generator for magic (`ihp-sg13g2.tcl`).  
    The file in the pre-release version is a placeholder only.
-2. Density rule check (`check_density.py`)  
-   Needs verification.
-3. Fill generation (`generate_fill.py`)  
-   Work in progress.
 4. Seal ring generator (may be implemented in the device generation script)
 
-All items not included in this pre-release are expected to be completed by April 2025.
+All items not included in this pre-release are expected to be completed by June 2025.

--- a/ihp-sg13g2/libs.tech/magic/generate_fill.py
+++ b/ihp-sg13g2/libs.tech/magic/generate_fill.py
@@ -24,6 +24,7 @@ import sys
 import os
 import re
 import glob
+import functools
 import subprocess
 import multiprocessing
 
@@ -32,31 +33,37 @@ def usage():
     print("generate_fill.py <layout_name> [-keep] [-test] [-dist]")
     print("")
     print("where:")
-    print("    <layout_name> is the path to the .mag file to be filled.")
+    print("    <layout_name> is the path to the .mag or .gds file to be filled.")
     print("")
     print("  If '-keep' is specified, then keep the generation script.")
     print("  If '-test' is specified, then create but do not run the generation script.")
     print("  If '-dist' is specified, then run distributed (multi-processing).")
     return 0
 
-def makegds(file):
+def makegds(file, rcfile):
     # Procedure for multiprocessing only:  Run the distributed processing
     # script to load a .mag file of one flattened square area of the layout,
     # and run the fill generator to produce a .gds file output from it.
 
-    magpath = os.path.split(file)[0]
+    layoutpath = os.path.split(file)[0]
     filename = os.path.split(file)[1]
 
     myenv = os.environ.copy()
     myenv['MAGTYPE'] = 'mag'
 
-    mproc = subprocess.run(['magic', '-dnull', '-noconsole',
-		'-rcfile', rcfile, magpath + '/generate_fill_dist.tcl',
-		filename],
+    magic_run_opts = [
+		'magic',
+		'-dnull',
+		'-noconsole',
+		'-rcfile', rcfile,
+		layoutpath + '/generate_fill_dist.tcl',
+		filename]
+
+    mproc = subprocess.run(magic_run_opts,
 		stdin = subprocess.DEVNULL,
 		stdout = subprocess.PIPE,
 		stderr = subprocess.PIPE,
-		cwd = magpath,
+		cwd = layoutpath,
 		env = myenv,
 		universal_newlines = True)
     if mproc.stdout:
@@ -91,57 +98,106 @@ if __name__ == '__main__':
         usage()
         sys.exit(1)
 
+    # Process options
+
+    if '-debug' in optionlist:
+        debugmode = True
+        print('Running in debug mode.')
+    if '-keep' in optionlist:
+        keepmode = True
+        if debugmode:
+            print('Keeping all files after running.')
+    elif debugmode:
+        print('Files other than final layout will be removed after running.')
+    if '-test' in optionlist:
+        testmode = True
+        if debugmode:
+            print('Running in test mode:  No output files will be created.')
+    if '-dist' in optionlist:
+        distmode = True
+        if debugmode:
+            print('Running in distributed (multi-processing) mode.')
+    elif debugmode:
+        print('Running in single-processor mode.')
+
+    # Find layout from command-line argument
+
     user_project_path = arguments[0]
 
-    magpath = os.getcwd()+'/'+os.path.split(user_project_path)[0]
-    if magpath == '':
-        magpath = os.getcwd()
+    if os.path.split(user_project_path)[0] == '':
+        layoutpath = os.getcwd()
+    else:
+        layoutpath = os.getcwd() + '/' + os.path.split(user_project_path)[0]
     
-    if os.path.splitext(user_project_path)[1] != '.mag':
-        if os.path.splitext(user_project_path)[1] == '':
-            user_project_path += '.mag'
-        else:
-            print('Error:  Project is not a magic database .mag file!')
-            sys.exit(1)
+    # Use os.extsep, not os.path.splitext(), because gzipped files have
+    # multiple periods (e.g., "layout.gds.gz")
 
+    project = user_project_path.split(os.extsep, 1)
+
+    if len(project) == 1:
+        # No file extension given;  figure it out
+        layoutfiles = glob.glob(user_project_path + '.*')
+        if len(layoutfiles) == 1:
+            proj_extension = '.' + layoutfiles[0].split(os.extsep, 1)[1]
+            user_project_path = layoutfiles[0]
+        elif len(layoutfiles) == 0:
+            print('Error:  Project is not a magic database or GDS file!')
+            sys.exit(1)
+        else:
+            print('Error:  Project name is ambiguous!')
+            sys.exit(1)
+    else:
+        proj_extension = '.' + project[1]
+
+    is_mag = False
+    is_gds = False
+
+    if proj_extension == '.mag' or proj_extension == '.mag.gz':
+        is_mag = True
+    elif proj_extension == '.gds' or proj_extension == '.gds.gz':
+        is_gds = True
+    else:
+        print('Error:  Project is not a magic database or GDS file!')
+        sys.exit(1)
+ 
     if not os.path.isfile(user_project_path):
         print('Error:  Project "' + user_project_path + '" does not exist or is not readable.')
         sys.exit(1)
 
-    if '-debug' in optionlist:
-        debugmode = True
-    if '-keep' in optionlist:
-        keepmode = True
-    if '-test' in optionlist:
-        testmode = True
-    if '-dist' in optionlist:
-        distmode = True
+    # The path where the fill generation script resides should be the same
+    # path where the magic startup script resides, for the same PDK
+    scriptpath = os.path.dirname(os.path.realpath(__file__))
 
-    # Searching for rcfile
-    
-    rcfile_paths=[magpath+'/.magicrc','/$PDK_PATH/libs.tech/magic/ihp-sg13g2.magicrc','/usr/share/pdk/ihp-sg13g2/libs.tech/magic/ihp-sg13g2.magicrc']
-    
-    rcfile=''
-    
-    for rc_path in rcfile_paths:
-        if os.path.isfile(rc_path):
-            rcfile=rc_path
-            break
-    
-    if rcfile=='':
-        print('Error: .magicrc file not found.')
+    # Search for magic startup script.  Order of precedence:
+    #  1. PDK_ROOT environment variable
+    #  2. Local .magicrc
+    #  3. The location of this script
+
+    if os.environ.get('PDK_ROOT'):
+        rcfile_path = os.environ.get('PDK_ROOT') + '/ihp-sg13g2/libs.tech/magic/ihp-sg13g2.magicrc'
+    elif os.path.isfile(layoutpath + '/.magicrc'):
+        rcfile_path = layoutpath + '/.magicrc'
+    elif os.path.isfile(scriptpath + '/ihp-sg13g2.magicrc'):
+        rcfile_path = scriptpath + '/ihp-sg13g2.magicrc'
+    else:
+        print('Unknown path to magic startup script.  Please set $PDK_ROOT')
         sys.exit(1)
-    
-    project = os.path.splitext(os.path.split(user_project_path)[1])[0]
 
-    topdir = os.path.split(magpath)[0]
-    gdsdir = topdir + '/gds'
-    hasgdsdir = True if os.path.isdir(gdsdir) else False
+    if os.path.isdir(layoutpath + '/gds'):
+        gdspath = layoutpath + '/gds'
+    elif os.path.isdir(layoutpath + '/../gds'):
+        gdspath = layoutpath + '/../gds'
+    else:
+        gdspath = layoutpath
     
-    ofile = open(magpath + '/generate_fill.tcl', 'w') 
+    project_file = os.path.split(user_project_path)[1]
+    project = project_file.split(os.extsep, 1)[0]
+    
+    ofile = open(layoutpath + '/generate_fill.tcl', 'w') 
 	
     print('#!/usr/bin/env wish', file=ofile)
     print('drc off', file=ofile)
+    print('crashbackups stop', file=ofile)
     print('tech unlock *', file=ofile)
     print('snap internal', file=ofile)
     print('box values 0 0 0 0', file=ofile)
@@ -153,12 +209,19 @@ if __name__ == '__main__':
     print('set starttime [orig_clock format [orig_clock seconds] -format "%D %T"]', file=ofile)
     print('puts stdout "Started: $starttime"', file=ofile)
     print('', file=ofile)
+    if is_gds:
+        print('gds read ' + project_file, file=ofile)
+    # NOTE:  No guarantee that the filename matches the top level cell name;
+    # might want to query using "cellname list top"
     print('load ' + project + ' -dereference', file=ofile)
     print('select top cell', file=ofile)
     print('expand', file=ofile)
     if not distmode:
         print('cif ostyle patternfill(tiled)', file=ofile)
     print('', file=ofile)
+    # Use FIXED_BBOX as the boundary if it exists
+    # (Note:  Actual boundary should be computed by position of SEALBOUND.)
+    print('catch {box values {*}[property FIXED_BBOX]}', file=ofile)
     print('set fullbox [box values]', file=ofile)
     print('set xmax [lindex $fullbox 2]', file=ofile)
     print('set xmin [lindex $fullbox 0]', file=ofile)
@@ -234,7 +297,7 @@ if __name__ == '__main__':
         print('quit -noprompt', file=ofile)
         ofile.close()
 
-        with open(magpath + '/generate_fill_dist.tcl', 'w') as ofile:
+        with open(layoutpath + '/generate_fill_dist.tcl', 'w') as ofile:
             print('#!/usr/bin/env wish', file=ofile)
             print('drc off', file=ofile)
             print('tech unlock *', file=ofile)
@@ -246,7 +309,7 @@ if __name__ == '__main__':
             print('gds write [file root $filename].gds', file=ofile)
             print('quit -noprompt', file=ofile)
 
-        ofile = open(magpath + '/generate_fill_final.tcl', 'w')
+        ofile = open(layoutpath + '/generate_fill_final.tcl', 'w')
         print('#!/usr/bin/env wish', file=ofile)
         print('drc off', file=ofile)
         print('tech unlock *', file=ofile)
@@ -272,7 +335,7 @@ if __name__ == '__main__':
     print('        set ylo [expr $ybase + $y * $stepheight]', file=ofile)
     print('        set xhi [expr $xlo + $stepwidth]', file=ofile)
     print('        set yhi [expr $ylo + $stepheight]', file=ofile)
-    print('        load ' + project + '_fill_pattern_${x}_$y -quiet', file=ofile)
+    print('        load ' + project + '_fill_pattern_${x}_$y -silent', file=ofile)
     print('        box values $xlo $ylo $xhi $yhi', file=ofile)
     print('        paint comment', file=ofile)
     print('        property FIXED_BBOX "$xlo $ylo $xhi $yhi"', file=ofile)
@@ -282,7 +345,7 @@ if __name__ == '__main__':
     print('}', file=ofile)
 
     # Now tile everything back together
-    print('load ' + project + '_fill_pattern -quiet', file=ofile)
+    print('load ' + project + '_fill_pattern -silent', file=ofile)
     print('for {set y 0} {$y < $ytiles} {incr y} {', file=ofile)
     print('    for {set x 0} {$x < $xtiles} {incr x} {', file=ofile)
     print('        box values 0 0 0 0', file=ofile)
@@ -295,10 +358,8 @@ if __name__ == '__main__':
 
     print('cif *hier write disable', file=ofile)
     print('cif *array write disable', file=ofile)
-    if hasgdsdir:
-        print('gds write ../gds/' + project + '_fill_pattern.gds', file=ofile)
-    else:
-        print('gds write ' + project + '_fill_pattern.gds', file=ofile)
+    print('gds compress 9', file=ofile)
+    print('gds write ' + gdspath + '/' + project + '_fill_pattern.gds.gz', file=ofile)
     print('set endtime [orig_clock format [orig_clock seconds] -format "%D %T"]', file=ofile)
     print('puts stdout "Ended: $endtime"', file=ofile)
     print('quit -noprompt', file=ofile)
@@ -309,19 +370,28 @@ if __name__ == '__main__':
 
     if not testmode:
         # Diagnostic
-        # print('This script will generate file ' + project + '_fill_pattern.gds')
+        # print('This script will generate file ' + project + '_fill_pattern.gds.gz')
         print('This script will generate files ' + project + '_fill_pattern_x_y.gds')
         print('Now generating fill patterns.  This may take. . . quite. . . a while.', flush=True)
         
-        mproc = subprocess.run(['magic', '-dnull', '-noconsole',
-		'-rcfile', rcfile, magpath + '/generate_fill.tcl'],
+        magic_run_opts = [
+		'magic',
+		'-dnull',
+		'-noconsole',
+		'-rcfile', rcfile_path,
+		layoutpath + '/generate_fill.tcl']
+
+        if debugmode:
+            print('Running: ' + ' '.join(magic_run_opts))
+
+        mproc = subprocess.run(magic_run_opts,
 		stdin = subprocess.DEVNULL,
 		stdout = subprocess.PIPE,
 		stderr = subprocess.PIPE,
-		cwd = magpath,
+		cwd = layoutpath,
 		env = myenv,
 		universal_newlines = True)
-        
+
         if mproc.stdout:
             for line in mproc.stdout.splitlines():
                 print(line)
@@ -332,17 +402,17 @@ if __name__ == '__main__':
             if mproc.returncode != 0:
                 print('ERROR:  Magic exited with status ' + str(mproc.returncode))
 	
-	
         if distmode:
             # If using distributed mode, then run magic on each of the generated
             # layout files
             pool = multiprocessing.Pool()
-            magfiles = glob.glob(magpath + '/' + project + '_fill_pattern_*.mag')
+            magfiles = glob.glob(layoutpath + '/' + project + '_fill_pattern_*.mag')
             # NOTE:  Adding 'x' to the end of each filename, or else magic will
             # try to read it from the command line as well as passing it as an
             # argument to the script.  We only want it passed as an argument.
             magxfiles = list(item + 'x' for item in magfiles)
-            pool.map(makegds, magxfiles)
+            makegdsfunc = functools.partial(makegds, rcfile=rcfile_path)
+            pool.map(makegdsfunc, magxfiles)
 
             # If using distributed mode, then remove all of the temporary .mag files
             # and then run the final generation script.
@@ -350,11 +420,11 @@ if __name__ == '__main__':
                 os.remove(file)
 
             mproc = subprocess.run(['magic', '-dnull', '-noconsole',
-			'-rcfile', rcfile, magpath + '/generate_fill_final.tcl'],
+			'-rcfile', rcfile_path, layoutpath + '/generate_fill_final.tcl'],
 			stdin = subprocess.DEVNULL,
 			stdout = subprocess.PIPE,
 			stderr = subprocess.PIPE,
-			cwd = magpath,
+			cwd = layoutpath,
 			env = myenv,
 			universal_newlines = True)
             if mproc.stdout:
@@ -369,20 +439,20 @@ if __name__ == '__main__':
 
     if not keepmode:
         # Remove fill generation script
-        os.remove(magpath + '/generate_fill.tcl')
+        os.remove(layoutpath + '/generate_fill.tcl')
         # Remove all individual fill tiles, leaving only the composite GDS.
-        filelist = os.listdir(magpath)
+        filelist = os.listdir(layoutpath)
         for file in filelist:
-            if os.path.splitext(magpath + '/' + file)[1] == '.gds':
+            if os.path.splitext(layoutpath + '/' + file)[1] == '.gds':
                 if file.startswith(project + '_fill_pattern_'):
-                    os.remove(magpath + '/' + file)
+                    os.remove(layoutpath + '/' + file)
 
         if distmode:
-            os.remove(magpath + '/generate_fill_dist.tcl')
-            os.remove(magpath + '/generate_fill_final.tcl')
-            os.remove(magpath + '/fill_gen_info.txt')
+            os.remove(layoutpath + '/generate_fill_dist.tcl')
+            os.remove(layoutpath + '/generate_fill_final.tcl')
+            os.remove(layoutpath + '/fill_gen_info.txt')
             if testmode:
-                magfiles = glob.glob(magpath + '/' + project + '_fill_pattern_*.mag')
+                magfiles = glob.glob(layoutpath + '/' + project + '_fill_pattern_*.mag')
                 for file in magfiles:
                     os.remove(file)
 

--- a/ihp-sg13g2/libs.tech/magic/ihp-sg13g2.tech
+++ b/ihp-sg13g2/libs.tech/magic/ihp-sg13g2.tech
@@ -700,8 +700,8 @@ style gdsii
 # DIFF (Fill)
 #----------------------------------------------------------------
 
- layer DIFFFILL	difffill
-	labels	difffill
+ layer DIFFFILL	difffill,fillfet
+	labels	difffill,fillfet
 	calma	1 22
 
 # Identify a varactor area, which generates its own thick oxide mask
@@ -857,6 +857,7 @@ style gdsii
  layer EDGESEAL seal
 	grow 7375
 	and DIFF
+	calma 39 0
 
 #----------------------------------------------------------------
 # POLY (GatPoly)
@@ -869,8 +870,8 @@ style gdsii
 	labels  allpolynonres port
 	calma	5 2
 
- layer POLYFILL	polyfill
-	labels 	polyfill
+ layer POLYFILL	polyfill,fillfet
+	labels 	polyfill,fillfet
 	calma	5 22
 
 #----------------------------------------------------------------
@@ -1729,23 +1730,23 @@ style density
  options calma-permissive-labels
  gridlimit 5
 
- templayer diff_all alldiff,difffill
+ templayer diff_all alldiff,difffill,fillfet,sealcont
 
- templayer poly_all allpoly,polyfill
+ templayer poly_all allpoly,polyfill,fillfet
 
- templayer m1_all allm1,m1fill,diffprobe
+ templayer m1_all allm1,m1fill,diffprobe,sealcont,sealv1
 
- templayer m2_all allm2,m2fill
+ templayer m2_all allm2,m2fill,sealv1,sealv2
 
- templayer m3_all allm3,m3fill
+ templayer m3_all allm3,m3fill,sealv2,sealv3
 
- templayer m4_all allm4,m4fill
+ templayer m4_all allm4,m4fill,sealv3,sealv4
 
- templayer m5_all allm5,m5fill
+ templayer m5_all allm5,m5fill,sealv4,sealv5
 
- templayer m6_all allm6,m6fill
+ templayer m6_all allm6,m6fill,sealv5,sealv6
 
- templayer m7_all allm7,m7fill
+ templayer m7_all allm7,m7fill,sealv6,pillar,solder
 
 #----------------------------------------------------------------
 style patternfill variants (),(tiled)
@@ -1817,88 +1818,101 @@ style patternfill variants (),(tiled)
 	or	trans
 	grow	580
 	or	alldiff,difffill,obsactive
+
+ templayer      obstruct_poly alldiff,difffill,allcont
+	grow	100
+	or	trans
+	grow	580
+	or	allpoly,polyfill,obspoly
+
+ templayer	obstruct_diffpoly obstruct_diff,obstruct_poly
 	grow	420
 	or	well_guardband
 
-#------------------------------------------------------------------------
-# Poly filler keep-out areas determined by diffusion obstruction areas.
-# Spacing to diffusion, poly, contact: 1.1um (GFil.d)
-# Spacing to nwell, dnwell:  1.1um (GFil.e)
-# Spacing to TRANS: 1.1um (GFil.f)
-#------------------------------------------------------------------------
-
- templayer      obstruct_poly 	alldiff,allpoly,difffill,polyfill,obsactive
-	or	trans
-	grow	1000
-	or	well_guardband
-	grow	100
-
 #---------------------------------------------------
 # DIFF and POLY fill
-# Done in three passes at sizes 4600, 2000, and 1000
-# on diffusion.  Poly overlaps diffusion with
-# extensions, lengths 5000, 2400, and 1400; and
-# widths 4300, 1700, and 700
+# Done in three passes at sizes 5000x4600, 2400x2000,
+# and 1000x1100 on diffusion.  Poly overlaps diffusion
+# with extensions, with sizes 5000x3000, 2400x1400,
+# and 1400x700
 #---------------------------------------------------
 
- templayer	difffill_coarse topbox
-        slots   0 4600 820 0 5000 420 1360 0
-        and-not obstruct_diff
+ templayer	diffpolyfill_coarse topbox
+        slots   0 5000 2000 0 5000 2000 1360 0
+        and-not obstruct_diffpoly
 	and	topbox
         shrink  2295
         grow    2295
 
- templayer	polyfill_coarse topbox
-	slots	0 5000 420 0 3000 2420 1560 1000
-        and-not obstruct_diff
-	and	topbox
-        shrink  2495
-        grow    2495
+ templayer	difffill_coarse diffpolyfill_coarse
+	slots	200 4600 1000 0 5000 1000 0 0
+
+ templayer	polyfill_coarse diffpolyfill_coarse
+	slots	0 5000 1000 1000 3000 1000 0 0
 
  templayer      obstruct_diff_medium allpoly,polyfill,allcont
+	or	polyfill_coarse
 	grow	100
 	or	trans
 	grow	580
 	or	alldiff,difffill,obsactive,difffill_coarse
+
+ templayer      obstruct_poly_medium alldiff,difffill,allcont
+	or	difffill_coarse
+	grow	100
+	or	trans
+	grow	580
+	or	allpoly,polyfill,obspoly,polyfill_coarse
+
+ templayer      obstruct_diffpoly_medium obstruct_diff_medium,obstruct_poly_medium
 	grow	420
 	or	well_guardband
 
- templayer	difffill_medium topbox
-        slots   0 2000 820 0 2000 420 750 0
-        and-not obstruct_diff_medium
+ templayer	diffpolyfill_medium topbox
+        slots   0 2400 1200 0 2400 1200 750 0
+        and-not obstruct_diffpoly_medium
 	and	topbox
-        shrink  995
-        grow    995
+        shrink  1195
+        grow    1195
 
- templayer	polyfill_medium topbox
-	slots	0 2400 420 0 1000 1420 550 500
-        and-not obstruct_diff
-	and	topbox
-        shrink  995
-        grow    995
+ templayer	difffill_medium diffpolyfill_medium
+	slots	200 2000 1000 0 2400 1000 0 0
+
+ templayer	polyfill_medium diffpolyfill_medium
+	slots	0 2400 1000 500 1400 1000 0 0
 
  templayer      obstruct_diff_fine allpoly,polyfill,allcont
+	or	polyfill_coarse,polyfill_medium
 	grow	100
 	or	trans
 	grow	580
 	or	alldiff,difffill,obsactive
 	or	difffill_coarse,difffill_medium
+
+ templayer      obstruct_poly_fine alldiff,difffill,allcont
+	or	difffill_coarse,difffill_medium
+	grow	100
+	or	trans
+	grow	580
+	or	allpoly,polyfill,obspoly
+	or	polyfill_coarse,polyfill_medium
+
+ templayer      obstruct_diffpoly_fine obstruct_diff_fine,obstruct_poly_fine
 	grow	420
 	or	well_guardband
 
- templayer	difffill_fine topbox
-        slots   0 1000 820 0 1000 420 360 0
-        and-not obstruct_diff_fine
+ templayer	diffpolyfill_fine topbox
+        slots   0 1400 1200 0 1100 1200 360 0
+        and-not obstruct_diffpoly_fine
 	and	topbox
-        shrink  495
-        grow    495
+        shrink  545
+        grow    545
 
- templayer	polyfill_fine topbox
-	slots	0 1400 420 0 700 720 160 150
-        and-not obstruct_diff
-	and	topbox
-        shrink  995
-        grow    995
+ templayer	difffill_fine diffpolyfill_fine
+	slots	200 1000 1000 0 1100 1000 0 0
+
+ templayer	polyfill_fine diffpolyfill_fine
+	slots	0 1400 1000 200 700 1000 0 0
 
 #---------------------------------------------------
  layer  DIFFFILL difffill_coarse
@@ -1921,19 +1935,20 @@ style patternfill variants (),(tiled)
 # Three passes in sizes 5000, 2000, and 1000
 #---------------------------------------------------
 
- templayer	obstruct_m1 trans,pad
+ templayer	obstruct_m1 trans,pad,seal
 	grow	580
 	or	allm1,obsm1,m1fill,fillblock
         grow    420
 
  templayer	met1fill_coarse topbox
-        slots   0 5000 420 0 5000 420 1700 850
+	# Make spacing 2um so that max density is < 50%
+        slots   0 5000 2000 0 5000 2000 1500 500
         and-not obstruct_m1
 	and	topbox
         shrink  2495
         grow    2495
 
- templayer      obstruct_m1_medium trans,pad
+ templayer      obstruct_m1_medium trans,pad,seal
 	grow	580
 	or	allm1,obsm1,m1fill,fillblock
 	or	met1fill_coarse
@@ -1943,21 +1958,21 @@ style patternfill variants (),(tiled)
         slots   0 2000 420 0 2000 420 650 320
         and-not obstruct_m1_medium
 	and	topbox
-        shrink  495
-        grow    495
+        shrink  995
+        grow    995
 
- templayer      obstruct_m1_fine trans,pad
+ templayer      obstruct_m1_fine trans,pad,seal
 	grow	580
 	or	allm1,obsm1,m1fill,fillblock
 	or	met1fill_coarse,met1fill_medium
         grow    420
 
  templayer	met1fill_fine topbox
-        slots   0 1000 420 0 1000 420 300 0
+        slots   0 1200 420 0 1200 420 300 0
         and-not obstruct_m1_fine
 	and	topbox
-        shrink  495
-        grow    495
+        shrink  595
+        grow    595
 
  layer	MET1FILL met1fill_coarse
 	or	met1fill_medium
@@ -1969,19 +1984,21 @@ style patternfill variants (),(tiled)
 # Three passes in sizes 5000, 2000, and 1000
 #---------------------------------------------------
 
- templayer	obstruct_m2 trans,pad
+ templayer	obstruct_m2 trans,pad,seal
 	grow	580
 	or	allm2,obsm2,m2fill,fillblock
         grow    420
 
  templayer	met2fill_coarse topbox
-        slots   0 5000 420 0 5000 420 1700 850
+        # slots   0 5000 420 0 5000 420 1700 850
+	# Make spacing 2.00um so that max density is < 50%
+        slots   0 5000 2000 0 5000 2000 2500 1500
         and-not obstruct_m2
 	and	topbox
         shrink  2495
         grow    2495
 
- templayer      obstruct_m2_medium trans,pad
+ templayer      obstruct_m2_medium trans,pad,seal
 	grow	580
 	or	allm2,obsm2,m2fill,fillblock
 	or	met2fill_coarse
@@ -1991,21 +2008,21 @@ style patternfill variants (),(tiled)
         slots   0 2000 420 0 2000 420 650 320
         and-not obstruct_m2_medium
 	and	topbox
-        shrink  495
-        grow    495
+        shrink  995
+        grow    995
 
- templayer      obstruct_m2_fine trans,pad
+ templayer      obstruct_m2_fine trans,pad,seal
 	grow	580
 	or	allm2,obsm2,m2fill,fillblock
 	or	met2fill_coarse,met2fill_medium
         grow    420
 
  templayer	met2fill_fine topbox
-        slots   0 1000 420 0 1000 420 300 0
+        slots   0 1200 420 0 1200 420 300 0
         and-not obstruct_m2_fine
 	and	topbox
-        shrink  495
-        grow    495
+        shrink  595
+        grow    595
 
  layer	MET2FILL met2fill_coarse
 	or met2fill_medium
@@ -2017,19 +2034,21 @@ style patternfill variants (),(tiled)
 # Three passes in sizes 5000, 2000, and 1000
 #---------------------------------------------------
 
- templayer	obstruct_m3 trans,pad
+ templayer	obstruct_m3 trans,pad,seal
 	grow	580
 	or	allm3,obsm3,m3fill,fillblock
         grow    420
 
  templayer	met3fill_coarse topbox
-        slots   0 5000 420 0 5000 420 1700 850
+        # slots   0 5000 420 0 5000 420 1700 850
+	# Make spacing 2.00um so that max density is < 50%
+        slots   0 5000 2000 0 5000 2000 3500 2500
         and-not obstruct_m3
 	and	topbox
         shrink  2495
         grow    2495
 
- templayer      obstruct_m3_medium trans,pad
+ templayer      obstruct_m3_medium trans,pad,seal
 	grow	580
 	or	allm3,obsm3,m3fill,fillblock
 	or	met3fill_coarse
@@ -2039,21 +2058,21 @@ style patternfill variants (),(tiled)
         slots   0 2000 420 0 2000 420 650 320
         and-not obstruct_m3_medium
 	and	topbox
-        shrink  495
-        grow    495
+        shrink  995
+        grow    995
 
- templayer      obstruct_m3_fine trans,pad
+ templayer      obstruct_m3_fine trans,pad,seal
 	grow	580
 	or	allm3,obsm3,m3fill,fillblock
 	or	met3fill_coarse,met3fill_medium
         grow    420
 
  templayer	met3fill_fine topbox
-        slots   0 1000 420 0 1000 420 300 0
+        slots   0 1200 420 0 1200 420 300 0
         and-not obstruct_m3_fine
 	and	topbox
-        shrink  495
-        grow    495
+        shrink  595
+        grow    595
 
  layer	MET3FILL met3fill_coarse
 	or	met3fill_medium
@@ -2065,19 +2084,21 @@ style patternfill variants (),(tiled)
 # Three passes in sizes 5000, 2000, and 1000
 #---------------------------------------------------
 
- templayer	obstruct_m4 trans,pad
+ templayer	obstruct_m4 trans,pad,seal
 	grow	580
 	or	allm4,obsm4,m4fill,fillblock
         grow    420
 
  templayer	met4fill_coarse topbox
-        slots   0 5000 420 0 5000 420 1700 850
+        # slots   0 5000 420 0 5000 420 1700 850
+	# Make spacing 2.00um so that max density is < 50%
+        slots   0 5000 2000 0 5000 2000 4500 3500
         and-not obstruct_m4
 	and	topbox
         shrink  2495
         grow    2495
 
- templayer      obstruct_m4_medium trans,pad
+ templayer      obstruct_m4_medium trans,pad,seal
 	grow	580
 	or	allm4,obsm4,m4fill,fillblock
 	or	met4fill_coarse
@@ -2087,21 +2108,21 @@ style patternfill variants (),(tiled)
         slots   0 2000 420 0 2000 420 650 320
         and-not obstruct_m4_medium
 	and	topbox
-        shrink  495
-        grow    495
+        shrink  995
+        grow    995
 
- templayer      obstruct_m4_fine trans,pad
+ templayer      obstruct_m4_fine trans,pad,seal
 	grow	580
 	or	allm4,obsm4,m4fill,fillblock
 	or	met4fill_coarse,met4fill_medium
         grow    420
 
  templayer	met4fill_fine topbox
-        slots   0 1000 420 0 1000 420 300 0
+        slots   0 1200 420 0 1200 420 300 0
         and-not obstruct_m4_fine
 	and	topbox
-        shrink  495
-        grow    495
+        shrink  595
+        grow    595
 
  layer	MET4FILL met4fill_coarse
 	or	met4fill_medium
@@ -2113,19 +2134,21 @@ style patternfill variants (),(tiled)
 # Three passes in sizes 5000, 2000, and 1000
 #---------------------------------------------------
 
- templayer	obstruct_m5 trans,pad
+ templayer	obstruct_m5 trans,pad,seal
 	grow	580
 	or	allm5,obsm5,m5fill,fillblock
         grow    420
 
  templayer	met5fill_coarse topbox
-        slots   0 5000 420 0 5000 420 1700 850
+        # slots   0 5000 420 0 5000 420 1700 850
+	# Make spacing 2.00um so that max density is < 50%
+        slots   0 5000 2000 0 5000 2000 500 4500
         and-not obstruct_m5
 	and	topbox
         shrink  2495
         grow    2495
 
- templayer      obstruct_m5_medium trans,pad
+ templayer      obstruct_m5_medium trans,pad,seal
 	grow	580
 	or	allm5,obsm5,m5fill,fillblock
 	or	met5fill_coarse
@@ -2135,21 +2158,21 @@ style patternfill variants (),(tiled)
         slots   0 2000 420 0 2000 420 650 320
         and-not obstruct_m5_medium
 	and	topbox
-        shrink  495
-        grow    495
+        shrink  995
+        grow    995
 
- templayer      obstruct_m5_fine trans,pad
+ templayer      obstruct_m5_fine trans,pad,seal
 	grow	580
 	or	allm5,obsm5,m5fill,fillblock
 	or	met5fill_coarse,met5fill_medium
         grow    420
 
  templayer	met5fill_fine topbox
-        slots   0 1000 420 0 1000 420 300 0
+        slots   0 1200 420 0 1200 420 300 0
         and-not obstruct_m5_fine
 	and	topbox
-        shrink  495
-        grow    495
+        shrink  595
+        grow    595
 
  layer	MET5FILL met5fill_coarse
 	or	met5fill_medium
@@ -2163,19 +2186,19 @@ style patternfill variants (),(tiled)
 # Also:  Prohibiting metal6 fill under pads.
 # Two passes in sizes 10000, 5000
 #---------------------------------------------------
- templayer	obstruct_m6 trans,pad,solder,pillar
+ templayer	obstruct_m6 trans,pad,seal,solder,pillar
 	grow	1900
 	or	allm6,obsm6,m6fill,fillblock
         grow    3000
 
  templayer	met6fill_coarse topbox
-        slots   0 10000 3000 0 10000 3000 3000 1500
+        slots   0 10000 4000 0 10000 4000 2500 3500
         and-not obstruct_m6
 	and	topbox
         shrink  4995
         grow    4995
 
- templayer      obstruct_m6_medium trans,pad,solder,pillar
+ templayer      obstruct_m6_medium trans,pad,seal,solder,pillar
 	grow	1900
 	or	allm6,obsm6,m6fill,fillblock
 	or	met6fill_coarse
@@ -2198,19 +2221,19 @@ style patternfill variants (),(tiled)
 # Space to TRANS: 4.9 (TM2Fil.d)
 # Two passes in sizes 10000, 5000
 #---------------------------------------------------
- templayer	obstruct_m7 trans,pad,solder,pillar
+ templayer	obstruct_m7 trans,pad,seal,solder,pillar
 	grow	1900
 	or	allm7,obsm7,m7fill,fillblock
         grow    3000
 
  templayer	met7fill_coarse topbox
-        slots   0 10000 3000 0 10000 3000 3000 1500
+        slots   0 10000 4000 0 10000 4000 4500 1500
         and-not obstruct_m7
 	and	topbox
         shrink  4995
         grow    4995
 
- templayer      obstruct_m7_medium trans,pad,solder,pillar
+ templayer      obstruct_m7_medium trans,pad,seal,solder,pillar
 	grow	1900
 	or	allm7,obsm7,m7fill,fillblock
 	or	met7fill_coarse


### PR DESCRIPTION
Made a number of changes in support of pattern fill generation and density checks.  Modified the tech file parameters for the generated fill to center the fill-related density on 50% fill. Corrected an issue with failure to generate poly fill on top of diffusion fill, and then to ensure that the poly fill shape is centered on the diffusion fill shape.  Added different position offsets to each of the metal fill layers so they are not stacked directly on top of one another.  Corrected the expressions for calculating the pro-rated densities on the right and top edge of a layout.  Added some documentation of pattern fill and density checks to the README file, and updated the RELEASE_NOTES file.

Fixes #408 

- [X] Tests pass
- [X] Appropriate changes to README are included in PR

Signed-off-by: R. Timothy Edwards <tim@opencircuitdesign.com>
