### PR TITLE
HBT selft enabled also for XYCE simulator

### DIFF
--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests_xyce/dc_hbt_13g2.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests_xyce/dc_hbt_13g2.sch
@@ -1,5 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
-}
+v {xschem version=3.4.7 file_version=1.2}
 G {}
 K {}
 V {}
@@ -14,7 +13,7 @@ divy=5
 subdivy=1
 unity=1
 x1=0
-x2=1.2
+x2=1.5
 divx=5
 subdivx=1
 
@@ -27,6 +26,8 @@ node=i(Vc)
 y1=-5.5e-05
 rainbow=0}
 T {Nx - number of emitters} 660 0 0 0 0.2 0.2 {}
+T {Ctrl-Click to execute launcher} -680 50 0 0 0.3 0.3 {layer=11}
+T {.save file can be created with IHP->"Create FET and BIP .save file"} -680 200 0 0 0.3 0.3 {layer=11}
 N 570 -50 570 -30 {
 lab=GND}
 N 570 -120 570 -110 {
@@ -55,11 +56,7 @@ C {devices/vsource.sym} 830 -120 0 0 {name=Vce value=0.0}
 C {devices/gnd.sym} 830 -30 0 0 {name=l3 lab=GND}
 C {devices/gnd.sym} 750 -30 0 0 {name=l4 lab=GND}
 C {devices/title.sym} -130 260 0 0 {name=l5 author="Copyright 2023 IHP PDK Authors"}
-C {devices/launcher.sym} -280 170 0 0 {name=h5
-descr="load waves" 
-tclcommand="xschem raw_read $netlist_dir/dc_hbt_13G2.raw dc"
-}
-C {devices/isource.sym} 570 -80 2 0 {name=I0 value=0.0}
+C {devices/isource.sym} 570 -80 2 0 {name=I0 value=1u}
 C {devices/ammeter.sym} 760 -190 1 0 {name=Vc}
 C {sg13g2_pr/npn13G2.sym} 680 -120 0 0 {name=Q1
 model=npn13G2
@@ -73,11 +70,11 @@ value="
 .preprocess replaceground true
 .option temp=27
 .step I0 0 5u 0.1u
-.dc Vce 0 1.2 0.01
-.print dc format=raw file=dc_hbt_13G2.raw I(Vc)
+.dc Vce 0 1.5 0.01
+.print dc format=raw file=dc_hbt_13g2.raw I(Vc)
 "
 "}
-C {launcher.sym} 250 -370 0 0 {name=h1
+C {launcher.sym} -620 120 0 0 {name=h1
 descr=SimulateXyce
 tclcommand="
 # Setup the default simulation commands if not already set up
@@ -108,7 +105,34 @@ only_toplevel=false
 value="
 .lib cornerHBT.lib hbt_typ
 "}
-C {launcher.sym} -280 -360 0 0 {name=h2
+C {simulator_commands_shown.sym} -360 -580 0 0 {name=Simulator1
+simulator=ngspice
+only_toplevel=false 
+value="
+.options savecurrents
+.include dc_hbt_13g2.save
+.param temp=27
+.control
+save all 
+op
+write dc_hbt_13g2.raw
+set appendwrite
+dc Vce 0 1.5 0.01 I0 0 5u 0.1u
+write dc_hbt_13g2.raw
+.endc
+"}
+C {devices/launcher.sym} -620 150 0 0 {name=h3
+descr="OP annotate" 
+tclcommand="xschem annotate_op"
+}
+C {devices/launcher.sym} -620 180 0 0 {name=h4
+descr="Load waves" 
+tclcommand="
+xschem raw_read $netlist_dir/[file rootname [file tail [xschem get current_name]]].raw dc
+xschem setprop rect 2 0 fullxzoom
+"
+}
+C {launcher.sym} -620 90 0 0 {name=h6
 descr=SimulateNGSPICE
 tclcommand="
 # Setup the default simulation commands if not already set up
@@ -124,18 +148,12 @@ set sim(spice,1,cmd) \{ngspice  \\"$N\\" -a\}
 # change the simulator to be used (Xyce)
 set sim(spice,default) 0
 
+# Create FET and BIP .save file
+mkdir -p $netlist_dir
+write_data [save_params] $netlist_dir/[file rootname [file tail [xschem get current_name]]].save
+
 # run netlist and simulation
 xschem netlist
 simulate
 "}
-C {simulator_commands_shown.sym} -360 -580 0 0 {name=Simulator1
-simulator=ngspice
-only_toplevel=false 
-value="
-.param temp=27
-.control
-save all 
-dc Vce 0 1.2 0.01 I0 0 5u 0.1u
-write dc_hbt_13G2.raw
-.endc
-"}
+C {sg13g2_pr/annotate_bip_params.sym} 550 -300 0 0 {name=annot1 ref=Q1}

--- a/ihp-sg13g2/libs.tech/xyce/models/sg13g2_hbt_mod.lib
+++ b/ihp-sg13g2/libs.tech/xyce/models/sg13g2_hbt_mod.lib
@@ -278,7 +278,7 @@ Csub s1 bn C = '2.30E-14-(1.50E-15*Nx)'
 +El=le*1e6
 +selft=1
 
-Qnpn13G2l c b e s1  npn13G2l_NX_vbic dtemp=dtemp m=1
+Qnpn13G2l c b e s1 t npn13G2l_NX_vbic dtemp=dtemp m=1
 
 .model npn13G2l_NX_vbic npn
 + level = 12
@@ -511,7 +511,7 @@ Rt t 0 R = 1e9
 +El=le*1e6
 +selft=1
 
-Qnpn13G2v c b e s1  npn13G2v_NX_vbic dtemp=dtemp m=1
+Qnpn13G2v c b e s1 t npn13G2v_NX_vbic dtemp=dtemp m=1
 
 .model npn13G2v_NX_vbic npn
 + level = 12

--- a/ihp-sg13g2/libs.tech/xyce/models/sg13g2_hbt_mod.lib
+++ b/ihp-sg13g2/libs.tech/xyce/models/sg13g2_hbt_mod.lib
@@ -42,9 +42,9 @@
 .param Nx=1 dtemp=0
 +Ny=1 le=0.96e-6 we=0.12e-6
 +El=le*1e6
-+selft=0
++selft=1
 
-Qnpn13G2 c b e s1  npn13G2_NX_vbic dtemp=dtemp m=1
+Qnpn13G2 c b e s1 t npn13G2_NX_vbic dtemp=dtemp m=1
 
 .model npn13G2_NX_vbic npn
 + level = 12
@@ -139,6 +139,7 @@ Qnpn13G2 c b e s1  npn13G2_NX_vbic dtemp=dtemp m=1
 
 Rsub s1 bn R = '300+100*Nx'
 Csub s1 bn C = '2.30E-14-(1.50E-15*Nx)'
+Rt t 0 R = 1e9
 .ends npn13G2
 
 * 5 terminal version of npn13G2 device
@@ -275,7 +276,7 @@ Csub s1 bn C = '2.30E-14-(1.50E-15*Nx)'
 .param Nx=1 le=2.50e-6 dtemp=0
 +Ny=1 we=0.12e-6
 +El=le*1e6
-+selft=0
++selft=1
 
 Qnpn13G2l c b e s1  npn13G2l_NX_vbic dtemp=dtemp m=1
 
@@ -372,6 +373,7 @@ Qnpn13G2l c b e s1  npn13G2l_NX_vbic dtemp=dtemp m=1
 
 Rsub s1 bn R = '(300+(400*Nx))*(El/2.5)**0.5'
 Csub s1 bn C = '(1.70E-14-(2.00E-15*Nx))*(El/2.5)**0'
+Rt t 0 R = 1e9
 .ends npn13G2l
 
 * a five terminal version of npn13G2l device
@@ -507,7 +509,7 @@ Rt t 0 R = 1e9
 .param Nx=1 le=2.50e-6 dtemp=0
 +Ny=1 we=0.12e-6
 +El=le*1e6
-+selft=0
++selft=1
 
 Qnpn13G2v c b e s1  npn13G2v_NX_vbic dtemp=dtemp m=1
 
@@ -604,6 +606,7 @@ Qnpn13G2v c b e s1  npn13G2v_NX_vbic dtemp=dtemp m=1
 
 Rsub s1 bn R = '(300+(400*Nx))*(El/2.5)**0.85'
 Csub s1 bn C = '(1.70E-14-(2.00E-15*Nx))*(El/2.5)**0'
+Rt t 0 R = 1e9
 .ends npn13G2v
 
 * a five terminal npn13G2v device model 


### PR DESCRIPTION
- [x] selft also enabled in XYCE model files
- [x] example file sg13g2_tests_xyce/dc_hbt_13g2.sch updated
- [x] Now ngspice simulations match xyce simulations
![image](https://github.com/user-attachments/assets/f9368409-215e-47f4-960f-8f78dcfefbb5)

