### PR TITLE
OpenEMS layer stackup hot-fix

### DIFF
--- a/ihp-sg13g2/libs.tech/openems/testcase/SG13_Octagon_L2n0/OpenEMS_Matlab/SG13_L2n0_30GHz_mesh0u5_50dB.m
+++ b/ihp-sg13g2/libs.tech/openems/testcase/SG13_Octagon_L2n0/OpenEMS_Matlab/SG13_L2n0_30GHz_mesh0u5_50dB.m
@@ -58,7 +58,7 @@ mesh.z = [mesh.z linspace(EPI.zmin,EPI.zmax,2)];
 %% SiO2
 CSX = AddMaterial( CSX, 'SiO2' );
 CSX = SetMaterialProperty( CSX, 'SiO2', 'Epsilon', 4.1 );
-SiO2.thick = 17.73;
+SiO2.thick = 15.73;
 SiO2.zmin = EPI.zmax;
 SiO2.zmax = SiO2.zmin + SiO2.thick;
 

--- a/ihp-sg13g2/libs.tech/openems/testcase/SG13_Octagon_L2n0/OpenEMS_Matlab/SG13_L2n0_30GHz_mesh0u5_50dB_finerZ.m
+++ b/ihp-sg13g2/libs.tech/openems/testcase/SG13_Octagon_L2n0/OpenEMS_Matlab/SG13_L2n0_30GHz_mesh0u5_50dB_finerZ.m
@@ -58,7 +58,7 @@ mesh.z = [mesh.z linspace(EPI.zmin,EPI.zmax,5)];
 %% SiO2
 CSX = AddMaterial( CSX, 'SiO2' );
 CSX = SetMaterialProperty( CSX, 'SiO2', 'Epsilon', 4.1 );
-SiO2.thick = 17.73;
+SiO2.thick = 15.73;
 SiO2.zmin = EPI.zmax;
 SiO2.zmax = SiO2.zmin + SiO2.thick;
 

--- a/ihp-sg13g2/libs.tech/openems/testcase/SG13_Octagon_L2n0/OpenEMS_Matlab/SG13_L2n0_30GHz_mesh1u5_50dB.m
+++ b/ihp-sg13g2/libs.tech/openems/testcase/SG13_Octagon_L2n0/OpenEMS_Matlab/SG13_L2n0_30GHz_mesh1u5_50dB.m
@@ -58,7 +58,7 @@ mesh.z = [mesh.z linspace(EPI.zmin,EPI.zmax,2)];
 %% SiO2
 CSX = AddMaterial( CSX, 'SiO2' );
 CSX = SetMaterialProperty( CSX, 'SiO2', 'Epsilon', 4.1 );
-SiO2.thick = 17.73;
+SiO2.thick = 15.73;
 SiO2.zmin = EPI.zmax;
 SiO2.zmax = SiO2.zmin + SiO2.thick;
 

--- a/ihp-sg13g2/libs.tech/openems/testcase/SG13_Octagon_L2n0/OpenEMS_Matlab/SG13_L2n0_30GHz_mesh1um_50dB.m
+++ b/ihp-sg13g2/libs.tech/openems/testcase/SG13_Octagon_L2n0/OpenEMS_Matlab/SG13_L2n0_30GHz_mesh1um_50dB.m
@@ -58,7 +58,7 @@ mesh.z = [mesh.z linspace(EPI.zmin,EPI.zmax,2)];
 %% SiO2
 CSX = AddMaterial( CSX, 'SiO2' );
 CSX = SetMaterialProperty( CSX, 'SiO2', 'Epsilon', 4.1 );
-SiO2.thick = 17.73;
+SiO2.thick = 15.73;
 SiO2.zmin = EPI.zmax;
 SiO2.zmax = SiO2.zmin + SiO2.thick;
 

--- a/ihp-sg13g2/libs.tech/openems/testcase/SG13_Octagon_L2n0/OpenEMS_Python/SG13_L2n0_2port_groundpolygon_mesh1.5um.py
+++ b/ihp-sg13g2/libs.tech/openems/testcase/SG13_Octagon_L2n0/OpenEMS_Python/SG13_L2n0_2port_groundpolygon_mesh1.5um.py
@@ -99,7 +99,7 @@ def createSimulation (exciteport):
 
     # SiO2
     SiO2 = CSX.AddMaterial('SiO2', epsilon=4.1)
-    SiO2_thick = 17.73
+    SiO2_thick = 15.73
     SiO2_zmin = EPI_zmax
     SiO2_zmax = SiO2_zmin + SiO2_thick
 

--- a/ihp-sg13g2/libs.tech/openems/testcase/SG13_Octagon_L2n0/OpenEMS_Python/SG13_L2n0_mesh1.5um_v2.py
+++ b/ihp-sg13g2/libs.tech/openems/testcase/SG13_Octagon_L2n0/OpenEMS_Python/SG13_L2n0_mesh1.5um_v2.py
@@ -86,7 +86,7 @@ EPI_zmax = EPI_zmin + EPI_thick
 
 # SiO2
 SiO2 = CSX.AddMaterial('SiO2', epsilon=4.1)
-SiO2_thick = 17.73
+SiO2_thick = 15.73
 SiO2_zmin = EPI_zmax
 SiO2_zmax = SiO2_zmin + SiO2_thick
 

--- a/ihp-sg13g2/libs.tech/openems/testcase/SG13_Octagon_L2n0/OpenEMS_Python/SG13_L2n0_mesh1um_v2.py
+++ b/ihp-sg13g2/libs.tech/openems/testcase/SG13_Octagon_L2n0/OpenEMS_Python/SG13_L2n0_mesh1um_v2.py
@@ -86,7 +86,7 @@ EPI_zmax = EPI_zmin + EPI_thick
 
 # SiO2
 SiO2 = CSX.AddMaterial('SiO2', epsilon=4.1)
-SiO2_thick = 17.73
+SiO2_thick = 15.73
 SiO2_zmin = EPI_zmax
 SiO2_zmax = SiO2_zmin + SiO2_thick
 


### PR DESCRIPTION
Modified values for the layer stack of BEOL for EM simulation. The value of SiO2 was changed from `17.73` to  `15.73` in the python/matlab scripts.

Fixes #439 

