### PR TITLE
Enable Safe Operating Area voltage warning messages

### DIFF
--- a/ihp-sg13g2/libs.tech/ngspice/.spiceinit
+++ b/ihp-sg13g2/libs.tech/ngspice/.spiceinit
@@ -15,8 +15,8 @@ setcs sourcepath = (  $sourcepath $PDK_ROOT/$PDK/libs.tech/ngspice/models $PDK_R
 
 *option node
 *option opts
-*option warn=1
-*option maxwarns=10
+option warn=1
+option maxwarns=10
 *option savecurrents
 
 *set ngbehavior=hsa


### PR DESCRIPTION
Safe Operating Area voltage warning messages are turned off by default (**and turned on by default in this PR**). 
However, it can be important to give the designer the hint that some transistors may be destroyed or at least out of Safe Operating Area as defined in https://github.com/IHP-GmbH/IHP-Open-PDK/blob/main/ihp-sg13g2/libs.doc/doc/SG13G2_os_process_spec.pdf . 
If the designer is aware of the voltage exceed messages, he can still switch them off manually. This works fine for the HBT transistors as the max. voltages are already defined in the model files.

The SOA voltages are not defined in the MOS models. However, it seems like it's not supported in the current implementation of the PSP models in ngspice anyway, but can be added later if it's supported by ngspice