### PR TITLE
Stdcell wrong format fix

### DIFF
--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_dlhr_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_dlhr_1.sym
@@ -19,7 +19,7 @@ G {}
 K {type=primitive
 function3="1 d ~ 3 & x 0 & | 2 &"
 function4="3 ~"
-format="@name @@D @@GATE @@Q @@Q_N @@@RESET_B VDD @VSS @prefix\\\\dlhr_1"
+format="@name @@D @@GATE @@Q @@Q_N @@@RESET_B @VDD @VSS @prefix\\\\dlhr_1"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
 verilogprefix=sg13g2_

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_sdfbbp_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_sdfbbp_1.sym
@@ -17,7 +17,7 @@ v {xschem version=3.1.0 file_version=1.0
 
 G {}
 K {type=primitive
-format="@name @@CLK @@D @@Q @@Q_N @@@RESET_B @@SCD @@SCE @@SET_B VDD @VSS @prefix\\\\sdfbbp_1"
+format="@name @@CLK @@D @@Q @@Q_N @@@RESET_B @@SCD @@SCE @@SET_B @VDD @VSS @prefix\\\\sdfbbp_1"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
 verilogprefix=sg13g2_

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/tran_inv.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/tran_inv.sch
@@ -1,5 +1,4 @@
-v {xschem version=3.4.4 file_version=1.2
-}
+v {xschem version=3.4.6 file_version=1.2}
 G {}
 K {}
 V {}
@@ -54,7 +53,6 @@ value="
 vvdd vdd 0 dc 1.8
 vvss vss 0 0
 .control
-pre_osdi ./psp103_nqs.osdi
 save all 
 tran 50p 20n
 meas tran tdelay TRIG v(in) VAL=0.9 FALL=1 TARG v(out) VAL=0.9 RISE=1


### PR DESCRIPTION
The changes fix format of two standard cells and remove ./pre_osdi from the inverter testbench.
Cells fixed:

- sg13g2_dlhr_1
- sg13g2_sdfbbp_1

Fixes #465 
