### PR TITLE
DRC: Update density checks

### DIFF
--- a/ihp-sg13g2/libs.tech/klayout/tech/drc/sg13g2_maximal.lydrc
+++ b/ihp-sg13g2/libs.tech/klayout/tech/drc/sg13g2_maximal.lydrc
@@ -1280,9 +1280,14 @@ class DRC::DRCLayer
         return result
     end
 
-    def _ext_with_density(inverse, range, *args)
-        if self.is_empty?
-            return DRC::DRCLayer::new(@engine, RBA::Region::new())
+    def _ext_with_density(inverse,
+                          range,
+                          *args,
+                          tiles_stay_inside: false)
+        if inverse
+            method = :without_density
+        else
+            method = :with_density
         end
         if self.is_merged?
           merged_layer = self
@@ -1312,43 +1317,93 @@ class DRC::DRCLayer
             origin_x = bbox.left
             origin_y = bbox.bottom
             if tile_size and tile_step and (tile_size.get[0] != tile_step.get[0] or tile_size.get[1] != tile_step.get[1])
-              origin_x = bbox.left + tile_step.get[0]/2
-              origin_y = bbox.bottom + tile_step.get[1]/2
+                origin_x = bbox.left + (tile_size.get[0]-tile_step.get[0])/2
+                origin_y = bbox.bottom + (tile_size.get[1]-tile_step.get[1])/2
             end
             tile_origin = DRC::DRCTileOrigin::new(origin_x, origin_y)
             arguments.push(tile_origin)
-        elsif origin != 'cc'
+        elsif origin == 'cc'
+            origin_x = bbox.center.x
+            origin_y = bbox.center.y
+            tile_origin = DRC::DRCTileOrigin::new(origin_x, origin_y)
+        else
             raise "Unknown origin: 'cc' or 'll' expected"
         end
         if tile_size
             boundary_layer = DRC::DRCLayer::new(@engine, RBA::Region::new(bbox.to_itype(@engine.dbu)))
             tile_boundary = DRC::DRCTileBoundary::new(boundary_layer)
-            if inverse
-                return merged_layer.without_density(*arguments, tile_boundary, @engine.padding_ignore)
+            if tiles_stay_inside
+                if origin != 'll'
+                    raise "Option 'tiles_stay_inside' requires origin='ll'"
+                end
+                tile_width = tile_size.get[0]
+                tile_height = tile_size.get[1]
+                enlarged_bbox = bbox.dup
+                if tile_width &gt; bbox.width
+                    enlarged_bbox.right = bbox.left + tile_width
+                end
+                if tile_height &gt; bbox.height
+                    enlarged_bbox.top = bbox.bottom + tile_height
+                end
+                enlarged_boundary_layer = DRC::DRCLayer::new(@engine, RBA::Region::new(enlarged_bbox.to_itype(@engine.dbu)))
+                if tile_step
+                    tile_step_x = tile_step.get[0]
+                    tile_step_y = tile_step.get[1]
+                else
+                    tile_step_x = tile_width
+                    tile_step_y = tile_height
+                end
+                tile_count_x = 1 + ((bbox.width - tile_width) / tile_step_x).floor()
+                tile_count_x = tile_count_x &lt; 1 ? 1 : tile_count_x
+                tile_count_y = 1 + ((bbox.height - tile_height) / tile_step_y).floor()
+                tile_count_y = tile_count_y &lt; 1 ? 1 : tile_count_y
+                if tile_count_x == 1 and tile_count_y == 1
+                    tile_count = DRC::DRCTileCount::new(tile_count_x, 2)
+                else
+                    tile_count = DRC::DRCTileCount::new(tile_count_x, tile_count_y)
+                end
+                result = merged_layer.public_send(method, *arguments, tile_count, tile_boundary, @engine.padding_ignore)
+                need_top_row = false
+                need_right_column = false
+                if bbox.height &gt; tile_height + (tile_count_y-1)*tile_step_y
+                    need_top_row = true
+                    tile_origin2 = DRC::DRCTileOrigin::new(tile_origin.get[0], tile_origin.get[1]+bbox.height-tile_height)
+                    tile_count = DRC::DRCTileCount::new([2, tile_count_x].max, 1)
+                    result += merged_layer.public_send(method, *arguments, tile_origin2, tile_count, tile_boundary, @engine.padding_ignore)
+                end
+                if bbox.width &gt; tile_width + (tile_count_x-1)*tile_step_x
+                    need_right_column = true
+                    tile_origin2 = DRC::DRCTileOrigin::new(tile_origin.get[0]+bbox.width-tile_width, tile_origin.get[1])
+                    tile_count = DRC::DRCTileCount::new(1, [2, tile_count_y].max)
+                    result += merged_layer.public_send(method, *arguments, tile_origin2, tile_count, tile_boundary, @engine.padding_ignore)
+                end
+                if (need_top_row and bbox.width &gt; tile_width) or (need_right_column and bbox.height &gt; tile_height)
+                    tile_origin2 = DRC::DRCTileOrigin::new(tile_origin.get[0]+bbox.width-tile_width, tile_origin.get[1]+bbox.height-tile_height)
+                    tile_count = DRC::DRCTileCount::new(1, 2)
+                    result += merged_layer.public_send(method, *arguments, tile_origin2, tile_count, tile_boundary, @engine.padding_ignore)
+                end
+                result.raw.select_inside(enlarged_boundary_layer)
             else
-                return merged_layer.with_density(*arguments, tile_boundary, @engine.padding_ignore)
+                result = merged_layer.public_send(method, *arguments, tile_boundary, @engine.padding_ignore)
             end
+            return result.and(boundary_layer)
         else
             tile_size = DRC::DRCTileSize::new(bbox.width, bbox.height)
-            tile_count = DRC::DRCTileCount::new(1,2)
+            tile_count = DRC::DRCTileCount::new(1,3)
             enlarged_bbox = bbox.enlarged(1.1).to_itype(@engine.dbu)
             boundary_layer = DRC::DRCLayer::new(@engine, RBA::Region::new(enlarged_bbox))
             tile_boundary = DRC::DRCTileBoundary::new(boundary_layer)
-            if inverse
-                result = merged_layer.without_density(*arguments, tile_size, tile_count, tile_boundary, @engine.padding_ignore)
-            else
-                result = merged_layer.with_density(*arguments, tile_size, tile_count, tile_boundary, @engine.padding_ignore)
-            end
+            result = merged_layer.public_send(method, *arguments, tile_size, tile_count, tile_boundary, @engine.padding_ignore)
             return result.raw.overlapping(DRC::DRCLayer::new(@engine, RBA::Region::new(bbox.to_itype(@engine.dbu))))
         end
     end
 
-    def ext_with_density(*args)
-        self._ext_with_density(false, *args)
+    def ext_with_density(*args, **kargs)
+        self._ext_with_density(false, *args, **kargs)
     end
 
-    def ext_without_density(*args)
-        self._ext_with_density(true, *args)
+    def ext_without_density(*args, **kargs)
+        self._ext_with_density(true, *args, **kargs)
     end
 
     def ext_outside(other)
@@ -2020,7 +2075,7 @@ if $densityRules
 	    Act_density.ext_without_density(0.35 .. 0.55, 'll')
 	end.().output("AFil.g/g1", "Global Activ density [%] = 35.00 .. 55.00")
 	-&gt; do
-	    Act_density.ext_without_density(0.25 .. 0.65, 'll', tile_size(800.0.um), tile_step(400.0.um))
+	    Act_density.ext_without_density(0.25 .. 0.65, 'll', tile_size(800.0.um), tile_step(400.0.um), tiles_stay_inside: true)
 	end.().output("AFil.g2/g3", "Activ coverage ratio for any 800 x 800 µm² chip area [%] = 25.00 .. 65.00")
 end
 
@@ -2454,7 +2509,7 @@ end
 
 if $densityRules
 	-&gt; do
-	    M1_density.ext_without_density(0.25 .. 0.75, 'll', tile_size(800.0.um), tile_step(400.0.um))
+	    M1_density.ext_without_density(0.25 .. 0.75, 'll', tile_size(800.0.um), tile_step(400.0.um), tiles_stay_inside: true)
 	end.().output("M1Fil.h/k", "Metal1 and Metal1:filler coverage ratio for any 800 x 800 µm² chip area [%] = 25.00 .. 75.00")
 end
 
@@ -2477,7 +2532,7 @@ end
 
 if $densityRules
 	-&gt; do
-	    M2_density.ext_without_density(0.25 .. 0.75, 'll', tile_size(800.0.um), tile_step(400.0.um))
+	    M2_density.ext_without_density(0.25 .. 0.75, 'll', tile_size(800.0.um), tile_step(400.0.um), tiles_stay_inside: true)
 	end.().output("M2Fil.h/k", "Metal2 and Metal2:filler coverage ratio for any 800 x 800 µm² chip area [%] = 25.00 .. 75.00")
 end
 
@@ -2500,7 +2555,7 @@ end
 
 if $densityRules
 	-&gt; do
-	    M3_density.ext_without_density(0.25 .. 0.75, 'll', tile_size(800.0.um), tile_step(400.0.um))
+	    M3_density.ext_without_density(0.25 .. 0.75, 'll', tile_size(800.0.um), tile_step(400.0.um), tiles_stay_inside: true)
 	end.().output("M3Fil.h/k", "Metal3 and Metal3:filler coverage ratio for any 800 x 800 µm² chip area [%] = 25.00 .. 75.00")
 end
 
@@ -2523,7 +2578,7 @@ end
 
 if $densityRules
 	-&gt; do
-	    M4_density.ext_without_density(0.25 .. 0.75, 'll', tile_size(800.0.um), tile_step(400.0.um))
+	    M4_density.ext_without_density(0.25 .. 0.75, 'll', tile_size(800.0.um), tile_step(400.0.um), tiles_stay_inside: true)
 	end.().output("M4Fil.h/k", "Metal4 and Metal4:filler coverage ratio for any 800 x 800 µm² chip area [%] = 25.00 .. 75.00")
 end
 
@@ -2546,7 +2601,7 @@ end
 
 if $densityRules
 	-&gt; do
-	    M5_density.ext_without_density(0.25 .. 0.75, 'll', tile_size(800.0.um), tile_step(400.0.um))
+	    M5_density.ext_without_density(0.25 .. 0.75, 'll', tile_size(800.0.um), tile_step(400.0.um), tiles_stay_inside: true)
 	end.().output("M5Fil.h/k", "Metal5 and Metal5:filler coverage ratio for any 800 x 800 µm² chip area [%] = 25.00 .. 75.00")
 end
 

--- a/ihp-sg13g2/libs.tech/klayout/tech/drc/sg13g2_minimal.lydrc
+++ b/ihp-sg13g2/libs.tech/klayout/tech/drc/sg13g2_minimal.lydrc
@@ -106,15 +106,10 @@ end
 
 # Initial definitions of control flow variables
 # Strings from the command line have to be converted
-if defined? $density
-    $density = $density.to_s.downcase == "true"
+if defined? $densityRules
+    $densityRules = $densityRules.to_s.downcase == "true"
 else
-    $density = true
-end
-if defined? $sanityRules
-    $sanityRules = $sanityRules.to_s.downcase == "true"
-else
-    $sanityRules = true
+    $densityRules = true
 end
 
 class AbuttingEdges &lt; RBA::EdgePairToEdgeOperator
@@ -764,7 +759,7 @@ class DRC::DRCLayer
         return result
     end
 
-    def ext_with_density(range, *args)
+    def _ext_with_density(inverse, range, *args)
         if self.is_empty?
             return DRC::DRCLayer::new(@engine, RBA::Region::new())
         end
@@ -807,16 +802,32 @@ class DRC::DRCLayer
         if tile_size
             boundary_layer = DRC::DRCLayer::new(@engine, RBA::Region::new(bbox.to_itype(@engine.dbu)))
             tile_boundary = DRC::DRCTileBoundary::new(boundary_layer)
-            return merged_layer.with_density(*arguments, tile_boundary, @engine.padding_ignore)
+            if inverse
+                return merged_layer.without_density(*arguments, tile_boundary, @engine.padding_ignore)
+            else
+                return merged_layer.with_density(*arguments, tile_boundary, @engine.padding_ignore)
+            end
         else
             tile_size = DRC::DRCTileSize::new(bbox.width, bbox.height)
             tile_count = DRC::DRCTileCount::new(1,2)
             enlarged_bbox = bbox.enlarged(1.1).to_itype(@engine.dbu)
             boundary_layer = DRC::DRCLayer::new(@engine, RBA::Region::new(enlarged_bbox))
             tile_boundary = DRC::DRCTileBoundary::new(boundary_layer)
-            result = merged_layer.with_density(*arguments, tile_size, tile_count, tile_boundary, @engine.padding_ignore)
+            if inverse
+                result = merged_layer.without_density(*arguments, tile_size, tile_count, tile_boundary, @engine.padding_ignore)
+            else
+                result = merged_layer.with_density(*arguments, tile_size, tile_count, tile_boundary, @engine.padding_ignore)
+            end
             return result.raw.overlapping(DRC::DRCLayer::new(@engine, RBA::Region::new(bbox.to_itype(@engine.dbu))))
         end
+    end
+
+    def ext_with_density(*args)
+        self._ext_with_density(false, *args)
+    end
+
+    def ext_without_density(*args)
+        self._ext_with_density(true, *args)
     end
 
     def ext_outside(other)
@@ -825,6 +836,8 @@ class DRC::DRCLayer
         return output_layer
     end
 end
+
+$start_time = Time.now
 
 Activ = source.polygons("1/0")
 Activ_pin = source.polygons("1/2")
@@ -880,15 +893,11 @@ TopMetal2_filler = source.polygons("134/22")
 TopMetal2_slit = source.polygons("134/24")
 ColWind = source.polygons("139/0")
 LBE = source.polygons("157/0")
-
-if $sanityRules
-	PEmWind = source.polygons("11/0")
-	PEmPoly = source.polygons("53/0")
-	LDMOS = source.polygons("57/0")
-	PBiWind = source.polygons("58/0")
-	Flash = source.polygons("71/0")
-end
-
+PEmWind = source.polygons("11/0")
+PEmPoly = source.polygons("53/0")
+LDMOS = source.polygons("57/0")
+PBiWind = source.polygons("58/0")
+Flash = source.polygons("71/0")
 Activ_Act_a = Activ.ext_width(0.15.um)
 Act_density = Activ.ext_or(Activ_filler)
 Gat_density = GatPoly.ext_or(GatPoly_filler)
@@ -928,19 +937,13 @@ end.().output("Act.a", "Min. Activ width = 0.15")
     Act_Nsram.ext_space(0.21.um)
 end.().output("Act.b", "Min. Activ space or notch = 0.21")
 
-if $density
+if $densityRules
 	-&gt; do
-	    Act_density.ext_with_density(0.0 .. 0.35, 'll')
-	end.().output("AFil.g", "Min. global Activ density [%] = 35.00")
+	    Act_density.ext_without_density(0.35 .. 0.55, 'll')
+	end.().output("AFil.g/g1", "Global Activ density [%] = 35.00 .. 55.00")
 	-&gt; do
-	    Act_density.ext_with_density(0.55 .. 1.0, 'll')
-	end.().output("AFil.g1", "Max. global Activ density [%] = 55.00")
-	-&gt; do
-	    Act_density.ext_with_density(0.0 .. 0.25, 'll', tile_size(800.0.um), tile_step(400.0.um))
-	end.().output("AFil.g2", "Min. Activ coverage ratio for any 800 x 800 µm² chip area [%] = 25.00")
-	-&gt; do
-	    Act_density.ext_with_density(0.65 .. 1.0, 'll', tile_size(800.0.um), tile_step(400.0.um))
-	end.().output("AFil.g3", "Max. Activ coverage ratio for any 800 x 800 µm² chip area [%] = 65.00")
+	    Act_density.ext_without_density(0.25 .. 0.65, 'll', tile_size(800.0.um), tile_step(400.0.um))
+	end.().output("AFil.g2/g3", "Activ coverage ratio for any 800 x 800 µm² chip area [%] = 25.00 .. 65.00")
 end
 
 -&gt; do
@@ -956,7 +959,7 @@ end.().output("Gat.b", "Min. GatPoly space or notch = 0.18")
     GP_Nsram.ext_separation(Act_Nsram, 0.07.um)
 end.().output("Gat.d", "Min. GatPoly space to Activ = 0.07")
 
-if $density
+if $densityRules
 	-&gt; do
 	    Gat_density.ext_with_density(0.0 .. 0.15, 'll')
 	end.().output("GFil.g", "Min. global GatPoly density [%] = 15.00")
@@ -975,13 +978,10 @@ end.().output("M1.a", "Min. Metal1 width = 0.16")
     M1_Nsram.ext_space(0.18.um, consider_intersecting_edges: false, ignore_non_axis_aligned_edges: true)
 end.().output("M1.b", "Min. Metal1 space or notch = 0.18")
 
-if $density
+if $densityRules
 	-&gt; do
-	    M1_density.ext_with_density(0.0 .. 0.35, 'll')
-	end.().output("M1.j", "Min. global Metal1 density [%] = 35.0")
-	-&gt; do
-	    M1_density.ext_with_density(0.6 .. 1.0, 'll')
-	end.().output("M1.k", "Max. global Metal1 density [%] = 60.0")
+	    M1_density.ext_without_density(0.35 .. 0.6, 'll')
+	end.().output("M1.j/k", "Global Metal1 density [%] = 35.0 .. 60.0")
 end
 
 -&gt; do
@@ -991,13 +991,10 @@ end.().output("M2.a", "Min. Metal2 width = 0.20")
     M2_Nsram.ext_space(0.21.um, consider_intersecting_edges: false, ignore_non_axis_aligned_edges: true)
 end.().output("M2.b", "Min. Metal2 space or notch = 0.21")
 
-if $density
+if $densityRules
 	-&gt; do
-	    M2_density.ext_with_density(0.0 .. 0.35, 'll')
-	end.().output("M2.j", "Min. global Metal2 density [%] = 35.00")
-	-&gt; do
-	    M2_density.ext_with_density(0.6 .. 1.0, 'll')
-	end.().output("M2.k", "Max. global Metal2 density [%] = 60.00")
+	    M2_density.ext_without_density(0.35 .. 0.6, 'll')
+	end.().output("M2.j/k", "Global Metal2 density [%] = 35.00 .. 60.00")
 end
 
 -&gt; do
@@ -1007,13 +1004,10 @@ end.().output("M3.a", "Min. Metal3 width = 0.20")
     M3_Nsram.ext_space(0.21.um, consider_intersecting_edges: false, ignore_non_axis_aligned_edges: true)
 end.().output("M3.b", "Min. Metal3 space or notch = 0.21")
 
-if $density
+if $densityRules
 	-&gt; do
-	    M3_density.ext_with_density(0.0 .. 0.35, 'll')
-	end.().output("M3.j", "Min. global Metal3 density [%] = 35.00")
-	-&gt; do
-	    M3_density.ext_with_density(0.6 .. 1.0, 'll')
-	end.().output("M3.k", "Max. global Metal3 density [%] = 60.00")
+	    M3_density.ext_without_density(0.35 .. 0.6, 'll')
+	end.().output("M3.j/k", "Global Metal3 density [%] = 35.00 .. 60.00")
 end
 
 -&gt; do
@@ -1023,13 +1017,10 @@ end.().output("M4.a", "Min. Metal4 width = 0.20")
     M4_Nsram.ext_space(0.21.um, consider_intersecting_edges: false, ignore_non_axis_aligned_edges: true)
 end.().output("M4.b", "Min. Metal4 space or notch = 0.21")
 
-if $density
+if $densityRules
 	-&gt; do
-	    M4_density.ext_with_density(0.0 .. 0.35, 'll')
-	end.().output("M4.j", "Min. global Metal4 density [%] = 35.00")
-	-&gt; do
-	    M4_density.ext_with_density(0.6 .. 1.0, 'll')
-	end.().output("M4.k", "Max. global Metal4 density [%] = 60.00")
+	    M4_density.ext_without_density(0.35 .. 0.6, 'll')
+	end.().output("M4.j/k", "Global Metal4 density [%] = 35.00 .. 60.00")
 end
 
 -&gt; do
@@ -1039,43 +1030,25 @@ end.().output("M5.a", "Min. Metal5 width = 0.20")
     M5_Nsram.ext_space(0.21.um, consider_intersecting_edges: false, ignore_non_axis_aligned_edges: true)
 end.().output("M5.b", "Min. Metal5 space or notch = 0.21")
 
-if $density
+if $densityRules
 	-&gt; do
-	    M5_density.ext_with_density(0.0 .. 0.35, 'll')
-	end.().output("M5.j", "Min. global Metal5 density [%] = 35.00")
+	    M5_density.ext_without_density(0.35 .. 0.6, 'll')
+	end.().output("M5.j/k", "Global Metal5 density [%] = 35.00 .. 60.00")
 	-&gt; do
-	    M5_density.ext_with_density(0.6 .. 1.0, 'll')
-	end.().output("M5.k", "Max. global Metal5 density [%] = 60.00")
+	    M1_density.ext_without_density(0.25 .. 0.75, 'll', tile_size(800.0.um), tile_step(400.0.um))
+	end.().output("M1Fil.h/k", "Metal1 and Metal1:filler coverage ratio for any 800 x 800 µm² chip area [%] = 25.00 .. 75.00")
 	-&gt; do
-	    M1_density.ext_with_density(0.0 .. 0.25, 'll', tile_size(800.0.um), tile_step(400.0.um))
-	end.().output("M1Fil.h", "Min. Metal1 and Metal1:filler coverage ratio for any 800 x 800 µm² chip area [%] = 25.00")
+	    M2_density.ext_without_density(0.25 .. 0.75, 'll', tile_size(800.0.um), tile_step(400.0.um))
+	end.().output("M2Fil.h/k", "Metal2 and Metal2:filler coverage ratio for any 800 x 800 µm² chip area [%] = 25.00 .. 75.00")
 	-&gt; do
-	    M1_density.ext_with_density(0.75 .. 1.0, 'll', tile_size(800.0.um), tile_step(400.0.um))
-	end.().output("M1Fil.k", "Max. Metal1 and Metal1:filler coverage ratio for any 800 x 800 µm² chip area [%] = 75.00")
+	    M3_density.ext_without_density(0.25 .. 0.75, 'll', tile_size(800.0.um), tile_step(400.0.um))
+	end.().output("M3Fil.h/k", "Metal3 and Metal3:filler coverage ratio for any 800 x 800 µm² chip area [%] = 25.00 .. 75.00")
 	-&gt; do
-	    M2_density.ext_with_density(0.0 .. 0.25, 'll', tile_size(800.0.um), tile_step(400.0.um))
-	end.().output("M2Fil.h", "Min. Metal2 and Metal2:filler coverage ratio for any 800 x 800 µm² chip area [%] = 25.00")
+	    M4_density.ext_without_density(0.25 .. 0.75, 'll', tile_size(800.0.um), tile_step(400.0.um))
+	end.().output("M4Fil.h/k", "Metal4 and Metal4:filler coverage ratio for any 800 x 800 µm² chip area [%] = 25.00 .. 75.00")
 	-&gt; do
-	    M2_density.ext_with_density(0.75 .. 1.0, 'll', tile_size(800.0.um), tile_step(400.0.um))
-	end.().output("M2Fil.k", "Max. Metal2 and Metal2:filler coverage ratio for any 800 x 800 µm² chip area [%] = 75.00")
-	-&gt; do
-	    M3_density.ext_with_density(0.0 .. 0.25, 'll', tile_size(800.0.um), tile_step(400.0.um))
-	end.().output("M3Fil.h", "Min. Metal3 and Metal3:filler coverage ratio for any 800 x 800 µm² chip area [%] = 25.00")
-	-&gt; do
-	    M3_density.ext_with_density(0.75 .. 1.0, 'll', tile_size(800.0.um), tile_step(400.0.um))
-	end.().output("M3Fil.k", "Max. Metal3 and Metal3:filler coverage ratio for any 800 x 800 µm² chip area [%] = 75.00")
-	-&gt; do
-	    M4_density.ext_with_density(0.0 .. 0.25, 'll', tile_size(800.0.um), tile_step(400.0.um))
-	end.().output("M4Fil.h", "Min. Metal4 and Metal4:filler coverage ratio for any 800 x 800 µm² chip area [%] = 25.00")
-	-&gt; do
-	    M4_density.ext_with_density(0.75 .. 1.0, 'll', tile_size(800.0.um), tile_step(400.0.um))
-	end.().output("M4Fil.k", "Max. Metal4 and Metal4:filler coverage ratio for any 800 x 800 µm² chip area [%] = 75.00")
-	-&gt; do
-	    M5_density.ext_with_density(0.0 .. 0.25, 'll', tile_size(800.0.um), tile_step(400.0.um))
-	end.().output("M5Fil.h", "Min. Metal5 and Metal5:filler coverage ratio for any 800 x 800 µm² chip area [%] = 25.00")
-	-&gt; do
-	    M5_density.ext_with_density(0.75 .. 1.0, 'll', tile_size(800.0.um), tile_step(400.0.um))
-	end.().output("M5Fil.k", "Max. Metal5 and Metal5:filler coverage ratio for any 800 x 800 µm² chip area [%] = 75.00")
+	    M5_density.ext_without_density(0.25 .. 0.75, 'll', tile_size(800.0.um), tile_step(400.0.um))
+	end.().output("M5Fil.h/k", "Metal5 and Metal5:filler coverage ratio for any 800 x 800 µm² chip area [%] = 25.00 .. 75.00")
 end
 
 -&gt; do
@@ -1115,13 +1088,10 @@ end.().output("TM1.a", "Min. TopMetal1 width = 1.64")
     TopMetal1.ext_space(1.64.um)
 end.().output("TM1.b", "Min. TopMetal1 space or notch = 1.64")
 
-if $density
+if $densityRules
 	-&gt; do
-	    TM1_density.ext_with_density(0.0 .. 0.25, 'll')
-	end.().output("TM1.c", "Min. global TopMetal1 density [%] = 25.00")
-	-&gt; do
-	    TM1_density.ext_with_density(0.7 .. 1.0, 'll')
-	end.().output("TM1.d", "Max. global TopMetal1 density [%] = 70.00")
+	    TM1_density.ext_without_density(0.25 .. 0.7, 'll')
+	end.().output("TM1.c/d", "Global TopMetal1 density [%] = 25.00 .. 70.00")
 end
 
 -&gt; do
@@ -1137,13 +1107,10 @@ end.().output("TM2.a", "Min. TopMetal2 width = 2.00")
     TopMetal2.ext_space(2.0.um)
 end.().output("TM2.b", "Min. TopMetal2 space or notch = 2.00")
 
-if $density
+if $densityRules
 	-&gt; do
-	    TM2_density.ext_with_density(0.0 .. 0.25, 'll')
-	end.().output("TM2.c", "Min. global TopMetal2 density [%] = 25.00")
-	-&gt; do
-	    TM2_density.ext_with_density(0.7 .. 1.0, 'll')
-	end.().output("TM2.d", "Max. global TopMetal2 density [%] = 70.00")
+	    TM2_density.ext_without_density(0.25 .. 0.7, 'll')
+	end.().output("TM2.c/d", "Global TopMetal2 density [%] = 25.00 .. 70.00")
 end
 
 -&gt; do
@@ -1152,37 +1119,33 @@ end.().output("Pas.a", "Min. Passiv width = 2.10")
 -&gt; do
     Passiv.ext_space(3.5.um)
 end.().output("Pas.b", "Min. Passiv space or notch = 3.50")
-
-if $sanityRules
-	-&gt; do
-	    Activ_pin.ext_not(Activ)
-	end.().output("Pin.a", "Min. Activ enclosure of Activ:pin = 0.00")
-	-&gt; do
-	    GatPoly_pin.ext_not(GatPoly)
-	end.().output("Pin.b", "Min. GatPoly enclosure of GatPoly:pin = 0.00")
-	-&gt; do
-	    Metal1_pin.ext_not(Metal1)
-	end.().output("Pin.e", "Min. Metal1 enclosure of Metal1:pin = 0.00")
-	-&gt; do
-	    Metal2_pin.ext_not(Metal2)
-	end.().output("Pin.f.M2", "Min. Metal2 enclosure of Metal2:pin = 0.00")
-	-&gt; do
-	    Metal3_pin.ext_not(Metal3)
-	end.().output("Pin.f.M3", "Min. Metal3 enclosure of Metal3:pin = 0.00")
-	-&gt; do
-	    Metal4_pin.ext_not(Metal4)
-	end.().output("Pin.f.M4", "Min. Metal4 enclosure of Metal4:pin = 0.00")
-	-&gt; do
-	    Metal5_pin.ext_not(Metal5)
-	end.().output("Pin.f.M5", "Min. Metal5 enclosure of Metal5:pin = 0.00")
-	-&gt; do
-	    TopMetal1_pin.ext_not(TopMetal1)
-	end.().output("Pin.g", "Min. TopMetal1 enclosure of TopMetal1:pin = 0.00")
-	-&gt; do
-	    TopMetal2_pin.ext_not(TopMetal2)
-	end.().output("Pin.h", "Min. TopMetal2 enclosure of TopMetal2:pin = 0.00")
-end
-
+-&gt; do
+    Activ_pin.ext_not(Activ)
+end.().output("Pin.a", "Min. Activ enclosure of Activ:pin = 0.00")
+-&gt; do
+    GatPoly_pin.ext_not(GatPoly)
+end.().output("Pin.b", "Min. GatPoly enclosure of GatPoly:pin = 0.00")
+-&gt; do
+    Metal1_pin.ext_not(Metal1)
+end.().output("Pin.e", "Min. Metal1 enclosure of Metal1:pin = 0.00")
+-&gt; do
+    Metal2_pin.ext_not(Metal2)
+end.().output("Pin.f.M2", "Min. Metal2 enclosure of Metal2:pin = 0.00")
+-&gt; do
+    Metal3_pin.ext_not(Metal3)
+end.().output("Pin.f.M3", "Min. Metal3 enclosure of Metal3:pin = 0.00")
+-&gt; do
+    Metal4_pin.ext_not(Metal4)
+end.().output("Pin.f.M4", "Min. Metal4 enclosure of Metal4:pin = 0.00")
+-&gt; do
+    Metal5_pin.ext_not(Metal5)
+end.().output("Pin.f.M5", "Min. Metal5 enclosure of Metal5:pin = 0.00")
+-&gt; do
+    TopMetal1_pin.ext_not(TopMetal1)
+end.().output("Pin.g", "Min. TopMetal1 enclosure of TopMetal1:pin = 0.00")
+-&gt; do
+    TopMetal2_pin.ext_not(TopMetal2)
+end.().output("Pin.h", "Min. TopMetal2 enclosure of TopMetal2:pin = 0.00")
 -&gt; do
     LBE.ext_width(100.0.um)
 end.().output("LBE.a", "Min. LBE width = 100.00")
@@ -1203,46 +1166,44 @@ end.().output("LBE.d", "Min. LBE space to inner edge of EdgeSeal = 150.00")
     LBE.with_holes.dup
 end.().output("LBE.h", "No LBE ring allowed")
 
-if $density
+if $densityRules
 	-&gt; do
 	    LBE.ext_with_density(0.2 .. 1.0, 'll')
 	end.().output("LBE.i", "Max. global LBE density [%] = 20.00")
 end
 
-
-if $sanityRules
-	-&gt; do
-	    BiWind.dup
-	end.().output("forbidden.BiWind", "Forbidden drawn layer BiWind on GDS layer 3/0 = 3/0")
-	-&gt; do
-	    PEmWind.dup
-	end.().output("forbidden.PEmWind", "Forbidden drawn layer PEmWind on GDS layer 11/0 = 11/0")
-	-&gt; do
-	    BasPoly.dup
-	end.().output("forbidden.BasPoly", "Forbidden drawn layer BasPoly on GDS layer 13/0 = 13/0")
-	-&gt; do
-	    DeepCo.dup
-	end.().output("forbidden.DeepCo", "Forbidden drawn layer DeepCo on GDS layer 35/0 = 35/0")
-	-&gt; do
-	    PEmPoly.dup
-	end.().output("forbidden.PEmPoly", "Forbidden drawn layer PEmPoly on GDS layer 53/0 = 53/0")
-	-&gt; do
-	    EmPoly.dup
-	end.().output("forbidden.EmPoly", "Forbidden gen./drawn layer EmPoly on GDS layer 53/0 = 53/0")
-	-&gt; do
-	    LDMOS.dup
-	end.().output("forbidden.LDMOS", "Forbidden drawn layer LDMOS on GDS layer 57/0 = 57/0")
-	-&gt; do
-	    PBiWind.dup
-	end.().output("forbidden.PBiWind", "Forbidden drawn layer PBiWind on GDS layer 58/0 = 58/0")
-	-&gt; do
-	    Flash.dup
-	end.().output("forbidden.Flash", "Forbidden drawn layer Flash on GDS layer 71/0 = 71/0")
-	-&gt; do
-	    ColWind.dup
-	end.().output("forbidden.ColWind", "Forbidden drawn layer ColWind on GDS layer 139/0 = 139/0")
-end
+-&gt; do
+    BiWind.dup
+end.().output("forbidden.BiWind", "Forbidden drawn layer BiWind on GDS layer 3/0 = 3/0")
+-&gt; do
+    PEmWind.dup
+end.().output("forbidden.PEmWind", "Forbidden drawn layer PEmWind on GDS layer 11/0 = 11/0")
+-&gt; do
+    BasPoly.dup
+end.().output("forbidden.BasPoly", "Forbidden drawn layer BasPoly on GDS layer 13/0 = 13/0")
+-&gt; do
+    DeepCo.dup
+end.().output("forbidden.DeepCo", "Forbidden drawn layer DeepCo on GDS layer 35/0 = 35/0")
+-&gt; do
+    PEmPoly.dup
+end.().output("forbidden.PEmPoly", "Forbidden drawn layer PEmPoly on GDS layer 53/0 = 53/0")
+-&gt; do
+    EmPoly.dup
+end.().output("forbidden.EmPoly", "Forbidden gen./drawn layer EmPoly on GDS layer 53/0 = 53/0")
+-&gt; do
+    LDMOS.dup
+end.().output("forbidden.LDMOS", "Forbidden drawn layer LDMOS on GDS layer 57/0 = 57/0")
+-&gt; do
+    PBiWind.dup
+end.().output("forbidden.PBiWind", "Forbidden drawn layer PBiWind on GDS layer 58/0 = 58/0")
+-&gt; do
+    Flash.dup
+end.().output("forbidden.Flash", "Forbidden drawn layer Flash on GDS layer 71/0 = 71/0")
+-&gt; do
+    ColWind.dup
+end.().output("forbidden.ColWind", "Forbidden drawn layer ColWind on GDS layer 139/0 = 139/0")
 
 puts("Number of DRC errors: #{$drc_error_count}")
+puts("Runtime in seconds: %.1f" % [Time.now - $start_time])
 </text>
 </klayout-macro>

--- a/ihp-sg13g2/libs.tech/klayout/tech/drc/sg13g2_minimal.lydrc
+++ b/ihp-sg13g2/libs.tech/klayout/tech/drc/sg13g2_minimal.lydrc
@@ -759,9 +759,14 @@ class DRC::DRCLayer
         return result
     end
 
-    def _ext_with_density(inverse, range, *args)
-        if self.is_empty?
-            return DRC::DRCLayer::new(@engine, RBA::Region::new())
+    def _ext_with_density(inverse,
+                          range,
+                          *args,
+                          tiles_stay_inside: false)
+        if inverse
+            method = :without_density
+        else
+            method = :with_density
         end
         if self.is_merged?
           merged_layer = self
@@ -791,43 +796,93 @@ class DRC::DRCLayer
             origin_x = bbox.left
             origin_y = bbox.bottom
             if tile_size and tile_step and (tile_size.get[0] != tile_step.get[0] or tile_size.get[1] != tile_step.get[1])
-              origin_x = bbox.left + tile_step.get[0]/2
-              origin_y = bbox.bottom + tile_step.get[1]/2
+                origin_x = bbox.left + (tile_size.get[0]-tile_step.get[0])/2
+                origin_y = bbox.bottom + (tile_size.get[1]-tile_step.get[1])/2
             end
             tile_origin = DRC::DRCTileOrigin::new(origin_x, origin_y)
             arguments.push(tile_origin)
-        elsif origin != 'cc'
+        elsif origin == 'cc'
+            origin_x = bbox.center.x
+            origin_y = bbox.center.y
+            tile_origin = DRC::DRCTileOrigin::new(origin_x, origin_y)
+        else
             raise "Unknown origin: 'cc' or 'll' expected"
         end
         if tile_size
             boundary_layer = DRC::DRCLayer::new(@engine, RBA::Region::new(bbox.to_itype(@engine.dbu)))
             tile_boundary = DRC::DRCTileBoundary::new(boundary_layer)
-            if inverse
-                return merged_layer.without_density(*arguments, tile_boundary, @engine.padding_ignore)
+            if tiles_stay_inside
+                if origin != 'll'
+                    raise "Option 'tiles_stay_inside' requires origin='ll'"
+                end
+                tile_width = tile_size.get[0]
+                tile_height = tile_size.get[1]
+                enlarged_bbox = bbox.dup
+                if tile_width &gt; bbox.width
+                    enlarged_bbox.right = bbox.left + tile_width
+                end
+                if tile_height &gt; bbox.height
+                    enlarged_bbox.top = bbox.bottom + tile_height
+                end
+                enlarged_boundary_layer = DRC::DRCLayer::new(@engine, RBA::Region::new(enlarged_bbox.to_itype(@engine.dbu)))
+                if tile_step
+                    tile_step_x = tile_step.get[0]
+                    tile_step_y = tile_step.get[1]
+                else
+                    tile_step_x = tile_width
+                    tile_step_y = tile_height
+                end
+                tile_count_x = 1 + ((bbox.width - tile_width) / tile_step_x).floor()
+                tile_count_x = tile_count_x &lt; 1 ? 1 : tile_count_x
+                tile_count_y = 1 + ((bbox.height - tile_height) / tile_step_y).floor()
+                tile_count_y = tile_count_y &lt; 1 ? 1 : tile_count_y
+                if tile_count_x == 1 and tile_count_y == 1
+                    tile_count = DRC::DRCTileCount::new(tile_count_x, 2)
+                else
+                    tile_count = DRC::DRCTileCount::new(tile_count_x, tile_count_y)
+                end
+                result = merged_layer.public_send(method, *arguments, tile_count, tile_boundary, @engine.padding_ignore)
+                need_top_row = false
+                need_right_column = false
+                if bbox.height &gt; tile_height + (tile_count_y-1)*tile_step_y
+                    need_top_row = true
+                    tile_origin2 = DRC::DRCTileOrigin::new(tile_origin.get[0], tile_origin.get[1]+bbox.height-tile_height)
+                    tile_count = DRC::DRCTileCount::new([2, tile_count_x].max, 1)
+                    result += merged_layer.public_send(method, *arguments, tile_origin2, tile_count, tile_boundary, @engine.padding_ignore)
+                end
+                if bbox.width &gt; tile_width + (tile_count_x-1)*tile_step_x
+                    need_right_column = true
+                    tile_origin2 = DRC::DRCTileOrigin::new(tile_origin.get[0]+bbox.width-tile_width, tile_origin.get[1])
+                    tile_count = DRC::DRCTileCount::new(1, [2, tile_count_y].max)
+                    result += merged_layer.public_send(method, *arguments, tile_origin2, tile_count, tile_boundary, @engine.padding_ignore)
+                end
+                if (need_top_row and bbox.width &gt; tile_width) or (need_right_column and bbox.height &gt; tile_height)
+                    tile_origin2 = DRC::DRCTileOrigin::new(tile_origin.get[0]+bbox.width-tile_width, tile_origin.get[1]+bbox.height-tile_height)
+                    tile_count = DRC::DRCTileCount::new(1, 2)
+                    result += merged_layer.public_send(method, *arguments, tile_origin2, tile_count, tile_boundary, @engine.padding_ignore)
+                end
+                result.raw.select_inside(enlarged_boundary_layer)
             else
-                return merged_layer.with_density(*arguments, tile_boundary, @engine.padding_ignore)
+                result = merged_layer.public_send(method, *arguments, tile_boundary, @engine.padding_ignore)
             end
+            return result.and(boundary_layer)
         else
             tile_size = DRC::DRCTileSize::new(bbox.width, bbox.height)
-            tile_count = DRC::DRCTileCount::new(1,2)
+            tile_count = DRC::DRCTileCount::new(1,3)
             enlarged_bbox = bbox.enlarged(1.1).to_itype(@engine.dbu)
             boundary_layer = DRC::DRCLayer::new(@engine, RBA::Region::new(enlarged_bbox))
             tile_boundary = DRC::DRCTileBoundary::new(boundary_layer)
-            if inverse
-                result = merged_layer.without_density(*arguments, tile_size, tile_count, tile_boundary, @engine.padding_ignore)
-            else
-                result = merged_layer.with_density(*arguments, tile_size, tile_count, tile_boundary, @engine.padding_ignore)
-            end
+            result = merged_layer.public_send(method, *arguments, tile_size, tile_count, tile_boundary, @engine.padding_ignore)
             return result.raw.overlapping(DRC::DRCLayer::new(@engine, RBA::Region::new(bbox.to_itype(@engine.dbu))))
         end
     end
 
-    def ext_with_density(*args)
-        self._ext_with_density(false, *args)
+    def ext_with_density(*args, **kargs)
+        self._ext_with_density(false, *args, **kargs)
     end
 
-    def ext_without_density(*args)
-        self._ext_with_density(true, *args)
+    def ext_without_density(*args, **kargs)
+        self._ext_with_density(true, *args, **kargs)
     end
 
     def ext_outside(other)
@@ -942,7 +997,7 @@ if $densityRules
 	    Act_density.ext_without_density(0.35 .. 0.55, 'll')
 	end.().output("AFil.g/g1", "Global Activ density [%] = 35.00 .. 55.00")
 	-&gt; do
-	    Act_density.ext_without_density(0.25 .. 0.65, 'll', tile_size(800.0.um), tile_step(400.0.um))
+	    Act_density.ext_without_density(0.25 .. 0.65, 'll', tile_size(800.0.um), tile_step(400.0.um), tiles_stay_inside: true)
 	end.().output("AFil.g2/g3", "Activ coverage ratio for any 800 x 800 µm² chip area [%] = 25.00 .. 65.00")
 end
 
@@ -1035,19 +1090,19 @@ if $densityRules
 	    M5_density.ext_without_density(0.35 .. 0.6, 'll')
 	end.().output("M5.j/k", "Global Metal5 density [%] = 35.00 .. 60.00")
 	-&gt; do
-	    M1_density.ext_without_density(0.25 .. 0.75, 'll', tile_size(800.0.um), tile_step(400.0.um))
+	    M1_density.ext_without_density(0.25 .. 0.75, 'll', tile_size(800.0.um), tile_step(400.0.um), tiles_stay_inside: true)
 	end.().output("M1Fil.h/k", "Metal1 and Metal1:filler coverage ratio for any 800 x 800 µm² chip area [%] = 25.00 .. 75.00")
 	-&gt; do
-	    M2_density.ext_without_density(0.25 .. 0.75, 'll', tile_size(800.0.um), tile_step(400.0.um))
+	    M2_density.ext_without_density(0.25 .. 0.75, 'll', tile_size(800.0.um), tile_step(400.0.um), tiles_stay_inside: true)
 	end.().output("M2Fil.h/k", "Metal2 and Metal2:filler coverage ratio for any 800 x 800 µm² chip area [%] = 25.00 .. 75.00")
 	-&gt; do
-	    M3_density.ext_without_density(0.25 .. 0.75, 'll', tile_size(800.0.um), tile_step(400.0.um))
+	    M3_density.ext_without_density(0.25 .. 0.75, 'll', tile_size(800.0.um), tile_step(400.0.um), tiles_stay_inside: true)
 	end.().output("M3Fil.h/k", "Metal3 and Metal3:filler coverage ratio for any 800 x 800 µm² chip area [%] = 25.00 .. 75.00")
 	-&gt; do
-	    M4_density.ext_without_density(0.25 .. 0.75, 'll', tile_size(800.0.um), tile_step(400.0.um))
+	    M4_density.ext_without_density(0.25 .. 0.75, 'll', tile_size(800.0.um), tile_step(400.0.um), tiles_stay_inside: true)
 	end.().output("M4Fil.h/k", "Metal4 and Metal4:filler coverage ratio for any 800 x 800 µm² chip area [%] = 25.00 .. 75.00")
 	-&gt; do
-	    M5_density.ext_without_density(0.25 .. 0.75, 'll', tile_size(800.0.um), tile_step(400.0.um))
+	    M5_density.ext_without_density(0.25 .. 0.75, 'll', tile_size(800.0.um), tile_step(400.0.um), tiles_stay_inside: true)
 	end.().output("M5Fil.h/k", "Metal5 and Metal5:filler coverage ratio for any 800 x 800 µm² chip area [%] = 25.00 .. 75.00")
 end
 


### PR DESCRIPTION
- checking for a density >0 creates errors for empty layers
- error markers are clamped to the chip area
- new option `tiles_stay_inside` that moves tiles back into the chip
  area if they overlap the chip boundary

Fixes issuees #391 and #404