### PR TITLE
introduce num_sigmas instead mc_ok for statistical models

### DIFF
--- a/ihp-sg13g2/libs.tech/ngspice/models/capacitors_stat.lib
+++ b/ihp-sg13g2/libs.tech/ngspice/models/capacitors_stat.lib
@@ -15,10 +15,10 @@
 * limitations under the License.
 *
 *#######################################################################
-.param mc_ok=1
+.param num_sigmas=1
 * ngspice MC parameters
-.param  mc_cap_carea  = 'gauss(cap_carea_norm, 0.033, mc_ok)'
-.param  mc_cap_cpara  = 'gauss(cap_cpara_norm, 0.067, mc_ok)'
+.param  mc_cap_carea  = 'gauss(cap_carea_norm, 0.033, num_sigmas)'
+.param  mc_cap_cpara  = 'gauss(cap_cpara_norm, 0.067, num_sigmas)'
 
 .param  cap_carea  = mc_cap_carea
 .param  cap_cpara  = mc_cap_cpara

--- a/ihp-sg13g2/libs.tech/ngspice/models/resistors_stat.lib
+++ b/ihp-sg13g2/libs.tech/ngspice/models/resistors_stat.lib
@@ -15,13 +15,13 @@
 * limitations under the License.
 *
 *#######################################################################
-.param mc_ok=1
+.param num_sigmas=1
 * ngspice MC parameters
-.param  mc_rsh_rhigh = 'gauss(rsh_rhigh_norm, 0.0833, 1)'
-.param  mc_rsh_rsil  = 'gauss(rsh_rsil_norm, 0.0467, 1)'
-.param  mc_rsh_rppd  = 'gauss(rsh_rppd_norm, 0.033, 1)'
-.param  mc_res_area  = 'gauss(res_area_norm, 0.033, 1)'
-.param  mc_res_rpara = 'gauss(res_rpara_norm, 0.067, 1)'
+.param  mc_rsh_rhigh = 'gauss(rsh_rhigh_norm, 0.0833,  num_sigmas)'
+.param  mc_rsh_rsil  = 'gauss(rsh_rsil_norm, 0.0467,  num_sigmas)'
+.param  mc_rsh_rppd  = 'gauss(rsh_rppd_norm, 0.033,  num_sigmas)'
+.param  mc_res_area  = 'gauss(res_area_norm, 0.033,  num_sigmas)'
+.param  mc_res_rpara = 'gauss(res_rpara_norm, 0.067,  num_sigmas)'
 
 .param  rsh_rhigh = mc_rsh_rhigh
 .param  rsh_rsil  = mc_rsh_rsil

--- a/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_hbt_stat.lib
+++ b/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_hbt_stat.lib
@@ -16,18 +16,18 @@
 *
 *#######################################################################
 
-.param mc_ok=1
+.param num_sigmas=1
 
 * ngspice process variation parameters
-.param  mc_vbic_cje  = 'gauss(vbic_cje_norm, 0.058, mc_ok)'
-.param  mc_vbic_cjc  = 'gauss(vbic_cjc_norm, 0.043, mc_ok)'
-.param  mc_vbic_cjcp = 'gauss(vbic_cjcp_norm, 0.037, mc_ok)'
-.param  mc_vbic_is   = 'gauss(vbic_is_norm, 0.087, mc_ok)'
-.param  mc_vbic_ibei = 'gauss(vbic_ibei_norm, 0.11, mc_ok)'
-.param  mc_vbic_re   = 'gauss(vbic_re_norm, 0.09, mc_ok)'
-.param  mc_vbic_rcx  = 'gauss(vbic_rcx_norm, 0.069, mc_ok)'
-.param  mc_vbic_rbx  = 'gauss(vbic_rbx_norm, 0.041, mc_ok)'
-*.param  mc_vbic_tf   = 'gauss(vbic_tf_norm, 0.037, mc_ok)'
+.param  mc_vbic_cje  = 'gauss(vbic_cje_norm, 0.058, num_sigmas)'
+.param  mc_vbic_cjc  = 'gauss(vbic_cjc_norm, 0.043, num_sigmas)'
+.param  mc_vbic_cjcp = 'gauss(vbic_cjcp_norm, 0.037, num_sigmas)'
+.param  mc_vbic_is   = 'gauss(vbic_is_norm, 0.087, num_sigmas)'
+.param  mc_vbic_ibei = 'gauss(vbic_ibei_norm, 0.11, num_sigmas)'
+.param  mc_vbic_re   = 'gauss(vbic_re_norm, 0.09, num_sigmas)'
+.param  mc_vbic_rcx  = 'gauss(vbic_rcx_norm, 0.069, num_sigmas)'
+.param  mc_vbic_rbx  = 'gauss(vbic_rbx_norm, 0.041, num_sigmas)'
+*.param  mc_vbic_tf   = 'gauss(vbic_tf_norm, 0.037, num_sigmas)'
 
 .param  vbic_cje  = mc_vbic_cje
 .param  vbic_cjc  = mc_vbic_cjc
@@ -40,13 +40,13 @@
 *.param  vbic_tf   = mc_vbic_tf
 
 * pnpMPA device
-.param mc_sgp_mpa_cje = 'gauss(sgp_mpa_cje_norm, 0.015, mc_ok)'
-.param mc_sgp_mpa_cjc = 'gauss(sgp_mpa_cjc_norm, 0.007, mc_ok)'
-.param mc_sgp_mpa_is  = 'gauss(sgp_mpa_is_norm, 0.043, mc_ok)'
-.param mc_sgp_mpa_bf  = 'gauss(sgp_mpa_bf_norm, 0.079, mc_ok)'
-.param mc_sgp_mpa_re  = 'gauss(sgp_mpa_re_norm, 0.016, mc_ok)'
-.param mc_sgp_mpa_rb  = 'gauss(sgp_mpa_rb_norm, 0.008, mc_ok)'
-.param mc_sgp_mpa_rc  = 'gauss(sgp_mpa_rc_norm, 0.017, mc_ok)'
+.param mc_sgp_mpa_cje = 'gauss(sgp_mpa_cje_norm, 0.015, num_sigmas)'
+.param mc_sgp_mpa_cjc = 'gauss(sgp_mpa_cjc_norm, 0.007, num_sigmas)'
+.param mc_sgp_mpa_is  = 'gauss(sgp_mpa_is_norm, 0.043, num_sigmas)'
+.param mc_sgp_mpa_bf  = 'gauss(sgp_mpa_bf_norm, 0.079, num_sigmas)'
+.param mc_sgp_mpa_re  = 'gauss(sgp_mpa_re_norm, 0.016, num_sigmas)'
+.param mc_sgp_mpa_rb  = 'gauss(sgp_mpa_rb_norm, 0.008, num_sigmas)'
+.param mc_sgp_mpa_rc  = 'gauss(sgp_mpa_rc_norm, 0.017, num_sigmas)'
 
 .param sgp_mpa_cje = mc_sgp_mpa_cje
 .param sgp_mpa_cjc = mc_sgp_mpa_cjc

--- a/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moshv_stat.lib
+++ b/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moshv_stat.lib
@@ -18,27 +18,27 @@
 *
 * NOTE:
 * values are one-sigma deviations (1/3 of min-max)
-.param mc_ok=1
+.param num_sigmas=1
 
 * ngspice statistical parameters
-.param mc_sg13g2_hv_nmos_vfbo        ='gauss(sg13g2_hv_nmos_vfbo_norm,      0.004,  mc_ok)'
-.param mc_sg13g2_hv_nmos_rsgo        ='gauss(sg13g2_hv_nmos_rsgo_norm,      1e-9,   mc_ok)'
-.param mc_sg13g2_hv_nmos_rsw1        ='gauss(sg13g2_hv_nmos_rsw1_norm,      0.0001, mc_ok)'
-.param mc_sg13g2_hv_nmos_mueo        ='gauss(sg13g2_hv_nmos_mueo_norm,      0.0335, mc_ok)'
-.param mc_sg13g2_hv_nmos_dphibo      ='gauss(sg13g2_hv_nmos_dphibo_norm,    0.1503, mc_ok)'
-.param mc_sg13g2_hv_nmos_dphibl      ='gauss(sg13g2_hv_nmos_dphibl_norm,    0.2052, mc_ok)'
-.param mc_sg13g2_hv_nmos_dphibw      ='gauss(sg13g2_hv_nmos_dphibw_norm,    1e-9,   mc_ok)'
-.param mc_sg13g2_hv_nmos_dphiblw     ='gauss(sg13g2_hv_nmos_dphiblw_norm,   0.0151, mc_ok)'
-.param mc_sg13g2_hv_nmos_ctl         ='gauss(sg13g2_hv_nmos_ctl_norm,       1e-9,   mc_ok)'
-.param mc_sg13g2_hv_nmos_thesato     ='gauss(sg13g2_hv_nmos_thesato_norm,   1e-9,   mc_ok)'
-.param mc_sg13g2_hv_nmos_thesatl     ='gauss(sg13g2_hv_nmos_thesatl_norm,   0.0358, mc_ok)'
-.param mc_sg13g2_hv_nmos_thesatw     ='gauss(sg13g2_hv_nmos_thesatw_norm,   1e-9,   mc_ok)'
-.param mc_sg13g2_hv_nmos_thesatlw    ='gauss(sg13g2_hv_nmos_thesatlw_norm,  0.0353, mc_ok)'
-.param mc_sg13g2_hv_nmos_toxo        ='gauss(sg13g2_hv_nmos_toxo_norm,      0.0133, mc_ok)'
-.param mc_sg13g2_hv_nmos_toxovo      ='gauss(sg13g2_hv_nmos_toxovo_norm,    0.0133, mc_ok)'
-.param mc_sg13g2_hv_nmos_cjorbot     ='gauss(sg13g2_hv_nmos_cjorbot_norm,   0.0267, mc_ok)'
-.param mc_sg13g2_hv_nmos_cjorsti     ='gauss(sg13g2_hv_nmos_cjorsti_norm,   0.0267, mc_ok)'
-.param mc_sg13g2_hv_nmos_cjorgat     ='gauss(sg13g2_hv_nmos_cjorgat_norm,   0.0267, mc_ok)'
+.param mc_sg13g2_hv_nmos_vfbo        ='gauss(sg13g2_hv_nmos_vfbo_norm,      0.004,  num_sigmas)'
+.param mc_sg13g2_hv_nmos_rsgo        ='gauss(sg13g2_hv_nmos_rsgo_norm,      1e-9,   num_sigmas)'
+.param mc_sg13g2_hv_nmos_rsw1        ='gauss(sg13g2_hv_nmos_rsw1_norm,      0.0001, num_sigmas)'
+.param mc_sg13g2_hv_nmos_mueo        ='gauss(sg13g2_hv_nmos_mueo_norm,      0.0335, num_sigmas)'
+.param mc_sg13g2_hv_nmos_dphibo      ='gauss(sg13g2_hv_nmos_dphibo_norm,    0.1503, num_sigmas)'
+.param mc_sg13g2_hv_nmos_dphibl      ='gauss(sg13g2_hv_nmos_dphibl_norm,    0.2052, num_sigmas)'
+.param mc_sg13g2_hv_nmos_dphibw      ='gauss(sg13g2_hv_nmos_dphibw_norm,    1e-9,   num_sigmas)'
+.param mc_sg13g2_hv_nmos_dphiblw     ='gauss(sg13g2_hv_nmos_dphiblw_norm,   0.0151, num_sigmas)'
+.param mc_sg13g2_hv_nmos_ctl         ='gauss(sg13g2_hv_nmos_ctl_norm,       1e-9,   num_sigmas)'
+.param mc_sg13g2_hv_nmos_thesato     ='gauss(sg13g2_hv_nmos_thesato_norm,   1e-9,   num_sigmas)'
+.param mc_sg13g2_hv_nmos_thesatl     ='gauss(sg13g2_hv_nmos_thesatl_norm,   0.0358, num_sigmas)'
+.param mc_sg13g2_hv_nmos_thesatw     ='gauss(sg13g2_hv_nmos_thesatw_norm,   1e-9,   num_sigmas)'
+.param mc_sg13g2_hv_nmos_thesatlw    ='gauss(sg13g2_hv_nmos_thesatlw_norm,  0.0353, num_sigmas)'
+.param mc_sg13g2_hv_nmos_toxo        ='gauss(sg13g2_hv_nmos_toxo_norm,      0.0133, num_sigmas)'
+.param mc_sg13g2_hv_nmos_toxovo      ='gauss(sg13g2_hv_nmos_toxovo_norm,    0.0133, num_sigmas)'
+.param mc_sg13g2_hv_nmos_cjorbot     ='gauss(sg13g2_hv_nmos_cjorbot_norm,   0.0267, num_sigmas)'
+.param mc_sg13g2_hv_nmos_cjorsti     ='gauss(sg13g2_hv_nmos_cjorsti_norm,   0.0267, num_sigmas)'
+.param mc_sg13g2_hv_nmos_cjorgat     ='gauss(sg13g2_hv_nmos_cjorgat_norm,   0.0267, num_sigmas)'
 
 .param sg13g2_hv_nmos_vfbo           = mc_sg13g2_hv_nmos_vfbo
 .param sg13g2_hv_nmos_rsgo           = mc_sg13g2_hv_nmos_rsgo
@@ -59,25 +59,25 @@
 .param sg13g2_hv_nmos_cjorsti        = mc_sg13g2_hv_nmos_cjorsti
 .param sg13g2_hv_nmos_cjorgat        = mc_sg13g2_hv_nmos_cjorgat
 
-.param mc_sg13g2_hv_pmos_vfbo        ='gauss(sg13g2_hv_pmos_vfbo_norm,    0.004,  mc_ok)'
-.param mc_sg13g2_hv_pmos_rsgo        ='gauss(sg13g2_hv_pmos_rsgo_norm,    0.4253, mc_ok)'
-.param mc_sg13g2_hv_pmos_rsw1        ='gauss(sg13g2_hv_pmos_rsw1_norm,    1e-9,   mc_ok)'
-.param mc_sg13g2_hv_pmos_mueo        ='gauss(sg13g2_hv_pmos_mueo_norm,    0.0014, mc_ok)'
-.param mc_sg13g2_hv_pmos_dphibo      ='gauss(sg13g2_hv_pmos_dphibo_norm,  0.0572, mc_ok)'
-.param mc_sg13g2_hv_pmos_dphibl      ='gauss(sg13g2_hv_pmos_dphibl_norm,  0.0672, mc_ok)'
-.param mc_sg13g2_hv_pmos_dphibw      ='gauss(sg13g2_hv_pmos_dphibw_norm,  0.0183, mc_ok)'
-.param mc_sg13g2_hv_pmos_dphiblw     ='gauss(sg13g2_hv_pmos_dphiblw_norm, 1.0138, mc_ok)'
-.param mc_sg13g2_hv_pmos_bgidlo      ='gauss(sg13g2_hv_pmos_bgidlo_norm,  0.1538, mc_ok)'
-.param mc_sg13g2_hv_pmos_thesato     ='gauss(sg13g2_hv_pmos_thesato_norm, 1e-9,   mc_ok)'
-.param mc_sg13g2_hv_pmos_thesatl     ='gauss(sg13g2_hv_pmos_thesatl_norm, 0.0198, mc_ok)'
-.param mc_sg13g2_hv_pmos_thesatw     ='gauss(sg13g2_hv_pmos_thesatw_norm, 0.4367, mc_ok)'
-.param mc_sg13g2_hv_pmos_thesatlw    ='gauss(sg13g2_hv_pmos_thesatlw_norm,1e-9,   mc_ok)'
-.param mc_sg13g2_hv_pmos_csl         ='gauss(sg13g2_hv_pmos_csl_norm,     1e-9,   mc_ok)'
-.param mc_sg13g2_hv_pmos_toxo        ='gauss(sg13g2_hv_pmos_toxo_norm,    0.0133, mc_ok)'
-.param mc_sg13g2_hv_pmos_toxovo      ='gauss(sg13g2_hv_pmos_toxovo_norm,  0.0133, mc_ok)'
-.param mc_sg13g2_hv_pmos_cjorbot     ='gauss(sg13g2_hv_pmos_cjorbot_norm, 0.0267, mc_ok)'
-.param mc_sg13g2_hv_pmos_cjorsti     ='gauss(sg13g2_hv_pmos_cjorsti_norm, 0.0267, mc_ok)'
-.param mc_sg13g2_hv_pmos_cjorgat     ='gauss(sg13g2_hv_pmos_cjorgat_norm, 0.0267, mc_ok)'
+.param mc_sg13g2_hv_pmos_vfbo        ='gauss(sg13g2_hv_pmos_vfbo_norm,    0.004,  num_sigmas)'
+.param mc_sg13g2_hv_pmos_rsgo        ='gauss(sg13g2_hv_pmos_rsgo_norm,    0.4253, num_sigmas)'
+.param mc_sg13g2_hv_pmos_rsw1        ='gauss(sg13g2_hv_pmos_rsw1_norm,    1e-9,   num_sigmas)'
+.param mc_sg13g2_hv_pmos_mueo        ='gauss(sg13g2_hv_pmos_mueo_norm,    0.0014, num_sigmas)'
+.param mc_sg13g2_hv_pmos_dphibo      ='gauss(sg13g2_hv_pmos_dphibo_norm,  0.0572, num_sigmas)'
+.param mc_sg13g2_hv_pmos_dphibl      ='gauss(sg13g2_hv_pmos_dphibl_norm,  0.0672, num_sigmas)'
+.param mc_sg13g2_hv_pmos_dphibw      ='gauss(sg13g2_hv_pmos_dphibw_norm,  0.0183, num_sigmas)'
+.param mc_sg13g2_hv_pmos_dphiblw     ='gauss(sg13g2_hv_pmos_dphiblw_norm, 1.0138, num_sigmas)'
+.param mc_sg13g2_hv_pmos_bgidlo      ='gauss(sg13g2_hv_pmos_bgidlo_norm,  0.1538, num_sigmas)'
+.param mc_sg13g2_hv_pmos_thesato     ='gauss(sg13g2_hv_pmos_thesato_norm, 1e-9,   num_sigmas)'
+.param mc_sg13g2_hv_pmos_thesatl     ='gauss(sg13g2_hv_pmos_thesatl_norm, 0.0198, num_sigmas)'
+.param mc_sg13g2_hv_pmos_thesatw     ='gauss(sg13g2_hv_pmos_thesatw_norm, 0.4367, num_sigmas)'
+.param mc_sg13g2_hv_pmos_thesatlw    ='gauss(sg13g2_hv_pmos_thesatlw_norm,1e-9,   num_sigmas)'
+.param mc_sg13g2_hv_pmos_csl         ='gauss(sg13g2_hv_pmos_csl_norm,     1e-9,   num_sigmas)'
+.param mc_sg13g2_hv_pmos_toxo        ='gauss(sg13g2_hv_pmos_toxo_norm,    0.0133, num_sigmas)'
+.param mc_sg13g2_hv_pmos_toxovo      ='gauss(sg13g2_hv_pmos_toxovo_norm,  0.0133, num_sigmas)'
+.param mc_sg13g2_hv_pmos_cjorbot     ='gauss(sg13g2_hv_pmos_cjorbot_norm, 0.0267, num_sigmas)'
+.param mc_sg13g2_hv_pmos_cjorsti     ='gauss(sg13g2_hv_pmos_cjorsti_norm, 0.0267, num_sigmas)'
+.param mc_sg13g2_hv_pmos_cjorgat     ='gauss(sg13g2_hv_pmos_cjorgat_norm, 0.0267, num_sigmas)'
 
 .param sg13g2_hv_pmos_vfbo           = mc_sg13g2_hv_pmos_vfbo
 .param sg13g2_hv_pmos_rsgo           = mc_sg13g2_hv_pmos_rsgo
@@ -99,10 +99,10 @@
 .param sg13g2_hv_pmos_cjorsti        = mc_sg13g2_hv_pmos_cjorsti
 .param sg13g2_hv_pmos_cjorgat        = mc_sg13g2_hv_pmos_cjorgat
 
-.param mc_sg13g2_hv_svaricap_vfbo    ='gauss(sg13g2_hv_svaricap_vfbo_norm, 0.04,  mc_ok)'
-.param mc_sg13g2_hv_svaricap_toxo    ='gauss(sg13g2_hv_svaricap_toxo_norm, 0.0133, mc_ok)'
-.param mc_sg13g2_hv_svaricap_dlq     ='gauss(sg13g2_hv_svaricap_dlq_norm, 0.10, mc_ok)'
-.param mc_sg13g2_hv_svaricap_dwq     ='gauss(sg13g2_hv_svaricap_dwq_norm, 0.10, mc_ok)'
+.param mc_sg13g2_hv_svaricap_vfbo    ='gauss(sg13g2_hv_svaricap_vfbo_norm, 0.04,  num_sigmas)'
+.param mc_sg13g2_hv_svaricap_toxo    ='gauss(sg13g2_hv_svaricap_toxo_norm, 0.0133, num_sigmas)'
+.param mc_sg13g2_hv_svaricap_dlq     ='gauss(sg13g2_hv_svaricap_dlq_norm, 0.10, num_sigmas)'
+.param mc_sg13g2_hv_svaricap_dwq     ='gauss(sg13g2_hv_svaricap_dwq_norm, 0.10, num_sigmas)'
 
 .param sg13g2_hv_svaricap_vfbo       = mc_sg13g2_hv_svaricap_vfbo
 .param sg13g2_hv_svaricap_toxo       = mc_sg13g2_hv_svaricap_toxo

--- a/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moslv_stat.lib
+++ b/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moslv_stat.lib
@@ -18,26 +18,26 @@
 *
 * NOTE:
 * values are one-sigma deviations (1/3 of min-max)
-.param mc_ok=1
+.param num_sigmas=1
 
 * ngspice statistical parameters
-.param mc_sg13g2_lv_nmos_vfbo     ='gauss(sg13g2_lv_nmos_vfbo_norm ,    0.0050, mc_ok)'
-.param mc_sg13g2_lv_nmos_ctl      ='gauss(sg13g2_lv_nmos_ctl_norm,      0.1562, mc_ok)'
-.param mc_sg13g2_lv_nmos_rsw1     ='gauss(sg13g2_lv_nmos_rsw1_norm,     0.0407, mc_ok)'
-.param mc_sg13g2_lv_nmos_muew     ='gauss(sg13g2_lv_nmos_muew_norm,     0.0320, mc_ok)'
-.param mc_sg13g2_lv_nmos_dphibo   ='gauss(sg13g2_lv_nmos_dphibo_norm,   0.0656, mc_ok)'
-.param mc_sg13g2_lv_nmos_dphibl   ='gauss(sg13g2_lv_nmos_dphibl_norm,   0.1135, mc_ok)'
-.param mc_sg13g2_lv_nmos_dphibw   ='gauss(sg13g2_lv_nmos_dphibw_norm,   0.1197, mc_ok)'
-.param mc_sg13g2_lv_nmos_dphiblw  ='gauss(sg13g2_lv_nmos_dphiblw_norm,  0.0135, mc_ok)'
-.param mc_sg13g2_lv_nmos_themuo   ='gauss(sg13g2_lv_nmos_themuo_norm,   0.0026, mc_ok)'
-.param mc_sg13g2_lv_nmos_thesatl  ='gauss(sg13g2_lv_nmos_thesatl_norm,  0.0908, mc_ok)'
-.param mc_sg13g2_lv_nmos_thesatw  ='gauss(sg13g2_lv_nmos_thesatw_norm,  0.0272, mc_ok)'
-.param mc_sg13g2_lv_nmos_thesatlw ='gauss(sg13g2_lv_nmos_thesatlw_norm, 0.1503, mc_ok)'
-.param mc_sg13g2_lv_nmos_toxo     ='gauss(sg13g2_lv_nmos_toxo_norm,     0.0133, mc_ok)'
-.param mc_sg13g2_lv_nmos_toxovo   ='gauss(sg13g2_lv_nmos_toxovo_norm,   0.0133, mc_ok)'
-.param mc_sg13g2_lv_nmos_cjorbot  ='gauss(sg13g2_lv_nmos_cjorbot_norm,  0.0267, mc_ok)'
-.param mc_sg13g2_lv_nmos_cjorsti  ='gauss(sg13g2_lv_nmos_cjorsti_norm,  0.0267, mc_ok)'
-.param mc_sg13g2_lv_nmos_cjorgat  ='gauss(sg13g2_lv_nmos_cjorgat_norm,  0.0267, mc_ok)'
+.param mc_sg13g2_lv_nmos_vfbo     ='gauss(sg13g2_lv_nmos_vfbo_norm ,    0.0050, num_sigmas)'
+.param mc_sg13g2_lv_nmos_ctl      ='gauss(sg13g2_lv_nmos_ctl_norm,      0.1562, num_sigmas)'
+.param mc_sg13g2_lv_nmos_rsw1     ='gauss(sg13g2_lv_nmos_rsw1_norm,     0.0407, num_sigmas)'
+.param mc_sg13g2_lv_nmos_muew     ='gauss(sg13g2_lv_nmos_muew_norm,     0.0320, num_sigmas)'
+.param mc_sg13g2_lv_nmos_dphibo   ='gauss(sg13g2_lv_nmos_dphibo_norm,   0.0656, num_sigmas)'
+.param mc_sg13g2_lv_nmos_dphibl   ='gauss(sg13g2_lv_nmos_dphibl_norm,   0.1135, num_sigmas)'
+.param mc_sg13g2_lv_nmos_dphibw   ='gauss(sg13g2_lv_nmos_dphibw_norm,   0.1197, num_sigmas)'
+.param mc_sg13g2_lv_nmos_dphiblw  ='gauss(sg13g2_lv_nmos_dphiblw_norm,  0.0135, num_sigmas)'
+.param mc_sg13g2_lv_nmos_themuo   ='gauss(sg13g2_lv_nmos_themuo_norm,   0.0026, num_sigmas)'
+.param mc_sg13g2_lv_nmos_thesatl  ='gauss(sg13g2_lv_nmos_thesatl_norm,  0.0908, num_sigmas)'
+.param mc_sg13g2_lv_nmos_thesatw  ='gauss(sg13g2_lv_nmos_thesatw_norm,  0.0272, num_sigmas)'
+.param mc_sg13g2_lv_nmos_thesatlw ='gauss(sg13g2_lv_nmos_thesatlw_norm, 0.1503, num_sigmas)'
+.param mc_sg13g2_lv_nmos_toxo     ='gauss(sg13g2_lv_nmos_toxo_norm,     0.0133, num_sigmas)'
+.param mc_sg13g2_lv_nmos_toxovo   ='gauss(sg13g2_lv_nmos_toxovo_norm,   0.0133, num_sigmas)'
+.param mc_sg13g2_lv_nmos_cjorbot  ='gauss(sg13g2_lv_nmos_cjorbot_norm,  0.0267, num_sigmas)'
+.param mc_sg13g2_lv_nmos_cjorsti  ='gauss(sg13g2_lv_nmos_cjorsti_norm,  0.0267, num_sigmas)'
+.param mc_sg13g2_lv_nmos_cjorgat  ='gauss(sg13g2_lv_nmos_cjorgat_norm,  0.0267, num_sigmas)'
 
 .param sg13g2_lv_nmos_vfbo        = mc_sg13g2_lv_nmos_vfbo
 .param sg13g2_lv_nmos_ctl         = mc_sg13g2_lv_nmos_ctl
@@ -57,23 +57,23 @@
 .param sg13g2_lv_nmos_cjorsti     = mc_sg13g2_lv_nmos_cjorsti
 .param sg13g2_lv_nmos_cjorgat     = mc_sg13g2_lv_nmos_cjorgat
 
-.param mc_sg13g2_lv_pmos_vfbo     ='gauss(sg13g2_lv_pmos_vfbo_norm,     0.005,  mc_ok)'
-.param mc_sg13g2_lv_pmos_ctl      ='gauss(sg13g2_lv_pmos_ctl_norm,      0.1880, mc_ok)'
-.param mc_sg13g2_lv_pmos_rsw1     ='gauss(sg13g2_lv_pmos_rsw1_norm,     0.0727, mc_ok)'
-.param mc_sg13g2_lv_pmos_muew     ='gauss(sg13g2_lv_pmos_muew_norm,     0.0235  mc_ok)'
-.param mc_sg13g2_lv_pmos_dphibo   ='gauss(sg13g2_lv_pmos_dphibo_norm,   0.1078, mc_ok)'
-.param mc_sg13g2_lv_pmos_dphibl   ='gauss(sg13g2_lv_pmos_dphibl_norm,   0.1412, mc_ok)'
-.param mc_sg13g2_lv_pmos_dphibw   ='gauss(sg13g2_lv_pmos_dphibw_norm,   1.4858, mc_ok)'
-.param mc_sg13g2_lv_pmos_dphiblw  ='gauss(sg13g2_lv_pmos_dphiblw_norm,  1.0e-9, mc_ok)'
-.param mc_sg13g2_lv_pmos_themuo   ='gauss(sg13g2_lv_pmos_themuo_norm,   0.0247, mc_ok)'
-.param mc_sg13g2_lv_pmos_thesatl  ='gauss(sg13g2_lv_pmos_thesatl_norm,  0.1718, mc_ok)'
-.param mc_sg13g2_lv_pmos_thesatw  ='gauss(sg13g2_lv_pmos_thesatw_norm,  0.0427, mc_ok)'
-.param mc_sg13g2_lv_pmos_thesatlw ='gauss(sg13g2_lv_pmos_thesatlw_norm, 0.1667, mc_ok)'
-.param mc_sg13g2_lv_pmos_toxo     ='gauss(sg13g2_lv_pmos_toxo_norm,     0.0133, mc_ok)'
-.param mc_sg13g2_lv_pmos_toxovo   ='gauss(sg13g2_lv_pmos_toxovo_norm,   0.0133, mc_ok)'
-.param mc_sg13g2_lv_pmos_cjorbot  ='gauss(sg13g2_lv_pmos_cjorbot_norm,  0.0267, mc_ok)'
-.param mc_sg13g2_lv_pmos_cjorsti  ='gauss(sg13g2_lv_pmos_cjorsti_norm,  0.0267, mc_ok)'
-.param mc_sg13g2_lv_pmos_cjorgat  ='gauss(sg13g2_lv_pmos_cjorgat_norm,  0.0267, mc_ok)'
+.param mc_sg13g2_lv_pmos_vfbo     ='gauss(sg13g2_lv_pmos_vfbo_norm,     0.005,  num_sigmas)'
+.param mc_sg13g2_lv_pmos_ctl      ='gauss(sg13g2_lv_pmos_ctl_norm,      0.1880, num_sigmas)'
+.param mc_sg13g2_lv_pmos_rsw1     ='gauss(sg13g2_lv_pmos_rsw1_norm,     0.0727, num_sigmas)'
+.param mc_sg13g2_lv_pmos_muew     ='gauss(sg13g2_lv_pmos_muew_norm,     0.0235  num_sigmas)'
+.param mc_sg13g2_lv_pmos_dphibo   ='gauss(sg13g2_lv_pmos_dphibo_norm,   0.1078, num_sigmas)'
+.param mc_sg13g2_lv_pmos_dphibl   ='gauss(sg13g2_lv_pmos_dphibl_norm,   0.1412, num_sigmas)'
+.param mc_sg13g2_lv_pmos_dphibw   ='gauss(sg13g2_lv_pmos_dphibw_norm,   1.4858, num_sigmas)'
+.param mc_sg13g2_lv_pmos_dphiblw  ='gauss(sg13g2_lv_pmos_dphiblw_norm,  1.0e-9, num_sigmas)'
+.param mc_sg13g2_lv_pmos_themuo   ='gauss(sg13g2_lv_pmos_themuo_norm,   0.0247, num_sigmas)'
+.param mc_sg13g2_lv_pmos_thesatl  ='gauss(sg13g2_lv_pmos_thesatl_norm,  0.1718, num_sigmas)'
+.param mc_sg13g2_lv_pmos_thesatw  ='gauss(sg13g2_lv_pmos_thesatw_norm,  0.0427, num_sigmas)'
+.param mc_sg13g2_lv_pmos_thesatlw ='gauss(sg13g2_lv_pmos_thesatlw_norm, 0.1667, num_sigmas)'
+.param mc_sg13g2_lv_pmos_toxo     ='gauss(sg13g2_lv_pmos_toxo_norm,     0.0133, num_sigmas)'
+.param mc_sg13g2_lv_pmos_toxovo   ='gauss(sg13g2_lv_pmos_toxovo_norm,   0.0133, num_sigmas)'
+.param mc_sg13g2_lv_pmos_cjorbot  ='gauss(sg13g2_lv_pmos_cjorbot_norm,  0.0267, num_sigmas)'
+.param mc_sg13g2_lv_pmos_cjorsti  ='gauss(sg13g2_lv_pmos_cjorsti_norm,  0.0267, num_sigmas)'
+.param mc_sg13g2_lv_pmos_cjorgat  ='gauss(sg13g2_lv_pmos_cjorgat_norm,  0.0267, num_sigmas)'
 
 .param sg13g2_lv_pmos_vfbo        = mc_sg13g2_lv_pmos_vfbo
 .param sg13g2_lv_pmos_ctl         = mc_sg13g2_lv_pmos_ctl


### PR DESCRIPTION
Statistical variations got now more meaningful parameter name num_sigmas instead mc_ok. All lib's are unified, also the entries for resistors_stat.lib.
Selection of statistical simulation model have to done by .lib entry with prepended `_stat` in the name, e.g. `.lib sg13g2_moslv_stat`.
There is no need for setting mc_ok=1 on top level circuit.