### PR TITLE
Device generator for klayout

### DIFF
--- a/ihp-sg13g2/libs.tech/klayout/python/import_netlist/__init__.py
+++ b/ihp-sg13g2/libs.tech/klayout/python/import_netlist/__init__.py
@@ -1,0 +1,1 @@
+from .import_netlist import ihp130_import_netlist

--- a/ihp-sg13g2/libs.tech/klayout/python/import_netlist/ihp130_pcell_templates.py
+++ b/ihp-sg13g2/libs.tech/klayout/python/import_netlist/ihp130_pcell_templates.py
@@ -1,0 +1,630 @@
+# Copyright 2024 Efabless Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Original file changed by IHP PDK Authors 2025
+# Adopting the Skywater PDK sky130_pcell_templates.py 
+# file to the IHP SG13G2 technology
+# 
+
+import re
+
+templates = [
+    {
+        "regex": re.compile(
+            r"^.*sg13_lv_nmos(?=.*w=(?P<w>\d+(\.\d+)?u))(?=.*l=(?P<l>\d+(\.\d+)?u))(?=.*ng=(?P<ng>\d+))(?=.*m=(?P<m>\d+))(?!.*rfmode).*$"
+        ),
+        "pcell_library": "SG13_dev",
+        "pcell_name": "nmos",
+        "params": [
+            {
+                "name": "w",
+                "type": "string",
+            },
+            {
+                "name": "l",
+                "type": "string",
+            },
+            {
+                "name": "ng",
+                "type": "int",
+            },
+            {
+                "name": "m",
+                "type": "int",
+            },
+        ],
+        "default_params": {"w": "0.13u", "l": "0.13u", "ng": 1, "m": 1},
+    },  # Your updated template for sg13_lv_nmos
+    {
+        "regex": re.compile(
+            r"^.*sg13_lv_pmos(?=.*w=(?P<w>\d+(\.\d+)?u))(?=.*l=(?P<l>\d+(\.\d+)?u))(?=.*ng=(?P<ng>\d+))(?=.*m=(?P<m>\d+))(?!.*rfmode).*$"
+        ),
+        "pcell_library": "SG13_dev",
+        "pcell_name": "pmos",
+        "params": [
+            {
+                "name": "w",
+                "type": "string",
+            },
+            {
+                "name": "l",
+                "type": "string",
+            },
+            {
+                "name": "ng",
+                "type": "int",
+            },
+            {
+                "name": "m",
+                "type": "int",
+            },
+        ],
+        "default_params": {"w": "0.13u", "l": "0.13u", "ng": 1, "m": 1},
+    },
+    {
+        "regex": re.compile(
+            r"^.*sg13_hv_nmos(?=.*w=(?P<w>\d+(\.\d+)?u))(?=.*l=(?P<l>\d+(\.\d+)?u))(?=.*ng=(?P<ng>\d+))(?=.*m=(?P<m>\d+))(?!.*rfmode).*$"
+        ),
+        "pcell_library": "SG13_dev",
+        "pcell_name": "nmosHV",
+        "params": [
+            {
+                "name": "w",
+                "type": "string",
+            },
+            {
+                "name": "l",
+                "type": "string",
+            },
+            {
+                "name": "ng",
+                "type": "int",
+            },
+            {
+                "name": "m",
+                "type": "int",
+            },
+        ],
+        "default_params": {"w": "0.3u", "l": "0.4u", "ng": 1, "m": 1},
+    },
+    {
+        "regex": re.compile(
+            r"^.*sg13_hv_pmos(?=.*w=(?P<w>\d+(\.\d+)?u))(?=.*l=(?P<l>\d+(\.\d+)?u))(?=.*ng=(?P<ng>\d+))(?=.*m=(?P<m>\d+))(?!.*rfmode).*$"
+        ),
+        "pcell_library": "SG13_dev",
+        "pcell_name": "pmosHV",
+        "params": [
+            {
+                "name": "w",
+                "type": "string",
+            },
+            {
+                "name": "l",
+                "type": "string",
+            },
+            {
+                "name": "ng",
+                "type": "int",
+            },
+            {
+                "name": "m",
+                "type": "int",
+            },
+        ],
+        "default_params": {"w": "0.3u", "l": "0.45u", "ng": 1, "m": 1},
+    },
+    {
+        "regex": re.compile(
+            r"^.*sg13_lv_nmos(?=.*w=(?P<w>\d+(\.\d+)?u))(?=.*l=(?P<l>\d+(\.\d+)?u))(?=.*ng=(?P<ng>\d+))(?=.*m=(?P<m>\d+))(?=.*rfmode=(?P<rfmode>\d+)).*$"
+        ),
+        "pcell_library": "SG13_dev",
+        "pcell_name": "rfnmos",
+        "params": [
+            {
+                "name": "w",
+                "type": "string",
+            },
+            {
+                "name": "l",
+                "type": "string",
+            },
+            {
+                "name": "ng",
+                "type": "int",
+            },
+            {
+                "name": "m",
+                "type": "int",
+            },
+            {
+                "name": "rfmode",
+                "type": "int",
+            },
+        ],
+        "default_params": {
+            "w": "1.0u",
+            "l": "0.72u",
+            "ng": 1,
+            "m": 1,
+            "rfmode": 1,
+        },
+    },
+    {
+        "regex": re.compile(
+            r"^.*sg13_lv_pmos(?=.*w=(?P<w>\d+(\.\d+)?u))(?=.*l=(?P<l>\d+(\.\d+)?u))(?=.*ng=(?P<ng>\d+))(?=.*m=(?P<m>\d+))(?=.*rfmode=(?P<rfmode>\d+)).*$"
+        ),
+        "pcell_library": "SG13_dev",
+        "pcell_name": "rfpmos",
+        "params": [
+            {
+                "name": "w",
+                "type": "string",
+            },
+            {
+                "name": "l",
+                "type": "string",
+            },
+            {
+                "name": "ng",
+                "type": "int",
+            },
+            {
+                "name": "m",
+                "type": "int",
+            },
+            {
+                "name": "rfmode",
+                "type": "int",
+            },
+        ],
+        "default_params": {
+            "w": "1.0u",
+            "l": "0.72u",
+            "ng": 1,
+            "m": 1,
+            "rfmode": 1,
+        },
+    },
+    {
+        "regex": re.compile(
+            r"^.*sg13_hv_nmos(?=.*w=(?P<w>\d+(\.\d+)?u))(?=.*l=(?P<l>\d+(\.\d+)?u))(?=.*ng=(?P<ng>\d+))(?=.*m=(?P<m>\d+))(?=.*rfmode=(?P<rfmode>\d+)).*$"
+        ),
+        "pcell_library": "SG13_dev",
+        "pcell_name": "rfnmosHV",
+        "params": [
+            {
+                "name": "w",
+                "type": "string",
+            },
+            {
+                "name": "l",
+                "type": "string",
+            },
+            {
+                "name": "ng",
+                "type": "int",
+            },
+            {
+                "name": "m",
+                "type": "int",
+            },
+            {
+                "name": "rfmode",
+                "type": "int",
+            },
+        ],
+        "default_params": {
+            "w": "1.0u",
+            "l": "0.72u",
+            "ng": 1,
+            "m": 1,
+            "rfmode": 1,
+        },
+    },
+    {
+        "regex": re.compile(
+            r"^.*sg13_hv_pmos(?=.*w=(?P<w>\d+(\.\d+)?u))(?=.*l=(?P<l>\d+(\.\d+)?u))(?=.*ng=(?P<ng>\d+))(?=.*m=(?P<m>\d+))(?=.*rfmode=(?P<rfmode>\d+)).*$"
+        ),
+        "pcell_library": "SG13_dev",
+        "pcell_name": "rfpmosHV",
+        "params": [
+            {
+                "name": "w",
+                "type": "string",
+            },
+            {
+                "name": "l",
+                "type": "string",
+            },
+            {
+                "name": "ng",
+                "type": "int",
+            },
+            {
+                "name": "m",
+                "type": "int",
+            },
+            {
+                "name": "rfmode",
+                "type": "int",
+            },
+        ],
+        "default_params": {
+            "w": "1.0u",
+            "l": "0.72u",
+            "ng": 1,
+            "m": 1,
+            "rfmode": 1,
+        },
+    },
+    {
+        "regex": re.compile(r"^.*bondpad(?=.*size=(?P<size>\d+(\.\d+)?u)).*$"),
+        "pcell_library": "SG13_dev",
+        "pcell_name": "bondpad",
+        "params": [
+            {
+                "name": "size",
+                "type": "string",
+            }
+        ],
+        "default_params": {"size": "80u"},
+    },
+    {
+        "regex": re.compile(
+            r"^.*cap_cmim(?=.*w=(?P<w>\d+(\.\d+)?e-?\d+))(?=.*l=(?P<l>\d+(\.\d+)?e-?\d+))(?=.*m=(?P<m>\d+)).*$"
+        ),
+        "pcell_library": "SG13_dev",
+        "pcell_name": "cmim",
+        "params": [
+            {
+                "name": "w",
+                "type": "string",
+            },
+            {
+                "name": "l",
+                "type": "string",
+            },
+            {
+                "name": "m",
+                "type": "int",
+            },
+        ],
+        "default_params": {"w": "7.0e-6", "l": "7.0e-6", "m": 1},
+    },
+    {
+        "regex": re.compile(
+            r"^.*cap_rfcmim(?=.*w=(?P<w>\d+(\.\d+)?e-?\d+))(?=.*l=(?P<l>\d+(\.\d+)?e-?\d+))(?=.*wfeed=(?P<wfeed>\d+(\.\d+)?e-?\d+)).*$"
+        ),
+        "pcell_library": "SG13_dev",
+        "pcell_name": "rfcmim",
+        "params": [
+            {
+                "name": "w",
+                "type": "string",
+            },
+            {
+                "name": "l",
+                "type": "string",
+            },
+            {
+                "name": "wfeed",
+                "type": "string",
+            },
+        ],
+        "default_params": {"w": "10.0e-6", "l": "10.0e-6", "wfeed": "5.0e-6"},
+    },
+    {
+        "regex": re.compile(
+            r"^.*dantenna(?=.*l=(?P<l>\d+(\.\d+)?u))(?=.*w=(?P<w>\d+(\.\d+)?u)).*$"
+        ),
+        "pcell_library": "SG13_dev",
+        "pcell_name": "dantenna",
+        "params": [
+            {
+                "name": "l",
+                "type": "string",
+            },
+            {
+                "name": "w",
+                "type": "string",
+            },
+        ],
+        "default_params": {"l": "0.78u", "w": "0.78u"},
+    },
+    {
+        "regex": re.compile(
+            r"^.*dpantenna(?=.*l=(?P<l>\d+(\.\d+)?u))(?=.*w=(?P<w>\d+(\.\d+)?u)).*$"
+        ),
+        "pcell_library": "SG13_dev",
+        "pcell_name": "dpantenna",
+        "params": [
+            {
+                "name": "l",
+                "type": "string",
+            },
+            {
+                "name": "w",
+                "type": "string",
+            },
+        ],
+        "default_params": {"l": "0.78u", "w": "0.78u"},
+    },
+    {
+        "regex": re.compile(
+            r"^.*npn13G2(?=.*\bNx=(?P<Nx>\d+)\b)(?!.*\bEl=).*"
+        ),
+        "pcell_library": "SG13_dev",
+        "pcell_name": "npn13G2",
+        "params": [
+            {
+                "name": "Nx",
+                "type": "int",
+            }
+        ],
+        "default_params": {"Nx": 1},
+    },
+    {
+        "regex": re.compile(
+            r"^.*npn13G2l(?=.*\bNx=(?P<Nx>\d+)\b)(?=.*\bEl=(?P<El>\d+(\.\d+)?)).*"
+        ),
+        "pcell_library": "SG13_dev",
+        "pcell_name": "npn13G2L",
+        "params": [
+            {
+                "name": "Nx",
+                "type": "int",
+            },
+            {
+                "name": "El",
+                "type": "float",
+            },
+        ],
+        "default_params": {"Nx": 1, "El": 1.0},
+    },
+    {
+        "regex": re.compile(
+            r"^.*npn13G2v(?=.*\bNx=(?P<Nx>\d+)\b)(?=.*\bEl=(?P<El>\d+)).*"
+        ),
+        "pcell_library": "SG13_dev",
+        "pcell_name": "npn13G2V",
+        "params": [
+            {
+                "name": "Nx",
+                "type": "int",
+            },
+            {
+                "name": "El",
+                "type": "int",
+            },
+        ],
+        "default_params": {"Nx": 1, "El": 1},
+    },
+    {
+        "regex": re.compile(
+            r"^.*ntap1(?=.*R=(?P<R>\d+(\.\d+)?))(?=.*w=(?P<w>\d+(\.\d+)?e-?\d+))(?=.*l=(?P<l>\d+(\.\d+)?e-?\d+)).*$"
+        ),
+        "pcell_library": "SG13_dev",
+        "pcell_name": "ntap1",
+        "params": [
+            {
+                "name": "R",
+                "type": "float",
+            },
+            {
+                "name": "w",
+                "type": "string",
+            },
+            {
+                "name": "l",
+                "type": "string",
+            },
+        ],
+        "default_params": {"R": 262.8, "w": "0.78e-6", "l": "0.78e-6"},
+    },
+    {
+        "regex": re.compile(
+            r"^.*ptap1(?=.*R=(?P<R>\d+(\.\d+)?))(?=.*w=(?P<w>\d+(\.\d+)?e-?\d+))(?=.*l=(?P<l>\d+(\.\d+)?e-?\d+)).*$"
+        ),
+        "pcell_library": "SG13_dev",
+        "pcell_name": "ptap1",
+        "params": [
+            {
+                "name": "R",
+                "type": "float",
+            },
+            {
+                "name": "w",
+                "type": "string",
+            },
+            {
+                "name": "l",
+                "type": "string",
+            },
+        ],
+        "default_params": {"R": 262.8, "w": "0.78e-6", "l": "0.78e-6"},
+    },
+    {
+        "regex": re.compile(
+            r"^.*rhigh(?=.*w=(?P<w>\d+(\.\d+)?e-?\d+))(?=.*l=(?P<l>\d+(\.\d+)?e-?\d+))(?=.*m=(?P<m>\d+))(?=.*b=(?P<b>\d+)).*$"
+        ),
+        "pcell_library": "SG13_dev",
+        "pcell_name": "rhigh",
+        "params": [
+            {
+                "name": "w",
+                "type": "string",
+            },
+            {
+                "name": "l",
+                "type": "string",
+            },
+            {
+                "name": "m",
+                "type": "int",
+            },
+            {
+                "name": "b",
+                "type": "int",
+            },
+        ],
+        "default_params": {"w": "0.5e-6", "l": "0.5e-6", "m": 1, "b": 0},
+    },
+    {
+        "regex": re.compile(
+            r"^.*rppd(?=.*w=(?P<w>\d+(\.\d+)?e-?\d+))(?=.*l=(?P<l>\d+(\.\d+)?e-?\d+))(?=.*m=(?P<m>\d+))(?=.*b=(?P<b>\d+)).*$"
+        ),
+        "pcell_library": "SG13_dev",
+        "pcell_name": "rppd",
+        "params": [
+            {
+                "name": "w",
+                "type": "string",
+            },
+            {
+                "name": "l",
+                "type": "string",
+            },
+            {
+                "name": "m",
+                "type": "int",
+            },
+            {
+                "name": "b",
+                "type": "int",
+            },
+        ],
+        "default_params": {"w": "0.5e-6", "l": "0.5e-6", "m": 1, "b": 0},
+    },
+    {
+        "regex": re.compile(
+            r"^.*rsil(?=.*w=(?P<w>\d+(\.\d+)?e-?\d+))(?=.*l=(?P<l>\d+(\.\d+)?e-?\d+))(?=.*m=(?P<m>\d+))(?=.*b=(?P<b>\d+)).*$"
+        ),
+        "pcell_library": "SG13_dev",
+        "pcell_name": "rsil",
+        "params": [
+            {
+                "name": "w",
+                "type": "string",
+            },
+            {
+                "name": "l",
+                "type": "string",
+            },
+            {
+                "name": "m",
+                "type": "int",
+            },
+            {
+                "name": "b",
+                "type": "int",
+            },
+        ],
+        "default_params": {"w": "0.5e-6", "l": "0.5e-6", "m": 1, "b": 0},
+    },
+    {
+        "regex": re.compile(
+            r"^.*sg13_hv_svaricap(?=.*W=(?P<W>\d+(\.\d+)?e-?\d+))(?=.*L=(?P<L>\d+(\.\d+)?e-?\d+))(?=.*Nx=(?P<Nx>\d+)).*$"
+        ),
+        "pcell_library": "SG13_dev",
+        "pcell_name": "SVaricap",
+        "params": [
+            {
+                "name": "W",
+                "type": "string",
+            },
+            {
+                "name": "L",
+                "type": "string",
+            },
+            {
+                "name": "Nx",
+                "type": "int",
+            },
+        ],
+        "default_params": {"W": "3.74e-6", "L": "0.3e-6", "Nx": 1},
+    },
+    ###################################################################
+    {
+        "regex": re.compile(r"^.*diodevdd_2kv(?=.*m=(?P<m>\d+)).*$"),
+        "pcell_library": "SG13_dev",
+        "pcell_name": "esd",
+        "params": [
+            {
+                "name": "m",
+                "type": "int",
+            }
+        ],
+        "default_params": {"model": "diodevdd_2kv", "m": 1},
+    },
+    {
+        "regex": re.compile(r"^.*diodevdd_4kv(?=.*m=(?P<m>\d+)).*$"),
+        "pcell_library": "SG13_dev",
+        "pcell_name": "esd",
+        "params": [
+            {
+                "name": "m",
+                "type": "int",
+            }
+        ],
+        "default_params": {"model": "diodevdd_4kv", "m": 1},
+    },
+    {
+        "regex": re.compile(r"^.*diodevss_2kv(?=.*m=(?P<m>\d+)).*$"),
+        "pcell_library": "SG13_dev",
+        "pcell_name": "esd",
+        "params": [
+            {
+                "name": "m",
+                "type": "int",
+            }
+        ],
+        "default_params": {"model": "diodevss_2kv", "m": 1},
+    },
+    {
+        "regex": re.compile(r"^.*diodevss_4kv(?=.*m=(?P<m>\d+)).*$"),
+        "pcell_library": "SG13_dev",
+        "pcell_name": "esd",
+        "params": [
+            {
+                "name": "m",
+                "type": "int",
+            }
+        ],
+        "default_params": {"model": "diodevdd_4kv", "m": 1},
+    },
+    {
+        "regex": re.compile(r"^.*nmoscl_2(?=.*m=(?P<m>\d+)).*$"),
+        "pcell_library": "SG13_dev",
+        "pcell_name": "esd",
+        "params": [
+            {
+                "name": "m",
+                "type": "int",
+            }
+        ],
+        "default_params": {"model": "nmoscl_2", "m": 1},
+    },
+    {
+        "regex": re.compile(r"^.*nmoscl_2(?=.*m=(?P<m>\d+)).*$"),
+        "pcell_library": "SG13_dev",
+        "pcell_name": "esd",
+        "params": [
+            {
+                "name": "m",
+                "type": "int",
+            }
+        ],
+        "default_params": {"model": "nmoscl_2", "m": 1},
+    },
+]

--- a/ihp-sg13g2/libs.tech/klayout/python/import_netlist/import_netlist.py
+++ b/ihp-sg13g2/libs.tech/klayout/python/import_netlist/import_netlist.py
@@ -1,0 +1,277 @@
+# Copyright 2024 Efabless Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Original file changed by IHP PDK Authors 2025
+# Adopting the Skywater PDK import_netlist.py file to IHP SG13G2 technology
+
+
+import os
+import re
+import sys
+import pya
+
+from .ihp130_pcell_templates import templates
+
+
+def create_pcell_instance(pcell_name='CIRCLE', lib_name='Basic', params={}, pos=pya.Trans.R0):
+    """
+    Create a new instance of a PCell
+    and return its width and height
+    """
+
+    print(f"Creating PCell '{pcell_name}' with parameters:")
+    
+    for key, value in params.items():
+        print(f' - {key}: {value}')
+
+    # Get PCell Library
+    lib = pya.Library.library_by_name(lib_name)
+
+    if not lib:
+        print(f'Error: Library not found {lib_name}')
+        return (0, 0)
+
+    # The PCell Declaration. This one will create PCell variants.
+    pcell_decl = lib.layout().pcell_declaration(pcell_name)
+
+    if not pcell_decl:
+        print(f'Error: Pcell not found {pcell_name}')
+        return (0, 0)
+
+    # Get the active layout
+    cellview = pya.CellView().active()
+    layout = cellview.layout()
+    if layout == None:
+        print(f'Error: Couldn\'t get active layout.')
+        return
+
+    # Get the top cell. Assuming only one top cell exists
+    top_cell = layout.top_cell()
+
+    # Add a PCell variant
+    pcell_var = layout.add_pcell_variant(lib, pcell_decl.id(), params)
+    
+    bbox = layout.cell(pcell_var).bbox()
+    
+    # Add an offset to the position to account for the origin
+    offset = pya.Trans(pos, x=-bbox.left, y=-bbox.bottom)
+
+    width = bbox.width()
+    height = bbox.height()
+    
+    # Insert instance
+    top_cell.insert(pya.CellInstArray(pcell_var, offset))
+    
+    return (width, height)
+
+current_x = 0
+spacing = 100
+
+def create_subckt_instance(name, subckt_definitions):
+    global current_x
+    global spacing
+
+    for pcell_inst in subckt_definitions[name]['pcells']:
+        (width, height) = create_pcell_instance(
+            pcell_inst['pcell_name'],
+            pcell_inst['pcell_library'],
+            pcell_inst['params'],
+            pya.Trans(current_x, 0)
+        )
+        current_x += width + spacing
+
+    for subckt_inst in subckt_definitions[name]['subckts']:
+        if not subckt_inst in subckt_definitions:
+            print(f'Error: Unknown subckt {subckt_inst}')
+        else:
+            create_subckt_instance(subckt_inst, subckt_definitions)
+
+def ihp130_import_netlist():
+
+    # Get the schematic netlist
+    netlist_path = pya.FileDialog.ask_open_file_name("Choose the schematic netlist", '.', "SPICE (*.spice)")
+
+    print(f'Info: The netlist importer is still experimental.')
+    print(f'Please report issues to: https://github.com/efabless/sky130_klayout_pdk/issues')
+
+    # Check whether file exists
+    if not netlist_path or not os.path.isfile(netlist_path):
+        print(f'Error: {netlist_path} is not a file!')
+        sys.exit(0)
+
+    print(f'Reading Spice netlist: {netlist_path}')
+
+    # Parse the spice netlist
+    with open(netlist_path, 'r') as netlist_file:
+        netlist_content = netlist_file.read()
+
+    # Continue lines starting with '+'
+    netlist_content = netlist_content.replace('\n+', '')
+    
+    # Split lines
+    netlist_lines = netlist_content.split('\n')
+
+    # Subckt data
+    subckt_definitions = {'root': {'subckts': [], 'pcells': [], 'references': 0}}
+    active_subckt = None
+
+    # Parameter data
+    global_parameters = {}
+
+    # Handle ".include" statements
+    found = True
+    while found:
+        found = False
+        for i, line in enumerate(netlist_lines):
+            # Ignore comments
+            if line.startswith('*'):
+                continue
+
+            # Find start of include statement
+            if line.startswith('.include') or line.startswith('.INCLUDE'):
+                found = True
+                include_path = line.split(' ')[1]
+                
+                # Relative path
+                if not os.path.isabs(include_path):
+                    include_path = os.path.join(os.path.dirname(netlist_path), include_path)
+
+                # Get the content
+                with open(include_path, 'r') as include_file:
+                    include_content = include_file.read()
+                
+                # Continue lines starting with '+'
+                include_content = include_content.replace('\n+', '')
+                
+                # Split lines
+                include_lines = include_content.split('\n')
+
+                # Replace ".include" with the lines
+                netlist_lines[i:i+1] = include_lines
+                
+                break
+
+    # Scan for parameters
+    for line in netlist_lines:
+        # Ignore comments
+        if line.startswith('*'):
+            continue
+
+        # Find start of subckt definitions
+        if line.startswith('.param') or line.startswith('.PARAM'):
+            parameter = line.split(' ')[1]
+            name, value = parameter.split('=')
+            global_parameters[name] = value
+    
+    # Apply parameters
+    for i, line in enumerate(netlist_lines):
+        # Ignore comments
+        if line.startswith('*'):
+            continue
+
+        # Find start of subckt definitions
+        def replace_parameters(matchobj):
+            if matchobj.group(1) in global_parameters:
+                return global_parameters[matchobj.group(1)]
+            print(f'Error: Unknown parameter "{matchobj.group(1)}"')
+            return matchobj.group(1)
+
+        netlist_lines[i] = re.sub(r'{(.*?)}', replace_parameters, line)
+
+    # Scan for subckts
+    for line in netlist_lines:
+        # Ignore comments
+        if line.startswith('*'):
+            continue
+
+        # Find start of subckt definitions
+        if line.startswith('.subckt') or line.startswith('.SUBCKT'):
+            active_subckt = line.split(' ')[1]
+            subckt_definitions[active_subckt] = {'subckts': [], 'pcells': [], 'references': 0}
+
+    for line in netlist_lines:
+        # Ignore comments
+        if line.startswith('*'):
+            continue
+
+        # Find start of subckt definitions
+        if line.startswith('.subckt') or line.startswith('.SUBCKT'):
+            active_subckt = line.split(' ')[1]
+            
+            if not active_subckt in subckt_definitions:
+                print(f'Error: Unknown subckt "{active_subckt}"')
+
+        # Find end of subckt definitions
+        if line.startswith('.ends') or line.startswith('.ENDS'):
+            active_subckt = None
+
+        #print(f"Searching for match with '{line}'!")
+        any_match = False
+        for template in templates:
+      
+            match = template['regex'].match(line)
+            if match:
+                any_match = True
+                params = template['default_params']
+              
+                # Parse parameters
+                for param in template['params']:
+                    #print(f"Parsing parameter {param['name']}")
+                    if param["type"] == "string":
+                        params[param['name']] = match.group(param['name'])
+                    if param["type"] == "int":
+                        params[param['name']] = int(match.group(param['name']))
+                    if param["type"] == "float":
+                        params[param['name']] = float(match.group(param['name']))
+              
+                # Multiplicity 'm'
+                m = 1
+                if 'm' in params:
+                    m = params.pop('m')
+              
+                # Divide 'w' by 'nf' to get individual finger width
+                if 'nf' in params and params['nf'] > 1:
+                    if 'w' in params:
+                        params['w'] /= params['nf']
+              
+                #print(f'Instantiating Pcell with: {params}')
+              
+                for _ in range(m):
+                    subckt_definitions[active_subckt]['pcells'].append({
+                        'pcell_name':       template['pcell_name'],
+                        'pcell_library':    template['pcell_library'],
+                        'params':           params.copy(),
+                    })
+
+        # Line was handled by template
+        # no need to parse subcircuit
+        if any_match:
+            continue
+
+        # Subckt instantiation
+        # TODO: handle parameters
+        if line.startswith('x') or line.startswith('X'):
+            subckt = line.split(' ')[-1]
+            subckt_definitions[active_subckt]['subckts'].append(subckt)
+            
+            if not subckt in subckt_definitions:
+                print(f'Error: Unknown subckt "{active_subckt}"')
+            else:
+                subckt_definitions[subckt]['references'] += 1
+
+    # Instanciate all top-level subckts
+    for name in subckt_definitions.keys():
+        if subckt_definitions[name]['references'] == 0:
+            create_subckt_instance(name, subckt_definitions)
+

--- a/ihp-sg13g2/libs.tech/klayout/tech/macros/ihp130_import_netlist.lym
+++ b/ihp-sg13g2/libs.tech/klayout/tech/macros/ihp130_import_netlist.lym
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+# Copyright 2024 Efabless Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+-->
+
+<klayout-macro>
+ <description>Import Netlist</description>
+ <version/>
+ <category>pymacros</category>
+ <prolog/>
+ <epilog/>
+ <doc/>
+ <autorun>false</autorun>
+ <autorun-early>false</autorun-early>
+ <shortcut/>
+ <show-in-menu>true</show-in-menu>
+ <group-name>Import Netlist</group-name>
+ <menu-path>sg13g2_menu&gt;end("SG13G2 PDK").end</menu-path>
+ <interpreter>python</interpreter>
+ <dsl-interpreter-name/>
+ <text>
+
+import sys
+import os
+
+# install the path to 'python'
+lib_path = os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "python"))
+if not lib_path in sys.path:
+  sys.path.insert(0, lib_path)
+
+import import_netlist
+import_netlist.ihp130_import_netlist()
+
+ </text>
+</klayout-macro>


### PR DESCRIPTION
This PR is an adoption of the device generator provided for sywater130 technology. 
The original repository can be found [here](https://github.com/efabless/sky130_klayout_pdk) 

In order to generate the device one have to create a new layout and then go to menu `SG13G2 PDK->Import netlist`
 
![image](https://github.com/user-attachments/assets/b07c69fc-2a41-463f-8940-ddeac9b4f5e7)

Example netlist (`gallery.spice`):
```
.subckt gallery
XX1 net1 bondpad size=80u 
XC1 net2 net3 cap_cmim w=7.0e-6 l=7.0e-6 m=1
XC2 net4 net5 net6 cap_rfcmim w=10.0e-6 l=10.0e-6 wfeed=5.0e-6
XD1 net7 net8 dantenna l=0.78u w=0.78u
XD2 net9 net10 net11 diodevdd_2kv m=1
XD3 net12 net13 net14 diodevdd_4kv m=1
XD4 net15 net16 net17 diodevss_2kv m=1
XD5 net18 net19 net20 diodevss_4kv m=1
XD6 net21 net22 dpantenna l=0.78u w=0.78u
XD7 net23 net24 nmoscl_2 m=1
XD8 net25 net26 nmoscl_4 m=1
XQ1 net27 net28 net29 net30 npn13G2 Nx=1
XQ2 net31 net32 net33 net34 npn13G2l Nx=1 El=1.0
XQ3 net35 net36 net37 net38 npn13G2v Nx=1 El=1
XR1 net39 net40 ntap1 R=262.8 w=0.78e-6 l=0.78e-6
XR2 net41 net42 ptap1 R=262.8 w=0.78e-6 l=0.78e-6
XR3 net43 net44 rhigh w=0.5e-6 l=0.5e-6 m=1 b=0
XR4 net45 net46 rppd w=0.5e-6 l=0.5e-6 m=1 b=0
XR5 net47 net48 rsil w=0.5e-6 l=0.5e-6 m=1 b=0
XM1 net49 net50 net51 net52 sg13_hv_nmos w=0.3u l=0.45u ng=1 m=1
XM2 net53 net54 net55 net56 sg13_hv_pmos w=0.3u l=0.4u ng=1 m=1
XM3 net57 net58 net59 net60 sg13_hv_nmos w=1.0u l=0.72u ng=1 m=1 rfmode=1
XM4 net61 net62 net63 net64 sg13_hv_pmos w=1.0u l=0.72u ng=1 m=1 rfmode=1
XM5 net65 net66 net67 net68 sg13_lv_nmos w=0.15u l=0.13u ng=1 m=1
XM6 net69 net70 net71 net72 sg13_lv_pmos w=0.15u l=0.13u ng=1 m=1
XM7 net73 net74 net75 net76 sg13_lv_nmos w=1.0u l=0.72u ng=1 m=1 rfmode=1
XM8 net77 net78 net79 net80 sg13_lv_pmos w=1.0u l=0.72u ng=1 m=1 rfmode=1
XC3 net81 net82 net83 net84 sg13_hv_svaricap W=3.74e-6 L=0.3e-6 Nx=1
**.ends
.ends

```