### PR TITLE
Ptap1 and ntap1 devices pin change in xschem symbols

### DIFF
--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/ntap1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/ntap1.sym
@@ -41,8 +41,8 @@ L 4 -7.5 -17.5 7.5 -12.5 {}
 L 4 -7.5 -17.5 0 -20 {}
 L 4 0 -30 0 -20 {}
 L 4 -10 20 10 20 {}
-B 5 -2.5 27.5 2.5 32.5 {name=M dir=inout propag=1 pinnumber=2}
-B 5 -2.5 -32.5 2.5 -27.5 {name=P dir=inout propag=0 pinnumber=1}
+B 5 -2.5 -32.5 2.5 -27.5 {name=P dir=inout propag=0}
+B 5 -2.5 27.5 2.5 32.5 {name=M dir=inout propag=1}
 T {@model} 15 -16.25 0 0 0.2 0.2 {}
 T {w=@w} 15 -3.75 0 0 0.2 0.2 {layer=13}
 T {@spiceprefix@name} 15 -28.75 0 0 0.2 0.2 {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/ptap1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/ptap1.sym
@@ -42,8 +42,8 @@ L 4 -7.5 -17.5 7.5 -12.5 {}
 L 4 -7.5 -17.5 0 -20 {}
 L 4 0 -30 0 -20 {}
 L 4 -10 20 10 20 {}
-B 5 -2.5 27.5 2.5 32.5 {name=M dir=inout propag=1 pinnumber=2}
-B 5 -2.5 -32.5 2.5 -27.5 {name=P dir=inout propag=0 pinnumber=1}
+B 5 -2.5 -32.5 2.5 -27.5 {name=P dir=inout propag=0 }
+B 5 -2.5 27.5 2.5 32.5 {name=M dir=inout propag=1 }
 T {@model} 15 -16.25 0 0 0.2 0.2 {}
 T {w=@w} 15 -3.75 0 0 0.2 0.2 {layer=13}
 T {@spiceprefix@name} 15 -28.75 0 0 0.2 0.2 {}


### PR DESCRIPTION
This PR changes the pin order in the netlist  streamed out from xschem.

For `ptap1` the lvs netlist is annotated as follows

<img src="https://github.com/user-attachments/assets/00a2069c-9bff-41cf-bfdf-55d4660713b0" width="200" height="200"/>

```
R1 GND sub! ptap1 A=6.084e-13 P=3.12e-06

```
For `ntap1` the lvs netlist is annotated as follows

<img src="https://github.com/user-attachments/assets/4879baf7-d805-4965-b2bc-6f2089085fe9" width="200" height="200"/>

```
R1 vdd well ntap1 A=6.084e-13 P=3.12e-06

```