### PR TITLE
Changed ptap_holes calculation

### DIFF
--- a/ihp-sg13g2/libs.tech/klayout/tech/lvs/rule_decks/general_derivations.lvs
+++ b/ihp-sg13g2/libs.tech/klayout/tech/lvs/rule_decks/general_derivations.lvs
@@ -88,7 +88,7 @@ ptap1_mk = substrate_drw.and(pwell).interacting(ptap1_lbl)
 # n & p taps (short connections)
 ntap = nactiv.and(nwell_drw).not(ntap1_mk).not(recog_diode).not(gatpoly)
 ptap = pactiv.and(pwell).not(ptap1_mk).not(recog_diode).not(gatpoly)
-ptap_holes = ptap.holes
+ptap_holes = ptap.not(edgeseal_drw).holes
 ntap_holes = ntap.holes
 
 # S/D (salicide)


### PR DESCRIPTION
The holes function returns the inside of donut shapes. The seal ring is a ptap that surrounds the entire chip. When the sealring is included, the entire chip becomes `ptap_holes`. This change ignores the sealring ptap when calculating ptap_holes. For designs without the sealring, there is no change. 
Warning: Use of the holes function in LVS can cause unexpected side-effects when macros have enclosing tap rings.

Fixes #498

- [?] Tests pass <- This change is part of a larger set of changes that I'm working on for the TO_Apr2025 shuttle tests. The larger set of changes is still being tested, but this specific change has been verified to solve the issue above.
- [X] Appropriate changes to README are included in PR <- No changes to README
