### PR TITLE
Calculation of OP param rin in HBT annotation updated

### DIFF
--- a/ihp-sg13g2/libs.tech/xschem/xschemrc
+++ b/ihp-sg13g2/libs.tech/xschem/xschemrc
@@ -827,7 +827,7 @@ proc display_bip_params {instname} {
     set gx [xschem raw value $devpath\[gx\] -1]
     set gmu [xschem raw value $devpath\[gmu\] -1]
     set gpi [xschem raw value $devpath\[gpi\] -1]
-    if {[catch { expr 1/($gx + $gmu + $gpi)} rin]} {
+    if {[catch { expr 1/$gx + 1/($gmu + $gpi)} rin]} {
       set rin {}
     }
     append txt "rin  = [to_eng ${rin}]\n"


### PR DESCRIPTION
- [x] Calculation of approximated rin used in HBT OP annotation changed from rin = 1/($gx + $gmu + $gpi) to rin = 1/$gx + 1/($gmu + $gpi)
