### PR TITLE
Signed-off-by: KrzysztofHerman <herman@ihp-microelectronics.com>

### DIFF
--- a/ihp-sg13g2/libs.tech/xyce/models/resistors_mod.lib
+++ b/ihp-sg13g2/libs.tech/xyce/models/resistors_mod.lib
@@ -1,13 +1,13 @@
 *#######################################################################
 *
 * Copyright 2023 IHP PDK Authors
-* 
+*
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
-* 
+*
 *    https://www.apache.org/licenses/LICENSE-2.0
-* 
+*
 * Unless required by applicable law or agreed to in writing, software
 *distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,8 +15,6 @@
 * limitations under the License.
 *
 *#######################################################################
-       
-.include resistors_parm.lib 
 
 **ptap1 (TIE SUB)
 * In order to have consistency between the netlisted device format 
@@ -37,45 +35,192 @@ R1 1 2 R=R
 .ends ntap1
 
 * Parasitic R/C models
-* aluminum: prozess tol. res_rpara 
+* aluminum: prozess tol. res_rpara
 * value is taken from extraction routine
-.subckt Rparasitic 1 2 
+.subckt Rparasitic 1 2
 .param R=0 w=0 l=0 TC1=0.00353 TC2=0
-R1 1 2 R=r*res_rpara TC1=TC1 TC2=TC2 
+R1 1 2 R=r*res_rpara TC1=TC1 TC2=TC2
 .ends Rparasitic
 
-.subckt rsil 1 3
-.param w=0.5e-6 l=0.5e-6 b=0 m=1
+.subckt rsil 1 2
+.param w=0.5e-6 l=0.5e-6 mm_ok=1 b=0 m=1 trise=0 sw_et=0
++postsim=0
 +kappa=1.85
 +ps=0.18e-6
-+leff=(b+1)*l+(2/kappa*weff+ps)*b
-+res_rzspec=2*rzspec/w
 +weff=w+0.01e-6
++leff=(b+1)*l+(2/kappa*weff+ps)*b
 +rzspec=4.5e-6
-R1 1 2 res_rsil L=leff W=weff m=m
-R2 2 3 R=res_rzspec TC1=3100e-6 TC2=0.3e-6 m=m
++lhead=0.86e-6
++cax=90e-18
++cpx=25e-18
++ax=175e-18*(1-1/(1.5*leff*1e6+1))/cax
++px=115e-18/cpx
++a0=0.5*(leff+lhead)*w-(postsim>0)*w*ax*1e-6
++a=(a0>0)*a0
++p0=leff+lhead+w-(postsim>0)*px*1e-6
++p=(p0>0)*p0
++rshspec=7
++rqrc=4.5e-6
++rz=rzspec/w-(postsim>0)*rqrc/w
+
+Yr3_cmc R1 1 0 2 dt rmod_rsil L=leff W=weff mult=m
++a1=a a2=a
++p1=p p2=p
++c1=1 c2=1
++trise=trise
++sw_et=sw_et
++sw_mman=1
++nsmm_rsh='gauss(1, 1, (mm_ok != 1 ? 0 : 1))' ; number of standard deviations for rsh
++nsmm_w='gauss(1, 1, (mm_ok != 1 ? 0 : 1))'   ; number of standard deviations for w
++nsmm_l='gauss(1, 1, (mm_ok != 1 ? 0 : 1))'   ; number of standard deviations for l
+
+.model rmod_rsil r3_cmc
++rsh=rsh_rsil
++ecrit=1000
++dfinf=1e-4
++dp=1000
++xw=0.01
++rc=rz
++ca=cax
++cp=cpx
++tc1=3100e-6
++tc2=0.3e-6
++tc1rc=3100e-6
++tc2rc=0.3e-6
++gth0=1e-12
++gtha=6e-6
++gthp=2e-6
++gthc=1e-12
++cth0=0
++cthp=0
++ctha=594e-15
++cthc=0
++kfn=2.812e-12
++afn=1.607
++bfn=1.267
++smm_rsh=1.2 ; relative standard deviation for rsh [%]
++smm_w=0.01  ; absolute standard deviation for w [um]
++smm_l=0.01  ; absolute standard deviation for l [um]
+
 .ends rsil
 
-.subckt rhigh 1 3 
-.param w=0.5e-6 l=0.96e-6 b=0 m=1
+.subckt rhigh 1 2
+.param w=0.5e-6 l=0.96e-6 mm_ok=1 b=0 trise=0 m=1 sw_et=0
++postsim=0
 +kappa=1.85
 +ps=0.18e-6
-+leff=(b+1)*l+(2/kappa*weff+ps)*b
-+res_rzspec=2*rzspec/w
 +weff=w-0.04e-6
++leff=(b+1)*l+(2/kappa*weff+ps)*b
++lhead=0.86e-6
 +rzspec=80e-6
-R1 1 2 res_rhigh L=leff W=weff m=m
-R2 2 3 R=res_rzspec TC1=-2300e-6 TC2=2.1e-6 m=m
++cax=90e-18
++cpx=25e-18
++ax=175e-18*(1-1/(1.5*leff*1e6+1))/cax
++px=115e-18/cpx
++a0=0.5*(leff+lhead)*w-(postsim>0)*w*ax*1e-6
++a=(a0>0)*a0
++p0=leff+lhead+w-(postsim>0)*px*1e-6
++p=(p0>0)*p0
++rshspec=1360
++rqrc=4.5e-6
++rz=rzspec/w-(postsim>0)*rqrc/w
+
+Yr3_cmc R1 1 0 2 dt rmod_rhigh L=leff W=weff mult=m
++a1=a a2=a
++p1=p p2=p
++c1=1 c2=1
++trise=trise
++sw_et=sw_et
++sw_mman=1
++nsmm_rsh='gauss(1, 1, (mm_ok != 1 ? 0 : 1))' ; number of standard deviations for rsh
++nsmm_w='gauss(1, 1, (mm_ok != 1 ? 0 : 1))'   ; number of standard deviations for w
++nsmm_l='gauss(1, 1, (mm_ok != 1 ? 0 : 1))'   ; number of standard deviations for l
+
+.model rmod_rhigh r3_cmc
++rsh=rsh_rhigh
++ecrit=1000
++dfinf=1e-4
++dp=1000
++xw=-0.04
++rc=rz
++ca=cax
++cp=cpx
++tc1=-2300e-6
++tc2=2.1e-6
++tc1rc=-2300e-6
++tc2rc=2.1e-6
++gth0=1e-12
++gtha=6e-6
++gthp=2e-6
++gthc=1e-12
++cth0=0
++cthp=0
++ctha=594e-15
++cthc=0
++kfn=5.205e-10
++afn=1.935
++bfn=0.9086
++smm_rsh=5  ; relative standard deviation for rsh [%]
++smm_w=0.01 ; absolute standard deviation for w [um]
++smm_l=0.01 ; absolute standard deviation for l [um]
+
 .ends rhigh
 
-.subckt rppd 1 3 
-.param w=0.5e-6 l=0.5e-6 b=0 m=1
+.subckt rppd 1 2
+.param w=0.5e-6 l=0.5e-6 mm_ok=1 b=0 ps=0.18e-6 trise=0 m=1 sw_et=0
++postsim=0
 +kappa=1.85
-+ps=0.18e-6
-+leff=(b+1)*l+(2/kappa*weff+ps)*b
-+res_rzspec=2*rzspec/w
 +weff=w+0.006e-6
++leff=(b+1)*l+(2/kappa*weff+ps)*b
++lhead=0.86e-6
 +rzspec=35e-6
-R1 1 2 res_rppd L=leff W=weff m=m
-R2 2 3 R=res_rzspec TC1=-950e-6 m=m
++cax=90e-18
++cpx=25e-18
++ax=175e-18*(1-1/(1.5*leff*1e6+1))/cax
++px=115e-18/cpx
++a0=0.5*(leff+lhead)*w-(postsim>0)*w*ax*1e-6
++a=(a0>0)*a0
++p0=leff+lhead+w-(postsim>0)*px*1e-6
++p=(p0>0)*p0
++rqrc=4.5e-6
++rz=rzspec/w-(postsim>0)*rqrc/w
+
+Yr3_cmc R1 1 0 2 dt rmod_rppd L=leff W=weff mult=m
++a1=a a2=a
++p1=p p2=p
++c1=1 c2=1
++trise=trise
++sw_et=sw_et
++sw_mman=1
++nsmm_rsh='gauss(1, 1, (mm_ok != 1 ? 0 : 1))' ; number of standard deviations for rsh
++nsmm_w='gauss(1, 1, (mm_ok != 1 ? 0 : 1))'   ; number of standard deviations for w
++nsmm_l='gauss(1, 1, (mm_ok != 1 ? 0 : 1))'   ; number of standard deviations for l
+
+.model rmod_rppd r3_cmc
++rsh=rsh_rppd
++ecrit=1000
++dfinf=1e-4
++dp=1000
++xw=0.006
++rc=rz
++ca=cax
++cp=cpx
++tc1=170e-6
++tc2=0.4e-6
++tc1rc=-950e-6
++gth0=1e-12
++gtha=6e-6
++gthp=2e-6
++gthc=1e-12
++cth0=0
++cthp=0
++ctha=594e-15
++cthc=0
++kfn=4.601e-11
++afn=1.886
++bfn=0.9963
++smm_rsh=1.5 ; relative standard deviation for rsh [%]
++smm_w=0.01  ; absolute standard deviation for w [um]
++smm_l=0.01  ; absolute standard deviation for l [um]
+
 .ends rppd


### PR DESCRIPTION
This PR adds an experimental support for CMC_R3 resistors to be used by Xyce.The 

The basic netlist for testing can be found below

```
** cemment

.lib your_location/IHP-Open-PDK/ihp-sg13g2/libs.tech/xyce/models/cornerRES.lib res_typ

XR2 GND Vr1 rsil w=1.0e-6 l=10.5e-6 m=1 b=0
XR3 GND Vr2 rppd w=1.0e-6 l=10.5e-6 m=1 b=0
XR1 GND Vr3 rhigh w=1.0e-6 l=10.5e-6 m=1 b=0
I1 GND Vr1 dc {Ip} ac 0
I2 GND Vr2 dc {Ip} ac 0
I3 GND Vr3 dc {Ip} ac 0

.param Ip=50u
.preprocess replaceground true
.option temp=27
.dc Ip list 1u 10u 100u
.print dc format=csv file=basic_res_xyce.csv V(Vr1) V(Vr2) V(Vr3)
.GLOBAL GND
.end
```
To use it one have to compile the R3_CMC plugin using an `ADMS` script, namely 
`$PDK_ROOT/$PDK/libs.tech/verilog-a/adms-compile-va.sh`

Once done the aforementioned netlist can be run using the following commadn:

```
 Xyce -plugin $PDK_ROOT/$PDK/libs.tech/xyce/plugins/Xyce_Plugin_r3_cmc.so netlist.spice 
```
 
