### PR TITLE
Self-heating of HBT devices enabled by default

### DIFF
--- a/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_hbt_mod.lib
+++ b/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_hbt_mod.lib
@@ -42,7 +42,7 @@
 .param Nx=1 dtemp=0
 +Ny=1 le=0.96e-6 we=0.12e-6
 +El=le*1e6
-+selft=0
++selft=1
 +sw_nqs=0
 
 Qnpn13G2 c b e s1 t npn13G2_NX_vbic dtemp=dtemp m=1
@@ -140,6 +140,7 @@ Qnpn13G2 c b e s1 t npn13G2_NX_vbic dtemp=dtemp m=1
 
 Rsub s1 bn R = '300+100*Nx'
 Csub s1 bn C = '2.30E-14-(1.50E-15*Nx)'
+Rt t 0 R = 1e9
 .ends npn13G2
 
 * 5 terminal version of npn13G2 device
@@ -246,8 +247,8 @@ Qnpn13G2 c b e s1 t npn13G2_NX_vbic dtemp=dtemp m=1
 + bfn = 1.00
 
 Rsub s1 bn R = '300+100*Nx'
-Rt t 0 R = 1e9
 Csub s1 bn C = '2.30E-14-(1.50E-15*Nx)'
+Rt t 0 R = 1e9
 .ends npn13G2_5t
 
 *--------------------npn13g2l----------------------------------------------------
@@ -277,7 +278,7 @@ Csub s1 bn C = '2.30E-14-(1.50E-15*Nx)'
 .param Nx=1 le=2.50e-6 dtemp=0
 +Ny=1 we=0.12e-6
 +El=le*1e6
-+selft=0
++selft=1
 +sw_nqs=0
 
 Qnpn13G2l c b e s1 t npn13G2l_NX_vbic dtemp=dtemp m=1
@@ -375,6 +376,7 @@ Qnpn13G2l c b e s1 t npn13G2l_NX_vbic dtemp=dtemp m=1
 
 Rsub s1 bn R = '(300+(400*Nx))*(El/2.5)**0.5'
 Csub s1 bn C = '(1.70E-14-(2.00E-15*Nx))*(El/2.5)**0'
+Rt t 0 R = 1e9
 .ends npn13G2l
 
 * a five terminal version of npn13G2l device
@@ -511,7 +513,7 @@ Rt t 0 R = 1e9
 .param Nx=1 le=2.50e-6 dtemp=0
 +Ny=1 we=0.12e-6
 +El=le*1e6
-+selft=0
++selft=1
 +sw_nqs=0
 
 Qnpn13G2v c b e s1 t npn13G2v_NX_vbic dtemp=dtemp m=1
@@ -609,6 +611,7 @@ Qnpn13G2v c b e s1 t npn13G2v_NX_vbic dtemp=dtemp m=1
 
 Rsub s1 bn R = '(300+(400*Nx))*(El/2.5)**0.85'
 Csub s1 bn C = '(1.70E-14-(2.00E-15*Nx))*(El/2.5)**0'
+Rt t 0 R = 1e9
 .ends npn13G2v
 
 * a five terminal npn13G2v device model 

--- a/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_hbt_mod_mismatch.lib
+++ b/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_hbt_mod_mismatch.lib
@@ -42,7 +42,7 @@
 .param Nx=1 dtemp=0
 +Ny=1 le=0.96e-6 we=0.12e-6
 +El=le*1e6
-+selft=0
++selft=1
 +sw_nqs=0
 +mm_ok=1
 
@@ -142,6 +142,7 @@ Qnpn13G2 c b e s1 t npn13G2_NX_vbic dtemp=dtemp m=1 area=qarea
 
 Rsub s1 bn R = '300+100*Nx'
 Csub s1 bn C = '2.30E-14-(1.50E-15*Nx)'
+Rt t 0 R = 1e9
 .ends npn13G2
 
 * 5 terminal version of npn13G2 device
@@ -250,8 +251,8 @@ Qnpn13G2 c b e s1 t npn13G2_NX_vbic dtemp=dtemp m=1 area=qarea
 + bfn = 1.00
 
 Rsub s1 bn R = '300+100*Nx'
-Rt t 0 R = 1e9
 Csub s1 bn C = '2.30E-14-(1.50E-15*Nx)'
+Rt t 0 R = 1e9
 .ends npn13G2_5t
 
 *--------------------npn13g2l----------------------------------------------------
@@ -281,7 +282,7 @@ Csub s1 bn C = '2.30E-14-(1.50E-15*Nx)'
 .param Nx=1 le=2.50e-6 dtemp=0
 +Ny=1 we=0.12e-6
 +El=le*1e6
-+selft=0
++selft=1
 +sw_nqs=0
 +mm_ok=1
 
@@ -381,6 +382,7 @@ Qnpn13G2l c b e s1 t npn13G2l_NX_vbic dtemp=dtemp m=1 area=qarea
 
 Rsub s1 bn R = '(300+(400*Nx))*(El/2.5)**0.5'
 Csub s1 bn C = '(1.70E-14-(2.00E-15*Nx))*(El/2.5)**0'
+Rt t 0 R = 1e9
 .ends npn13G2l
 
 * a five terminal version of npn13G2l device
@@ -513,12 +515,13 @@ Rt t 0 R = 1e9
 * model card checked with SPECTRE 10.x and ADS2009U1
 * ________________________________________________________________________
 
+
 * a four terminal npn13G2v device model 
 .subckt npn13G2v c b e bn
 .param Nx=1 le=2.50e-6 dtemp=0
 +Ny=1 we=0.12e-6
 +El=le*1e6
-+selft=0
++selft=1
 +sw_nqs=0
 +mm_ok=1
 
@@ -618,6 +621,7 @@ Qnpn13G2v c b e s1 t npn13G2v_NX_vbic dtemp=dtemp m=1 area=qarea
 
 Rsub s1 bn R = '(300+(400*Nx))*(El/2.5)**0.85'
 Csub s1 bn C = '(1.70E-14-(2.00E-15*Nx))*(El/2.5)**0'
+Rt t 0 R = 1e9
 .ends npn13G2v
 
 * a five terminal npn13G2v device model 


### PR DESCRIPTION
The self-heating model was enabled in the HBT model files to increase the accuracy of the HBT DC operating points.
As shown in the plot below, the output characteristic now exactly matches the measurement results shown in 
ihp-sg13g2/libs.doc/meas/HBT/doc/html_npn13g2_VBIC/reszoom_foutput_vb.htm

Fixes a part of #480

- [x] selft switched to 1 in sg13g2_hbt_mod.lib and sg13g2_hbt_mod_mismatch.lib
- [x] Ic over Vce with constant Vbe matches measurements in ihp-sg13g2/libs.doc/meas/HBT/doc/html_npn13g2_VBIC/reszoom_foutput_vb.htm
- [x] Thermal 1GOhm resistor Rt added to sg13g2_hbt_mod.lib and sg13g2_hbt_mod_mismatch.lib

![image](https://github.com/user-attachments/assets/5b628ce5-3c3d-4337-ba23-d81d4b4f277b)

