### PR TITLE
Monte-Carlo simulation verified: Example files updated, case statistical + mismatch modelling (stat_mismatch) added, Xyce MC simulation enabled

### DIFF
--- a/ihp-sg13g2/libs.tech/ngspice/models/cornerCAP.lib
+++ b/ihp-sg13g2/libs.tech/ngspice/models/cornerCAP.lib
@@ -42,6 +42,15 @@
 .include capacitors_mod.lib
 .ENDL cap_typ_stat
 
+* Typical with statistical and with mismatch modeling
+.LIB cap_typ_stat_mismatch
+.param cap_carea_norm = 1.5E-15
+.param cap_cpara_norm  = 1.0
+
+.include capacitors_stat.lib
+.include capacitors_mod_mismatch.lib
+.ENDL cap_typ_stat_mismatch
+
 * Best Case without statistical modeling
 .LIB cap_bcs
 .param cap_carea = 0.9*1.5E-15

--- a/ihp-sg13g2/libs.tech/ngspice/models/cornerHBT.lib
+++ b/ihp-sg13g2/libs.tech/ngspice/models/cornerHBT.lib
@@ -83,6 +83,29 @@
 .include sg13g2_hbt_mod.lib
 .ENDL hbt_typ_stat
 
+.LIB hbt_typ_stat_mismatch
+.param vbic_cje_norm = 1.0
+.param vbic_cjc_norm = 1.0
+.param vbic_cjcp_norm = 1.0
+.param vbic_is_norm = 1.0
+.param vbic_ibei_norm = 1.0
+.param vbic_re_norm = 1.0
+.param vbic_rcx_norm = 1.0
+.param vbic_rbx_norm = 1.0
+.param vbic_tf = 1.0
+
+.param sgp_mpa_cje_norm = 1.0
+.param sgp_mpa_cjc_norm = 1.0
+.param sgp_mpa_is_norm = 1.0
+.param sgp_mpa_bf_norm = 1.0
+.param sgp_mpa_re_norm = 1.0
+.param sgp_mpa_rb_norm = 1.0
+.param sgp_mpa_rc_norm = 1.0
+
+.include sg13g2_hbt_stat.lib
+.include sg13g2_hbt_mod_mismatch.lib
+.ENDL hbt_typ_stat_mismatch
+
 .LIB hbt_bcs
 .param vbic_cje = 0.83
 .param vbic_cjc = 0.87

--- a/ihp-sg13g2/libs.tech/ngspice/models/cornerRES.lib
+++ b/ihp-sg13g2/libs.tech/ngspice/models/cornerRES.lib
@@ -15,7 +15,7 @@
 * limitations under the License.
 *
 *#######################################################################
-* Typical
+* Typical without statistical and without mismatch modelling
 .LIB res_typ
   .param rsh_rhigh = 1360
   .param rsh_rppd  = 260.0
@@ -48,6 +48,18 @@
 .include resistors_stat.lib
 .include resistors_mod.lib
 .ENDL res_typ_stat
+
+* Typical with statistical and with mismatch modeling
+.LIB res_typ_stat_mismatch
+.param rsh_rhigh_norm= 1360
+.param rsh_rppd_norm= 260.0
+.param rsh_rsil_norm= 7.0
+.param res_area_norm= 1.0
+.param res_rpara_norm= 1.0
+
+.include resistors_stat.lib
+.include resistors_mod_mismatch.lib
+.ENDL res_typ_stat_mismatch
 
 * Best Case
 .LIB res_bcs

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/mc_hbt_13g2.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/mc_hbt_13g2.sch
@@ -1,11 +1,17 @@
-v {xschem version=3.4.5 file_version=1.2
-}
+v {xschem version=3.4.7 file_version=1.2}
 G {}
 K {}
 V {}
 S {}
 E {}
-T {Nx - number of emitters} -110 80 0 0 0.2 0.2 {}
+T {Nx - number of emitters} -110 90 0 0 0.2 0.2 {}
+T {Ctrl-Click to execute launcher} 420 120 0 0 0.3 0.3 {layer=11}
+T {Nx - number of emitters} 140 90 0 0 0.2 0.2 {}
+T {Uncomment the valid library:
+hbt_typ ... without statistical and without mismatch modelling
+hbt_typ_mismatch ... with mismatch modelling
+hbt_typ_stat ... with statistical modelling
+hbt_typ_stat_mismatch ... with statistical and with mismatch modelling} -190 -580 0 0 0.3 0.3 {layer=11}
 N -200 30 -200 50 {
 lab=GND}
 N -200 -40 -200 -30 {
@@ -28,25 +34,38 @@ N 20 -110 60 -110 {
 lab=#net3}
 N -200 -40 -110 -40 {
 lab=#net1}
-C {devices/code_shown.sym} -200 160 0 0 {name=MODEL only_toplevel=true
+N 60 -110 90 -110 {lab=#net3}
+N 150 -110 190 -110 {lab=#net4}
+N 190 -110 190 -70 {lab=#net4}
+N 130 -40 130 50 {lab=GND}
+N 130 -40 190 -40 {lab=GND}
+N 190 -10 190 50 {lab=GND}
+N 310 30 310 50 {
+lab=GND}
+N 310 -40 310 -30 {
+lab=#net5}
+N 230 -40 310 -40 {lab=#net5}
+C {devices/code_shown.sym} -190 -440 0 0 {name=MODEL only_toplevel=true
 format="tcleval( @value )"
 value="
-.lib $::SG13G2_MODELS/cornerHBT.lib hbt_typ_stat
 *.lib $::SG13G2_MODELS/cornerHBT.lib hbt_typ
+*.lib $::SG13G2_MODELS/cornerHBT.lib hbt_typ_mismatch
+*.lib $::SG13G2_MODELS/cornerHBT.lib hbt_typ_stat
+.lib $::SG13G2_MODELS/cornerHBT.lib hbt_typ_stat_mismatch
 "}
 C {devices/code_shown.sym} 400 -590 0 0 {name=NGSPICE only_toplevel=true 
 value="
 .param temp=27
-.param mc_ok = 1
 
 .control 
 save all
-let mc_runs = 1000
+let mc_runs = 3
 let run = 0
 set curplot=new
 set scratch=$curplot
 setplot $scratch
 let Ic=unitvec(mc_runs)
+let Ic1=unitvec(mc_runs)
 
 ***************** LOOP *********************
 dowhile run < mc_runs
@@ -57,16 +76,18 @@ set dt=$curplot
 setplot $scratch
 let out\{$run\}=\{$dt\}.I(Vc)
 let Ic[run]= \{$dt\}.I(Vc)
+let Ic1[run]= \{$dt\}.I(Vc1)
 setplot $dt
 reset
 let run=run+1 
 end
 ***************** LOOP *********************
 
-wrdata mc_hbt_op.csv \{$scratch\}.Ic
+wrdata mc_hbt_op.csv \{$scratch\}.Ic \{$scratch\}.Ic1
 write mc_hbt_op.raw
 echo
 print \{$scratch\}.Ic
+print \{$scratch\}.Ic1
 
 .endc
 "}
@@ -83,3 +104,33 @@ model=npn13G2
 spiceprefix=X
 Nx=1
 }
+C {launcher.sym} 480 100 0 0 {name=h1
+descr=SimulateNGSPICE
+tclcommand="
+# Setup the default simulation commands if not already set up
+# for example by already launched simulations.
+set_sim_defaults
+puts $sim(spice,1,cmd) 
+
+# Change the Xyce command. In the spice category there are currently
+# 5 commands (0, 1, 2, 3, 4). Command 3 is the Xyce batch
+# you can get the number by querying $sim(spice,n)
+set sim(spice,1,cmd) \{ngspice  \\"$N\\" -a\}
+
+# change the simulator to be used (Xyce)
+set sim(spice,default) 0
+
+# run netlist and simulation
+xschem netlist
+simulate
+"}
+C {sg13g2_pr/npn13G2.sym} 210 -40 0 1 {name=Q2
+model=npn13G2
+spiceprefix=X
+Nx=1
+}
+C {devices/ammeter.sym} 120 -110 3 1 {name=Vc1}
+C {devices/gnd.sym} 130 50 0 0 {name=l6 lab=GND}
+C {devices/gnd.sym} 190 50 0 0 {name=l7 lab=GND}
+C {devices/gnd.sym} 310 50 0 0 {name=l8 lab=GND}
+C {devices/isource.sym} 310 0 2 0 {name=I1 value=1u}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/mc_hv_nmos_cs_loop.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/mc_hv_nmos_cs_loop.sch
@@ -1,9 +1,15 @@
-v {xschem version=3.4.6 file_version=1.2}
+v {xschem version=3.4.7 file_version=1.2}
 G {}
 K {}
 V {}
 S {}
 E {}
+T {Uncomment the valid library:
+mos_tt ... without statistical and without mismatch modelling
+mos_tt_mismatch ... with mismatch modelling
+mos_tt_stat ... with statistical modelling
+mos_tt_stat_mismatch ... with statistical and with mismatch modelling} 380 -580 0 0 0.3 0.3 {layer=11}
+T {Ctrl-Click to execute launcher} 380 -300 0 0 0.3 0.3 {layer=11}
 N 480 -20 480 40 {
 lab=GND}
 N 480 -50 530 -50 {
@@ -24,26 +30,39 @@ N 380 -100 400 -100 {
 lab=Vgs}
 N 480 -120 480 -100 {
 lab=Vgs}
-C {devices/code_shown.sym} 260 110 0 0 {name=MODEL only_toplevel=true
-format="tcleval( @value )"
-value="
-.lib cornerMOShv.lib mos_tt_stat
-
-"}
+N 750 -20 750 40 {
+lab=GND}
+N 750 -50 800 -50 {
+lab=GND}
+N 800 -50 800 40 {
+lab=GND}
+N 750 -200 750 -180 {
+lab=GND}
+N 750 -100 750 -80 {
+lab=Vgs1}
+N 670 -50 710 -50 {
+lab=Vgs1}
+N 670 -100 670 -50 {
+lab=Vgs1}
+N 670 -100 750 -100 {
+lab=Vgs1}
+N 650 -100 670 -100 {
+lab=Vgs1}
+N 750 -120 750 -100 {
+lab=Vgs1}
 C {devices/code_shown.sym} -300 -440 0 0 {name=NGSPICE only_toplevel=true 
 value="
-.param mm_ok=1
-.param mc_ok=1
 .param temp=27
 
 .control
 
-let mc_runs = 1000
+let mc_runs = 3
 let run = 0
 set curplot=new
 set scratch=$curplot
 setplot $scratch
 let vg=unitvec(mc_runs)
+let vg1=unitvec(mc_runs)
 
 ***************** LOOP *********************
 dowhile run < mc_runs
@@ -55,16 +74,17 @@ set dt=$curplot
 setplot $scratch
 let out\{$run\}=\{$dt\}.Vgs
 let Vg[run]=\{$dt\}.Vgs
+let Vg1[run]=\{$dt\}.Vgs1
 setplot $dt
 reset
 let run=run+1 
 end
 ***************** LOOP *********************
 
-wrdata sg13_hv_nmos_cs.csv \{$scratch\}.vg
+wrdata sg13_hv_nmos_cs.csv \{$scratch\}.vg \{$scratch\}.vg1
 write sg13_hv_nmos_cs.raw
 echo
-print \{$scratch\}.vg
+print \{$scratch\}.vg \{$scratch\}.vg1
 
 .endc
 "}
@@ -82,3 +102,44 @@ m=1
 model=sg13_hv_nmos
 spiceprefix=X
 }
+C {devices/gnd.sym} 750 40 0 0 {name=l3 lab=GND}
+C {devices/gnd.sym} 800 40 0 0 {name=l6 lab=GND}
+C {devices/isource.sym} 750 -150 0 0 {name=I1 value=10u}
+C {devices/gnd.sym} 750 -200 2 0 {name=l7 lab=GND}
+C {devices/lab_pin.sym} 650 -100 0 0 {name=p2 sig_type=std_logic lab=Vgs1}
+C {sg13g2_pr/sg13_hv_nmos.sym} 730 -50 0 0 {name=M2
+l=0.45u
+w=1.0u
+ng=1
+m=1
+model=sg13_hv_nmos
+spiceprefix=X
+}
+C {devices/code_shown.sym} 380 -440 0 0 {name=MODEL only_toplevel=true
+format="tcleval( @value )"
+value="
+*.lib $::SG13G2_MODELS/cornerMOShv.lib mos_tt
+*.lib $::SG13G2_MODELS/cornerMOShv.lib mos_tt_mismatch
+*.lib $::SG13G2_MODELS/cornerMOShv.lib mos_tt_stat
+.lib $::SG13G2_MODELS/cornerMOShv.lib mos_tt_stat_mismatch
+"}
+C {launcher.sym} 440 -260 0 0 {name=h3
+descr=SimulateNGSPICE
+tclcommand="
+# Setup the default simulation commands if not already set up
+# for example by already launched simulations.
+set_sim_defaults
+puts $sim(spice,1,cmd) 
+
+# Change the Xyce command. In the spice category there are currently
+# 5 commands (0, 1, 2, 3, 4). Command 3 is the Xyce batch
+# you can get the number by querying $sim(spice,n)
+set sim(spice,1,cmd) \{ngspice  \\"$N\\" -a\}
+
+# change the simulator to be used (Xyce)
+set sim(spice,default) 0
+
+# run netlist and simulation
+xschem netlist
+simulate
+"}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/mc_hv_pmos_cs_loop.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/mc_hv_pmos_cs_loop.sch
@@ -1,9 +1,15 @@
-v {xschem version=3.4.6 file_version=1.2}
+v {xschem version=3.4.7 file_version=1.2}
 G {}
 K {}
 V {}
 S {}
 E {}
+T {Uncomment the valid library:
+mos_tt ... without statistical and without mismatch modelling
+mos_tt_mismatch ... with mismatch modelling
+mos_tt_stat ... with statistical modelling
+mos_tt_stat_mismatch ... with statistical and with mismatch modelling} 380 -570 0 0 0.3 0.3 {layer=11}
+T {Ctrl-Click to execute launcher} 380 -290 0 0 0.3 0.3 {layer=11}
 N 480 -20 480 40 {
 lab=GND}
 N 480 -50 530 -50 {
@@ -24,24 +30,39 @@ N 380 -100 400 -100 {
 lab=Vgs}
 N 480 -120 480 -100 {
 lab=Vgs}
-C {devices/code_shown.sym} 260 110 0 0 {name=MODEL only_toplevel=true
-format="tcleval( @value )"
-value="
-.lib cornerMOShv.lib mos_tt_stat
-"}
+N 740 -20 740 40 {
+lab=GND}
+N 740 -50 790 -50 {
+lab=GND}
+N 790 -50 790 40 {
+lab=GND}
+N 740 -200 740 -180 {
+lab=GND}
+N 740 -100 740 -80 {
+lab=Vgs1}
+N 660 -50 700 -50 {
+lab=Vgs1}
+N 660 -100 660 -50 {
+lab=Vgs1}
+N 660 -100 740 -100 {
+lab=Vgs1}
+N 640 -100 660 -100 {
+lab=Vgs1}
+N 740 -120 740 -100 {
+lab=Vgs1}
 C {devices/code_shown.sym} -300 -440 0 0 {name=NGSPICE only_toplevel=true 
 value="
-.param mm_ok=1
-.param mc_ok=1
 .param temp=27
 
 .control
-let mc_runs = 1000
+
+let mc_runs = 3
 let run = 0
 set curplot=new
 set scratch=$curplot
 setplot $scratch
 let vg=unitvec(mc_runs)
+let vg1=unitvec(mc_runs)
 
 ***************** LOOP *********************
 dowhile run < mc_runs
@@ -53,16 +74,17 @@ set dt=$curplot
 setplot $scratch
 let out\{$run\}=\{$dt\}.Vgs
 let Vg[run]=\{$dt\}.Vgs
+let Vg1[run]=\{$dt\}.Vgs1
 setplot $dt
 reset
 let run=run+1 
 end
 ***************** LOOP *********************
 
-wrdata sg13_hv_pmos_cs.csv \{$scratch\}.vg
+wrdata sg13_hv_pmos_cs.csv \{$scratch\}.vg \{$scratch\}.vg1
 write sg13_hv_pmos_cs.raw
 echo
-print \{$scratch\}.vg
+print \{$scratch\}.vg \{$scratch\}.vg1
 
 .endc
 "}
@@ -80,3 +102,44 @@ m=1
 model=sg13_hv_pmos
 spiceprefix=X
 }
+C {devices/gnd.sym} 740 40 0 0 {name=l3 lab=GND}
+C {devices/gnd.sym} 790 40 0 0 {name=l6 lab=GND}
+C {devices/isource.sym} 740 -150 2 0 {name=I1 value=10u}
+C {devices/gnd.sym} 740 -200 2 0 {name=l7 lab=GND}
+C {devices/lab_pin.sym} 640 -100 0 0 {name=p2 sig_type=std_logic lab=Vgs1}
+C {sg13g2_pr/sg13_hv_pmos.sym} 720 -50 2 1 {name=M2
+l=0.45u
+w=1.0u
+ng=1
+m=1
+model=sg13_hv_pmos
+spiceprefix=X
+}
+C {devices/code_shown.sym} 380 -430 0 0 {name=MODEL only_toplevel=true
+format="tcleval( @value )"
+value="
+*.lib $::SG13G2_MODELS/cornerMOShv.lib mos_tt
+*.lib $::SG13G2_MODELS/cornerMOShv.lib mos_tt_mismatch
+*.lib $::SG13G2_MODELS/cornerMOShv.lib mos_tt_stat
+.lib $::SG13G2_MODELS/cornerMOShv.lib mos_tt_stat_mismatch
+"}
+C {launcher.sym} 440 -250 0 0 {name=h3
+descr=SimulateNGSPICE
+tclcommand="
+# Setup the default simulation commands if not already set up
+# for example by already launched simulations.
+set_sim_defaults
+puts $sim(spice,1,cmd) 
+
+# Change the Xyce command. In the spice category there are currently
+# 5 commands (0, 1, 2, 3, 4). Command 3 is the Xyce batch
+# you can get the number by querying $sim(spice,n)
+set sim(spice,1,cmd) \{ngspice  \\"$N\\" -a\}
+
+# change the simulator to be used (Xyce)
+set sim(spice,default) 0
+
+# run netlist and simulation
+xschem netlist
+simulate
+"}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/mc_lv_nmos_cs_loop.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/mc_lv_nmos_cs_loop.sch
@@ -1,9 +1,15 @@
-v {xschem version=3.4.6 file_version=1.2}
+v {xschem version=3.4.7 file_version=1.2}
 G {}
 K {}
 V {}
 S {}
 E {}
+T {Uncomment the valid library:
+mos_tt ... without statistical and without mismatch modelling
+mos_tt_mismatch ... with mismatch modelling
+mos_tt_stat ... with statistical modelling
+mos_tt_stat_mismatch ... with statistical and with mismatch modelling} 340 -600 0 0 0.3 0.3 {layer=11}
+T {Ctrl-Click to execute launcher} 340 -320 0 0 0.3 0.3 {layer=11}
 N 480 -20 480 40 {
 lab=GND}
 N 480 -50 530 -50 {
@@ -24,25 +30,39 @@ N 380 -100 400 -100 {
 lab=Vgs}
 N 480 -120 480 -100 {
 lab=Vgs}
-C {devices/code_shown.sym} 260 110 0 0 {name=MODEL only_toplevel=true
-format="tcleval( @value )"
-value="
-.lib cornerMOSlv.lib mos_tt_stat
-"}
+N 710 -20 710 40 {
+lab=GND}
+N 710 -50 760 -50 {
+lab=GND}
+N 760 -50 760 40 {
+lab=GND}
+N 710 -200 710 -180 {
+lab=GND}
+N 710 -100 710 -80 {
+lab=Vgs1}
+N 630 -50 670 -50 {
+lab=Vgs1}
+N 630 -100 630 -50 {
+lab=Vgs1}
+N 630 -100 710 -100 {
+lab=Vgs1}
+N 610 -100 630 -100 {
+lab=Vgs1}
+N 710 -120 710 -100 {
+lab=Vgs1}
 C {devices/code_shown.sym} -300 -440 0 0 {name=NGSPICE only_toplevel=true 
 value="
-.param mm_ok=1
-.param mc_ok=1
 .param temp=27
 
 .control
 
-let mc_runs = 1000
+let mc_runs = 3
 let run = 0
 set curplot=new
 set scratch=$curplot
 setplot $scratch
 let vg=unitvec(mc_runs)
+let vg1=unitvec(mc_runs)
 
 ***************** LOOP *********************
 dowhile run < mc_runs
@@ -54,16 +74,17 @@ set dt=$curplot
 setplot $scratch
 let out\{$run\}=\{$dt\}.Vgs
 let Vg[run]=\{$dt\}.Vgs
+let Vg1[run]=\{$dt\}.Vgs1
 setplot $dt
 reset
 let run=run+1 
 end
 ***************** LOOP *********************
 
-wrdata sg13_lv_nmos_cs.csv \{$scratch\}.vg
+wrdata sg13_lv_nmos_cs.csv \{$scratch\}.vg \{$scratch\}.vg1
 write sg13_lv_nmos_cs.raw
 echo
-print \{$scratch\}.vg
+print \{$scratch\}.vg \{$scratch\}.vg1
 
 .endc
 "}
@@ -74,6 +95,191 @@ C {devices/isource.sym} 480 -150 0 0 {name=I0 value=10u}
 C {devices/gnd.sym} 480 -200 2 0 {name=l2 lab=GND}
 C {devices/lab_pin.sym} 380 -100 0 0 {name=p1 sig_type=std_logic lab=Vgs}
 C {sg13g2_pr/sg13_lv_nmos.sym} 460 -50 0 0 {name=M1
+l=0.45u
+w=1.0u
+ng=1
+m=1
+model=sg13_lv_nmos
+spiceprefix=X
+}
+C {devices/code_shown.sym} 340 -460 0 0 {name=MODEL only_toplevel=true
+format="tcleval( @value )"
+value="
+*.lib $::SG13G2_MODELS/cornerMOSlv.lib mos_tt
+*.lib $::SG13G2_MODELS/cornerMOSlv.lib mos_tt_mismatch
+*.lib $::SG13G2_MODELS/cornerMOSlv.lib mos_tt_stat
+.lib $::SG13G2_MODELS/cornerMOSlv.lib mos_tt_stat_mismatch
+"}
+C {launcher.sym} 400 -280 0 0 {name=h3
+descr=SimulateNGSPICE
+tclcommand="
+# Setup the default simulation commands if not already set up
+# for example by already launched simulations.
+set_sim_defaults
+puts $sim(spice,1,cmd) 
+
+# Change the Xyce command. In the spice category there are currently
+# 5 commands (0, 1, 2, 3, 4). Command 3 is the Xyce batch
+# you can get the number by querying $sim(spice,n)
+set sim(spice,1,cmd) \{ngspice  \\"$N\\" -a\}
+
+# change the simulator to be used (Xyce)
+set sim(spice,default) 0
+
+# run netlist and simulation
+xschem netlist
+simulate
+"}
+C {devices/gnd.sym} 710 40 0 0 {name=l3 lab=GND}
+C {devices/gnd.sym} 760 40 0 0 {name=l6 lab=GND}
+C {devices/isource.sym} 710 -150 0 0 {name=I1 value=10u}
+C {devices/gnd.sym} 710 -200 2 0 {name=l7 lab=GND}
+C {devices/lab_pin.sym} 610 -100 0 0 {name=p2 sig_type=std_logic lab=Vgs1}
+C {sg13g2_pr/sg13_lv_nmos.sym} 690 -50 0 0 {name=M2
+l=0.45u
+w=1.0u
+ng=1
+m=1
+model=sg13_lv_nmos
+spiceprefix=X
+}v {xschem version=3.4.7 file_version=1.2}
+G {}
+K {}
+V {}
+S {}
+E {}
+T {Uncomment the valid library:
+mos_tt ... without statistical and without mismatch modelling
+mos_tt_mismatch ... with mismatch modelling
+mos_tt_stat ... with statistical modelling
+mos_tt_stat_mismatch ... with statistical and with mismatch modelling} 340 -600 0 0 0.3 0.3 {layer=11}
+T {Ctrl-Click to execute launcher} 340 -320 0 0 0.3 0.3 {layer=11}
+N 480 -20 480 40 {
+lab=GND}
+N 480 -50 530 -50 {
+lab=GND}
+N 530 -50 530 40 {
+lab=GND}
+N 480 -200 480 -180 {
+lab=GND}
+N 480 -100 480 -80 {
+lab=Vgs}
+N 400 -50 440 -50 {
+lab=Vgs}
+N 400 -100 400 -50 {
+lab=Vgs}
+N 400 -100 480 -100 {
+lab=Vgs}
+N 380 -100 400 -100 {
+lab=Vgs}
+N 480 -120 480 -100 {
+lab=Vgs}
+N 710 -20 710 40 {
+lab=GND}
+N 710 -50 760 -50 {
+lab=GND}
+N 760 -50 760 40 {
+lab=GND}
+N 710 -200 710 -180 {
+lab=GND}
+N 710 -100 710 -80 {
+lab=Vgs1}
+N 630 -50 670 -50 {
+lab=Vgs1}
+N 630 -100 630 -50 {
+lab=Vgs1}
+N 630 -100 710 -100 {
+lab=Vgs1}
+N 610 -100 630 -100 {
+lab=Vgs1}
+N 710 -120 710 -100 {
+lab=Vgs1}
+C {devices/code_shown.sym} -300 -440 0 0 {name=NGSPICE only_toplevel=true 
+value="
+.param temp=27
+
+.control
+
+let mc_runs = 3
+let run = 0
+set curplot=new
+set scratch=$curplot
+setplot $scratch
+let vg=unitvec(mc_runs)
+let vg1=unitvec(mc_runs)
+
+***************** LOOP *********************
+dowhile run < mc_runs
+
+*dc Vds 0 3 0.01
+op
+set run=$&run
+set dt=$curplot
+setplot $scratch
+let out\{$run\}=\{$dt\}.Vgs
+let Vg[run]=\{$dt\}.Vgs
+let Vg1[run]=\{$dt\}.Vgs1
+setplot $dt
+reset
+let run=run+1 
+end
+***************** LOOP *********************
+
+wrdata sg13_lv_nmos_cs.csv \{$scratch\}.vg \{$scratch\}.vg1
+write sg13_lv_nmos_cs.raw
+echo
+print \{$scratch\}.vg \{$scratch\}.vg1
+
+.endc
+"}
+C {devices/gnd.sym} 480 40 0 0 {name=l1 lab=GND}
+C {devices/gnd.sym} 530 40 0 0 {name=l4 lab=GND}
+C {devices/title.sym} -130 260 0 0 {name=l5 author="Copyright 2023 IHP PDK Authors"}
+C {devices/isource.sym} 480 -150 0 0 {name=I0 value=10u}
+C {devices/gnd.sym} 480 -200 2 0 {name=l2 lab=GND}
+C {devices/lab_pin.sym} 380 -100 0 0 {name=p1 sig_type=std_logic lab=Vgs}
+C {sg13g2_pr/sg13_lv_nmos.sym} 460 -50 0 0 {name=M1
+l=0.45u
+w=1.0u
+ng=1
+m=1
+model=sg13_lv_nmos
+spiceprefix=X
+}
+C {devices/code_shown.sym} 340 -460 0 0 {name=MODEL only_toplevel=true
+format="tcleval( @value )"
+value="
+*.lib $::SG13G2_MODELS/cornerMOSlv.lib mos_tt
+*.lib $::SG13G2_MODELS/cornerMOSlv.lib mos_tt_mismatch
+*.lib $::SG13G2_MODELS/cornerMOSlv.lib mos_tt_stat
+.lib $::SG13G2_MODELS/cornerMOSlv.lib mos_tt_stat_mismatch
+"}
+C {launcher.sym} 400 -280 0 0 {name=h3
+descr=SimulateNGSPICE
+tclcommand="
+# Setup the default simulation commands if not already set up
+# for example by already launched simulations.
+set_sim_defaults
+puts $sim(spice,1,cmd) 
+
+# Change the Xyce command. In the spice category there are currently
+# 5 commands (0, 1, 2, 3, 4). Command 3 is the Xyce batch
+# you can get the number by querying $sim(spice,n)
+set sim(spice,1,cmd) \{ngspice  \\"$N\\" -a\}
+
+# change the simulator to be used (Xyce)
+set sim(spice,default) 0
+
+# run netlist and simulation
+xschem netlist
+simulate
+"}
+C {devices/gnd.sym} 710 40 0 0 {name=l3 lab=GND}
+C {devices/gnd.sym} 760 40 0 0 {name=l6 lab=GND}
+C {devices/isource.sym} 710 -150 0 0 {name=I1 value=10u}
+C {devices/gnd.sym} 710 -200 2 0 {name=l7 lab=GND}
+C {devices/lab_pin.sym} 610 -100 0 0 {name=p2 sig_type=std_logic lab=Vgs1}
+C {sg13g2_pr/sg13_lv_nmos.sym} 690 -50 0 0 {name=M2
 l=0.45u
 w=1.0u
 ng=1

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/mc_lv_pmos_cs_loop.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/mc_lv_pmos_cs_loop.sch
@@ -1,9 +1,15 @@
-v {xschem version=3.4.6 file_version=1.2}
+v {xschem version=3.4.7 file_version=1.2}
 G {}
 K {}
 V {}
 S {}
 E {}
+T {Uncomment the valid library:
+mos_tt ... without statistical and without mismatch modelling
+mos_tt_mismatch ... with mismatch modelling
+mos_tt_stat ... with statistical modelling
+mos_tt_stat_mismatch ... with statistical and with mismatch modelling} 350 -580 0 0 0.3 0.3 {layer=11}
+T {Ctrl-Click to execute launcher} 350 -300 0 0 0.3 0.3 {layer=11}
 N 480 -20 480 40 {
 lab=GND}
 N 480 -50 530 -50 {
@@ -24,24 +30,39 @@ N 380 -100 400 -100 {
 lab=Vgs}
 N 480 -120 480 -100 {
 lab=Vgs}
-C {devices/code_shown.sym} 260 110 0 0 {name=MODEL only_toplevel=true
-format="tcleval( @value )"
-value="
-.lib cornerMOSlv.lib mos_tt_stat
-"}
+N 760 -20 760 40 {
+lab=GND}
+N 760 -50 810 -50 {
+lab=GND}
+N 810 -50 810 40 {
+lab=GND}
+N 760 -200 760 -180 {
+lab=GND}
+N 760 -100 760 -80 {
+lab=Vgs1}
+N 680 -50 720 -50 {
+lab=Vgs1}
+N 680 -100 680 -50 {
+lab=Vgs1}
+N 680 -100 760 -100 {
+lab=Vgs1}
+N 660 -100 680 -100 {
+lab=Vgs1}
+N 760 -120 760 -100 {
+lab=Vgs1}
 C {devices/code_shown.sym} -300 -440 0 0 {name=NGSPICE only_toplevel=true 
 value="
-.param mm_ok=1
-.param mc_ok=1
 .param temp=27
 
 .control
-let mc_runs = 1000
+
+let mc_runs = 3
 let run = 0
 set curplot=new
 set scratch=$curplot
 setplot $scratch
 let vg=unitvec(mc_runs)
+let vg1=unitvec(mc_runs)
 
 ***************** LOOP *********************
 dowhile run < mc_runs
@@ -53,16 +74,17 @@ set dt=$curplot
 setplot $scratch
 let out\{$run\}=\{$dt\}.Vgs
 let Vg[run]=\{$dt\}.Vgs
+let Vg1[run]=\{$dt\}.Vgs1
 setplot $dt
 reset
 let run=run+1 
 end
 ***************** LOOP *********************
 
-wrdata sg13_lv_pmos_cs.csv \{$scratch\}.vg
+wrdata sg13_lv_pmos_cs.csv \{$scratch\}.vg \{$scratch\}.vg1
 write sg13_lv_pmos_cs.raw
 echo
-print \{$scratch\}.vg
+print \{$scratch\}.vg \{$scratch\}.vg1
 
 .endc
 "}
@@ -80,3 +102,44 @@ m=1
 model=sg13_lv_pmos
 spiceprefix=X
 }
+C {devices/gnd.sym} 760 40 0 0 {name=l3 lab=GND}
+C {devices/gnd.sym} 810 40 0 0 {name=l6 lab=GND}
+C {devices/isource.sym} 760 -150 2 0 {name=I1 value=10u}
+C {devices/gnd.sym} 760 -200 2 0 {name=l7 lab=GND}
+C {devices/lab_pin.sym} 660 -100 0 0 {name=p2 sig_type=std_logic lab=Vgs1}
+C {sg13g2_pr/sg13_lv_pmos.sym} 740 -50 2 1 {name=M2
+l=0.45u
+w=1.0u
+ng=1
+m=1
+model=sg13_lv_pmos
+spiceprefix=X
+}
+C {devices/code_shown.sym} 350 -440 0 0 {name=MODEL only_toplevel=true
+format="tcleval( @value )"
+value="
+*.lib $::SG13G2_MODELS/cornerMOSlv.lib mos_tt
+*.lib $::SG13G2_MODELS/cornerMOSlv.lib mos_tt_mismatch
+*.lib $::SG13G2_MODELS/cornerMOSlv.lib mos_tt_stat
+.lib $::SG13G2_MODELS/cornerMOSlv.lib mos_tt_stat_mismatch
+"}
+C {launcher.sym} 410 -260 0 0 {name=h3
+descr=SimulateNGSPICE
+tclcommand="
+# Setup the default simulation commands if not already set up
+# for example by already launched simulations.
+set_sim_defaults
+puts $sim(spice,1,cmd) 
+
+# Change the Xyce command. In the spice category there are currently
+# 5 commands (0, 1, 2, 3, 4). Command 3 is the Xyce batch
+# you can get the number by querying $sim(spice,n)
+set sim(spice,1,cmd) \{ngspice  \\"$N\\" -a\}
+
+# change the simulator to be used (Xyce)
+set sim(spice,default) 0
+
+# run netlist and simulation
+xschem netlist
+simulate
+"}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/mc_res_op.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/mc_res_op.sch
@@ -1,60 +1,88 @@
-v {xschem version=3.4.5 file_version=1.2
-}
+v {xschem version=3.4.7 file_version=1.2}
 G {}
 K {}
 V {}
 S {}
 E {}
 T {Uncomment the valid library:
-res_typ when mc_ok = 0
-res_typ_stat when mc_ok = 0} 360 -430 0 0 0.3 0.3 {}
+res_typ ... without statistical and without mismatch modelling
+res_typ_mismatch ... with mismatch modelling
+res_typ_stat ... with statistical modelling
+res_typ_stat_mismatch ... with statistical and with mismatch modelling} 370 -480 0 0 0.3 0.3 {layer=11}
+T {Ctrl-Click to execute launcher} 370 -200 0 0 0.3 0.3 {layer=11}
 N 380 40 380 100 {
 lab=GND}
 N 380 -100 380 -20 {
 lab=Vcc}
-N 380 -100 610 -100 {
+N 490 -100 490 -60 {
 lab=Vcc}
-N 610 -100 610 -60 {
-lab=Vcc}
-N 610 0 610 20 {
+N 490 0 490 20 {
 lab=#net1}
-N 610 80 610 100 {
+N 490 80 490 100 {
 lab=GND}
-N 760 -100 760 -60 {
+N 770 -100 770 -60 {
 lab=Vcc}
-N 760 0 760 20 {
+N 770 0 770 20 {
 lab=#net2}
-N 760 80 760 100 {
+N 770 80 770 100 {
 lab=GND}
-N 940 -100 940 -60 {
+N 1050 -100 1050 -60 {
 lab=Vcc}
-N 940 0 940 20 {
+N 1050 0 1050 20 {
 lab=#net3}
-N 940 80 940 100 {
+N 1050 80 1050 100 {
 lab=GND}
-N 610 -100 760 -100 {
+N 380 -100 490 -100 {
 lab=Vcc}
-N 760 -100 940 -100 {
+N 630 -100 630 -60 {
+lab=Vcc}
+N 630 0 630 20 {
+lab=#net4}
+N 630 80 630 100 {
+lab=GND}
+N 630 -100 770 -100 {lab=Vcc}
+N 490 -100 630 -100 {
+lab=Vcc}
+N 910 -100 910 -60 {
+lab=Vcc}
+N 910 0 910 20 {
+lab=#net5}
+N 910 80 910 100 {
+lab=GND}
+N 770 -100 910 -100 {lab=Vcc}
+N 910 -100 1050 -100 {
+lab=Vcc}
+N 1190 -100 1190 -60 {
+lab=Vcc}
+N 1190 0 1190 20 {
+lab=#net6}
+N 1190 80 1190 100 {
+lab=GND}
+N 1050 -100 1190 -100 {
 lab=Vcc}
 C {devices/code_shown.sym} 370 -340 0 0 {name=MODEL only_toplevel=true
 format="tcleval( @value )"
 value="
 *.lib $::SG13G2_MODELS/cornerRES.lib res_typ
-.lib $::SG13G2_MODELS/cornerRES.lib res_typ_stat
+*.lib $::SG13G2_MODELS/cornerRES.lib res_typ_mismatch
+*.lib $::SG13G2_MODELS/cornerRES.lib res_typ_stat
+.lib $::SG13G2_MODELS/cornerRES.lib res_typ_stat_mismatch
 "}
 C {devices/code_shown.sym} -490 -480 0 0 {name=NGSPICE only_toplevel=true 
 value="
 .param temp=27
-.param mc_ok = 1
 .control 
-let mc_runs = 1000
+let mc_runs = 3
 let run = 0
 set curplot=new
 set scratch=$curplot
 setplot $scratch
 let rsilval=unitvec(mc_runs)
+let rsilval1=unitvec(mc_runs)
 let rppdval=unitvec(mc_runs)
+let rppdval1=unitvec(mc_runs)
 let rhighval=unitvec(mc_runs)
+let rhighval1=unitvec(mc_runs)
 
 ***************** LOOP *********************
 dowhile run < mc_runs
@@ -65,32 +93,38 @@ set dt=$curplot
 setplot $scratch
 let out\{$run\}=\{$dt\}.I(Vsil)
 let rsilval[run]= 1.5/\{$dt\}.I(Vsil)
+let rsilval1[run]= 1.5/\{$dt\}.I(Vsil1)
 let rppdval[run]= 1.5/\{$dt\}.I(Vppd)
+let rppdval1[run]= 1.5/\{$dt\}.I(Vppd1)
 let rhighval[run]= 1.5/\{$dt\}.I(Vrh)
+let rhighval1[run]= 1.5/\{$dt\}.I(Vrh1)
 setplot $dt
 reset
 let run=run+1 
 end
 ***************** LOOP *********************
 
-wrdata mc_res_op.csv \{$scratch\}.rsilval \{$scratch\}.rppdval \{$scratch\}.rhighval
+wrdata mc_res_op.csv \{$scratch\}.rsilval \{$scratch\}.rsilval1 \{$scratch\}.rppdval \{$scratch\}.rppdval1 \{$scratch\}.rhighval \{$scratch\}.rhighval1
 write mc_res_op.raw
 echo
 print \{$scratch\}.rsilval
+print \{$scratch\}.rsilval1
 print \{$scratch\}.rppdval
+print \{$scratch\}.rppdval1
 print \{$scratch\}.rhighval
+print \{$scratch\}.rhighval1
 .endc
 "}
-C {devices/gnd.sym} 610 100 0 0 {name=l1 lab=GND}
+C {devices/gnd.sym} 490 100 0 0 {name=l1 lab=GND}
 C {devices/vsource.sym} 380 10 0 0 {name=Vres value=1.5}
 C {devices/gnd.sym} 380 100 0 0 {name=l3 lab=GND}
 C {devices/title.sym} -130 260 0 0 {name=l5 author="Copyright 2023 IHP PDK Authors"}
 C {devices/lab_pin.sym} 380 -50 2 0 {name=p1 sig_type=std_logic lab=Vcc}
-C {devices/ammeter.sym} 610 -30 0 0 {name=Vsil}
-C {devices/gnd.sym} 760 100 0 0 {name=l2 lab=GND}
-C {devices/ammeter.sym} 760 -30 0 0 {name=Vppd}
-C {devices/gnd.sym} 940 100 0 0 {name=l4 lab=GND}
-C {sg13g2_pr/rhigh.sym} 940 50 0 0 {name=R3
+C {devices/ammeter.sym} 490 -30 0 0 {name=Vsil}
+C {devices/gnd.sym} 770 100 0 0 {name=l2 lab=GND}
+C {devices/ammeter.sym} 770 -30 0 0 {name=Vppd}
+C {devices/gnd.sym} 1050 100 0 0 {name=l4 lab=GND}
+C {sg13g2_pr/rhigh.sym} 1050 50 0 0 {name=R3
 w=1.0e-6
 l=1.0e-6
 model=rhigh
@@ -99,8 +133,8 @@ m=1
 R=3.061e+3
 Imax=0.11e-4
 }
-C {devices/ammeter.sym} 940 -30 0 0 {name=Vrh}
-C {sg13g2_pr/rsil.sym} 610 50 0 0 {name=R1
+C {devices/ammeter.sym} 1050 -30 0 0 {name=Vrh}
+C {sg13g2_pr/rsil.sym} 490 50 0 0 {name=R1
 w=0.5e-6
 l=0.5e-5
 model=rsil
@@ -109,7 +143,7 @@ m=1
 R=7.0
 Imax=0.3e-6
 }
-C {sg13g2_pr/rppd.sym} 760 50 0 0 {name=R2
+C {sg13g2_pr/rppd.sym} 770 50 0 0 {name=R2
 w=0.5e-6
 l=0.5e-6
 model=rppd
@@ -118,3 +152,56 @@ m=1
 R=7.0
 Imax=0.3e-6
 }
+C {launcher.sym} 430 -160 0 0 {name=h3
+descr=SimulateNGSPICE
+tclcommand="
+# Setup the default simulation commands if not already set up
+# for example by already launched simulations.
+set_sim_defaults
+puts $sim(spice,1,cmd) 
+
+# Change the Xyce command. In the spice category there are currently
+# 5 commands (0, 1, 2, 3, 4). Command 3 is the Xyce batch
+# you can get the number by querying $sim(spice,n)
+set sim(spice,1,cmd) \{ngspice  \\"$N\\" -a\}
+
+# change the simulator to be used (Xyce)
+set sim(spice,default) 0
+
+# run netlist and simulation
+xschem netlist
+simulate
+"}
+C {devices/gnd.sym} 630 100 0 0 {name=l6 lab=GND}
+C {devices/ammeter.sym} 630 -30 0 0 {name=Vsil1}
+C {sg13g2_pr/rsil.sym} 630 50 0 0 {name=R4
+w=0.5e-6
+l=0.5e-5
+model=rsil
+spiceprefix=X
+m=1
+R=7.0
+Imax=0.3e-6
+}
+C {devices/gnd.sym} 910 100 0 0 {name=l7 lab=GND}
+C {devices/ammeter.sym} 910 -30 0 0 {name=Vppd1}
+C {sg13g2_pr/rppd.sym} 910 50 0 0 {name=R5
+w=0.5e-6
+l=0.5e-6
+model=rppd
+spiceprefix=X
+m=1
+R=7.0
+Imax=0.3e-6
+}
+C {devices/gnd.sym} 1190 100 0 0 {name=l8 lab=GND}
+C {sg13g2_pr/rhigh.sym} 1190 50 0 0 {name=R6
+w=1.0e-6
+l=1.0e-6
+model=rhigh
+spiceprefix=X
+m=1
+R=3.061e+3
+Imax=0.11e-4
+}
+C {devices/ammeter.sym} 1190 -30 0 0 {name=Vrh1}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests_xyce/IHP_testcases.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests_xyce/IHP_testcases.sch
@@ -1,4 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
+v {xschem version=3.4.7 file_version=1.2
 * Copyright 2023 IHP PDK Authors
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,9 +38,7 @@ url="https://github.com/IHP-GmbH/IHP-Open-PDK/tree/main"}
 C {sg13g2_tests/mc_hv_nmos_cs_loop.sym} 1200 -590 0 0 {name=x2}
 C {sg13g2_tests/mc_lv_pmos_cs_loop.sym} 1200 -550 0 0 {name=x3}
 C {sg13g2_tests/mc_hv_pmos_cs_loop.sym} 1200 -510 0 0 {name=x4}
-C {sg13g2_tests/mc_hbt_13g2.sym} 1200 -380 0 0 {name=x18}
 C {sg13g2_tests/mc_hbt_13g2_ac.sym} 1200 -350 0 0 {name=x19}
-C {sg13g2_tests/mc_mim_cap_ac.sym} 1200 -300 0 0 {name=x24}
 C {sg13g2_tests/sp_mim_cap.sym} 1560 -630 0 0 {name=x20}
 C {sg13g2_tests/sp_parasitic_cap.sym} 1560 -590 0 0 {name=x22}
 C {sg13g2_tests/sp_rfmim_cap.sym} 1560 -550 0 0 {name=x23}
@@ -69,3 +67,5 @@ C {sg13g2_tests_xyce/dc_esd_diodes.sym} 180 -150 0 0 {name=x31}
 C {sg13g2_tests_xyce/dc_esd_nmos_cl.sym} 180 -110 0 0 {name=x32}
 C {sg13g2_tests_xyce/dc_ntap1.sym} 180 -400 0 0 {name=x25}
 C {sg13g2_tests_xyce/dc_ptap1.sym} 180 -360 0 0 {name=x26}
+C {sg13g2_tests_xyce/mc_hbt_13g2.sym} 1200 -380 0 0 {name=x18}
+C {sg13g2_tests_xyce/mc_mim_cap_ac.sym} 1200 -290 0 0 {name=x24}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests_xyce/mc_hbt_13g2.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests_xyce/mc_hbt_13g2.sch
@@ -1,52 +1,117 @@
-v {xschem version=3.4.4 file_version=1.2
-}
+v {xschem version=3.4.7 file_version=1.2}
 G {}
 K {}
 V {}
 S {}
 E {}
-T {Nx - number of emitters} -110 80 0 0 0.2 0.2 {}
-N -200 30 -200 50 {
+T {Uncomment the valid library:
+hbt_typ ... without statistical and without mismatch modelling
+hbt_typ_mismatch ... with mismatch modelling 
+hbt_typ_stat ... with statistical modelling
+hbt_typ_stat_mismatch ... with statistical and with mismatch modelling} -210 -1040 0 0 0.3 0.3 {layer=11}
+T {Ctrl-Click to execute launcher} -360 -10 0 0 0.3 0.3 {layer=11}
+T {Ctrl-Click to execute launcher} 220 -440 0 0 0.3 0.3 {layer=11}
+T {Nx - number of emitters} 310 -20 0 0 0.2 0.2 {}
+T {Nx - number of emitters} 560 -20 0 0 0.2 0.2 {}
+N 220 -80 220 -60 {
 lab=GND}
-N -200 -40 -200 -30 {
+N 220 -150 220 -140 {
 lab=#net1}
-N -70 -10 -70 50 {
+N 350 -120 350 -60 {
 lab=GND}
-N 60 -10 60 50 {
+N 480 -120 480 -60 {
 lab=GND}
-N -70 -110 -70 -70 {
+N 350 -220 350 -180 {
 lab=#net2}
-N 60 -110 60 -70 {
+N 480 -220 480 -180 {
 lab=#net3}
-N -70 -40 -20 -40 {
+N 350 -150 400 -150 {
 lab=GND}
-N -20 -40 -20 50 {
+N 400 -150 400 -60 {
 lab=GND}
-N -70 -110 -40 -110 {
+N 350 -220 380 -220 {
 lab=#net2}
-N 20 -110 60 -110 {
+N 440 -220 480 -220 {
 lab=#net3}
-N -200 -40 -110 -40 {
+N 220 -150 310 -150 {
 lab=#net1}
-C {devices/code_shown.sym} -200 160 0 0 {name=MODEL only_toplevel=true
-format="tcleval( @value )"
+N 480 -220 510 -220 {lab=#net3}
+N 570 -220 610 -220 {lab=#net4}
+N 610 -220 610 -180 {lab=#net4}
+N 550 -150 550 -60 {lab=GND}
+N 550 -150 610 -150 {lab=GND}
+N 610 -120 610 -60 {lab=GND}
+N 730 -80 730 -60 {
+lab=GND}
+N 730 -150 730 -140 {
+lab=#net5}
+N 650 -150 730 -150 {lab=#net5}
+C {devices/title.sym} -130 260 0 0 {name=l5 author="Copyright 2023 IHP PDK Authors"}
+C {simulator_commands_shown.sym} 200 -680 0 0 {name=Simulator1
+simulator=xyce
+only_toplevel=false 
 value="
-.lib $::SG13G2_MODELS/cornerHBT.lib hbt_typ_stat
-*.lib $::SG13G2_MODELS/cornerHBT.lib hbt_typ
+.preprocess replaceground true
+.SAMPLING
++useExpr=true
+.options SAMPLES numsamples=3 SAMPLE_TYPE=MC 
+.op
+.dc Vce 1.5 1.5 0.1
+.PRINT dc format=csv file=mc_hbt_op_xyce.csv I(Vc) I(Vc1)
+"
 "}
-C {devices/code_shown.sym} 400 -590 0 0 {name=NGSPICE only_toplevel=true 
+C {launcher.sym} 280 -460 0 0 {name=h2
+descr=SimulateXyce
+tclcommand="
+# Setup the default simulation commands if not already set up
+# for example by already launched simulations.
+set_sim_defaults
+
+# Change the Xyce command. In the spice category there are currently
+# 5 commands (0, 1, 2, 3, 4). Command 3 is the Xyce batch
+# you can get the number by querying $sim(spice,n)
+set sim(spice,3,cmd) \{Xyce -plugin $env(PDK_ROOT)/$env(PDK)/libs.tech/xyce/plugins/Xyce_Plugin_r3_cmc.so \\"$N\\"\}
+
+# change the simulator to be used (Xyce)
+set sim(spice,default) 3
+
+# run netlist and simulation
+xschem netlist
+simulate
+"}
+C {simulator_commands_shown.sym} 200 -870 0 0 {name=Libs_Xyce
+simulator=xyce
+only_toplevel=false 
+value="tcleval(
+*.lib $::SG13G2_MODELS_XYCE/cornerHBT.lib hbt_typ
+*.lib $::SG13G2_MODELS_XYCE/cornerHBT.lib hbt_typ_mismatch *not implemented!
+*.lib $::SG13G2_MODELS_XYCE/cornerHBT.lib hbt_typ_stat
+.lib $::SG13G2_MODELS_XYCE/cornerHBT.lib hbt_typ_stat_mismatch
+)"}
+C {simulator_commands_shown.sym} -370 -870 0 0 {name=Libs_Ngspice
+simulator=ngspice
+only_toplevel=false 
+value="
+*.lib cornerHBT.lib hbt_typ
+*.lib cornerHBT.lib hbt_typ_mismatch
+*.lib cornerHBT.lib hbt_typ_stat
+.lib cornerHBT.lib hbt_typ_stat_mismatch
+"}
+C {simulator_commands_shown.sym} -390 -700 0 0 {name=Simulator2
+simulator=ngspice
+only_toplevel=false 
 value="
 .param temp=27
-.param mc_ok = 1
 
 .control 
 save all
-let mc_runs = 1000
+let mc_runs = 3
 let run = 0
 set curplot=new
 set scratch=$curplot
 setplot $scratch
 let Ic=unitvec(mc_runs)
+let Ic1=unitvec(mc_runs)
 
 ***************** LOOP *********************
 dowhile run < mc_runs
@@ -57,28 +122,61 @@ set dt=$curplot
 setplot $scratch
 let out\{$run\}=\{$dt\}.I(Vc)
 let Ic[run]= \{$dt\}.I(Vc)
+let Ic1[run]= \{$dt\}.I(Vc1)
 setplot $dt
 reset
 let run=run+1 
 end
 ***************** LOOP *********************
 
-wrdata mc_hbt_op.csv \{$scratch\}.Ic
+wrdata mc_hbt_op.csv \{$scratch\}.Ic \{$scratch\}.Ic1
 write mc_hbt_op.raw
 echo
 print \{$scratch\}.Ic
+print \{$scratch\}.Ic1
 
 .endc
+"
+}
+C {launcher.sym} -300 -30 0 0 {name=h1
+descr=SimulateNGSPICE
+tclcommand="
+# Setup the default simulation commands if not already set up
+# for example by already launched simulations.
+set_sim_defaults
+puts $sim(spice,1,cmd) 
+
+# Change the Xyce command. In the spice category there are currently
+# 5 commands (0, 1, 2, 3, 4). Command 3 is the Xyce batch
+# you can get the number by querying $sim(spice,n)
+set sim(spice,1,cmd) \{ngspice  \\"$N\\" -a\}
+
+# change the simulator to be used (Xyce)
+set sim(spice,default) 0
+
+# run netlist and simulation
+xschem netlist
+simulate
 "}
-C {devices/gnd.sym} -70 50 0 0 {name=l1 lab=GND}
-C {devices/gnd.sym} -200 50 0 0 {name=l2 lab=GND}
-C {devices/vsource.sym} 60 -40 0 0 {name=Vce value=1.5}
-C {devices/gnd.sym} 60 50 0 0 {name=l3 lab=GND}
-C {devices/gnd.sym} -20 50 0 0 {name=l4 lab=GND}
-C {devices/title.sym} -130 260 0 0 {name=l5 author="Copyright 2023 IHP PDK Authors"}
-C {devices/isource.sym} -200 0 2 0 {name=I0 value=1u}
-C {sg13g2_pr/npn13G2.sym} -90 -40 0 0 {name=Q1
+C {devices/gnd.sym} 350 -60 0 0 {name=l1 lab=GND}
+C {devices/gnd.sym} 220 -60 0 0 {name=l2 lab=GND}
+C {devices/vsource.sym} 480 -150 0 0 {name=Vce value=1.5}
+C {devices/gnd.sym} 480 -60 0 0 {name=l3 lab=GND}
+C {devices/gnd.sym} 400 -60 0 0 {name=l4 lab=GND}
+C {devices/isource.sym} 220 -110 2 0 {name=I0 value=1u}
+C {devices/ammeter.sym} 410 -220 1 0 {name=Vc}
+C {sg13g2_pr/npn13G2.sym} 330 -150 0 0 {name=Q1
 model=npn13G2
 spiceprefix=X
-Nx=1}
-C {devices/ammeter.sym} -10 -110 1 0 {name=Vc}
+Nx=1
+}
+C {sg13g2_pr/npn13G2.sym} 630 -150 0 1 {name=Q2
+model=npn13G2
+spiceprefix=X
+Nx=1
+}
+C {devices/ammeter.sym} 540 -220 3 1 {name=Vc1}
+C {devices/gnd.sym} 550 -60 0 0 {name=l6 lab=GND}
+C {devices/gnd.sym} 610 -60 0 0 {name=l7 lab=GND}
+C {devices/gnd.sym} 730 -60 0 0 {name=l8 lab=GND}
+C {devices/isource.sym} 730 -110 2 0 {name=I1 value=1u}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests_xyce/mc_res_op.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests_xyce/mc_res_op.sch
@@ -1,48 +1,75 @@
-v {xschem version=3.4.5 file_version=1.2
-}
+v {xschem version=3.4.7 file_version=1.2}
 G {}
 K {}
 V {}
 S {}
 E {}
-N 380 40 380 100 {
+T {Uncomment the valid library:
+res_typ ... without statistical and without mismatch modelling
+res_typ_mismatch ... with mismatch modelling
+res_typ_stat ... with statistical modelling
+res_typ_stat_mismatch ... with statistical and with mismatch modelling} -220 -900 0 0 0.3 0.3 {layer=11}
+T {Ctrl-Click to execute launcher} -380 300 0 0 0.3 0.3 {layer=11}
+T {Ctrl-Click to execute launcher} 210 -300 0 0 0.3 0.3 {layer=11}
+N 180 260 180 320 {
 lab=GND}
-N 380 -100 380 -20 {
+N 180 120 180 200 {
 lab=Vcc}
-N 380 -100 610 -100 {
+N 180 120 300 120 {
 lab=Vcc}
-N 610 -100 610 -60 {
+N 300 120 300 160 {
 lab=Vcc}
-N 610 0 610 20 {
+N 300 220 300 240 {
 lab=#net1}
-N 610 80 610 100 {
+N 300 300 300 320 {
 lab=GND}
-N 760 -100 760 -60 {
+N 570 120 570 160 {
 lab=Vcc}
-N 760 0 760 20 {
+N 570 220 570 240 {
 lab=#net2}
-N 760 80 760 100 {
+N 570 300 570 320 {
 lab=GND}
-N 940 -100 940 -60 {
+N 850 120 850 160 {
 lab=Vcc}
-N 940 0 940 20 {
+N 850 220 850 240 {
 lab=#net3}
-N 940 80 940 100 {
+N 850 300 850 320 {
 lab=GND}
-N 610 -100 760 -100 {
+N 440 120 570 120 {
 lab=Vcc}
-N 760 -100 940 -100 {
+N 710 120 850 120 {
 lab=Vcc}
-C {devices/gnd.sym} 610 100 0 0 {name=l1 lab=GND}
-C {devices/vsource.sym} 380 10 0 0 {name=Vres value=1.5}
-C {devices/gnd.sym} 380 100 0 0 {name=l3 lab=GND}
-C {devices/title.sym} -130 260 0 0 {name=l5 author="Copyright 2023 IHP PDK Authors"}
-C {devices/lab_pin.sym} 380 -50 2 0 {name=p1 sig_type=std_logic lab=Vcc}
-C {devices/ammeter.sym} 610 -30 0 0 {name=Vsil}
-C {devices/gnd.sym} 760 100 0 0 {name=l2 lab=GND}
-C {devices/ammeter.sym} 760 -30 0 0 {name=Vppd}
-C {devices/gnd.sym} 940 100 0 0 {name=l4 lab=GND}
-C {sg13g2_pr/rhigh.sym} 940 50 0 0 {name=R3
+N 440 120 440 160 {
+lab=Vcc}
+N 440 220 440 240 {
+lab=#net4}
+N 440 300 440 320 {
+lab=GND}
+N 300 120 440 120 {lab=Vcc}
+N 710 120 710 160 {
+lab=Vcc}
+N 710 220 710 240 {
+lab=#net5}
+N 710 300 710 320 {
+lab=GND}
+N 570 120 710 120 {lab=Vcc}
+N 990 120 990 160 {
+lab=Vcc}
+N 990 220 990 240 {
+lab=#net6}
+N 990 300 990 320 {
+lab=GND}
+N 850 120 990 120 {lab=Vcc}
+C {devices/gnd.sym} 300 320 0 0 {name=l1 lab=GND}
+C {devices/vsource.sym} 180 230 0 0 {name=Vres value=1.5}
+C {devices/gnd.sym} 180 320 0 0 {name=l3 lab=GND}
+C {devices/title.sym} -130 440 0 0 {name=l5 author="Copyright 2023 IHP PDK Authors"}
+C {devices/lab_pin.sym} 180 170 2 0 {name=p1 sig_type=std_logic lab=Vcc}
+C {devices/ammeter.sym} 300 190 0 0 {name=Vsil}
+C {devices/gnd.sym} 570 320 0 0 {name=l2 lab=GND}
+C {devices/ammeter.sym} 570 190 0 0 {name=Vppd}
+C {devices/gnd.sym} 850 320 0 0 {name=l4 lab=GND}
+C {sg13g2_pr/rhigh.sym} 850 270 0 0 {name=R3
 w=1.0e-6
 l=1.0e-6
 model=rhigh
@@ -51,8 +78,8 @@ m=1
 R=3.061e+3
 Imax=0.11e-4
 }
-C {devices/ammeter.sym} 940 -30 0 0 {name=Vrh}
-C {sg13g2_pr/rsil.sym} 610 50 0 0 {name=R1
+C {devices/ammeter.sym} 850 190 0 0 {name=Vrh}
+C {sg13g2_pr/rsil.sym} 300 270 0 0 {name=R1
 w=0.5e-6
 l=0.5e-5
 model=rsil
@@ -61,7 +88,7 @@ m=1
 R=7.0
 Imax=0.3e-6
 }
-C {sg13g2_pr/rppd.sym} 760 50 0 0 {name=R2
+C {sg13g2_pr/rppd.sym} 570 270 0 0 {name=R2
 w=0.5e-6
 l=0.5e-6
 model=rppd
@@ -70,20 +97,20 @@ m=1
 R=7.0
 Imax=0.3e-6
 }
-C {simulator_commands_shown.sym} 180 -610 0 0 {name=Simulator1
+C {simulator_commands_shown.sym} 190 -540 0 0 {name=Simulator1
 simulator=xyce
 only_toplevel=false 
 value="
 .preprocess replaceground true
 .SAMPLING
 +useExpr=true
-.options SAMPLES numsamples=1000 SAMPLE_TYPE=MC 
+.options SAMPLES numsamples=3 SAMPLE_TYPE=MC 
 .op
-*.dc Vres 1.5 1.5 0.1   * one point sweep 
-.PRINT  dc format=csv file=mc_res_op_xyce.csv   V(Vcc)  I(Vsil) I(Vppd)  I(Vrh)
+.dc Vres 1.5 1.5 0.1
+.PRINT dc format=csv file=mc_res_op_xyce.csv I(Vsil) I(Vsil1) I(Vppd) I(Vppd1) I(Vrh) I(Vrh1)
 "
 "}
-C {launcher.sym} 260 -390 0 0 {name=h2
+C {launcher.sym} 270 -320 0 0 {name=h2
 descr=SimulateXyce
 tclcommand="
 # Setup the default simulation commands if not already set up
@@ -93,7 +120,7 @@ set_sim_defaults
 # Change the Xyce command. In the spice category there are currently
 # 5 commands (0, 1, 2, 3, 4). Command 3 is the Xyce batch
 # you can get the number by querying $sim(spice,n)
-set sim(spice,3,cmd) \{Xyce \\"$N\\"\}
+set sim(spice,3,cmd) \{Xyce -plugin $env(PDK_ROOT)/$env(PDK)/libs.tech/xyce/plugins/Xyce_Plugin_r3_cmc.so \\"$N\\"\}
 
 # change the simulator to be used (Xyce)
 set sim(spice,default) 3
@@ -106,15 +133,70 @@ C {simulator_commands_shown.sym} 190 -730 0 0 {name=Libs_Xyce
 simulator=xyce
 only_toplevel=false 
 value="tcleval(
-.lib $::SG13G2_MODELS_XYCE/cornerRES.lib res_typ_stat
+*.lib $::SG13G2_MODELS_XYCE/cornerRES.lib res_typ
+*.lib $::SG13G2_MODELS_XYCE/cornerRES.lib res_typ_mismatch
+*.lib $::SG13G2_MODELS_XYCE/cornerRES.lib res_typ_stat
+.lib $::SG13G2_MODELS_XYCE/cornerRES.lib res_typ_stat_mismatch
 )"}
 C {simulator_commands_shown.sym} -380 -730 0 0 {name=Libs_Ngspice
 simulator=ngspice
 only_toplevel=false 
 value="
-.lib cornerRES.lib res_typ_stat
+*.lib cornerRES.lib res_typ
+*.lib cornerRES.lib res_typ_mismatch
+*.lib cornerRES.lib res_typ_stat
+.lib cornerRES.lib res_typ_stat_mismatch
 "}
-C {launcher.sym} -340 100 0 0 {name=h3
+C {simulator_commands_shown.sym} -400 -560 0 0 {name=Simulator2
+simulator=ngspice
+only_toplevel=false 
+value="
+.param temp=27
+.control 
+let mc_runs = 3
+let run = 0
+set curplot=new
+set scratch=$curplot
+setplot $scratch
+let rsilval=unitvec(mc_runs)
+let rsilval1=unitvec(mc_runs)
+let rppdval=unitvec(mc_runs)
+let rppdval1=unitvec(mc_runs)
+let rhighval=unitvec(mc_runs)
+let rhighval1=unitvec(mc_runs)
+
+***************** LOOP *********************
+dowhile run < mc_runs
+
+op
+set run=$&run
+set dt=$curplot
+setplot $scratch
+let out\{$run\}=\{$dt\}.I(Vsil)
+let rsilval[run]= 1.5/\{$dt\}.I(Vsil)
+let rsilval1[run]= 1.5/\{$dt\}.I(Vsil1)
+let rppdval[run]= 1.5/\{$dt\}.I(Vppd)
+let rppdval1[run]= 1.5/\{$dt\}.I(Vppd1)
+let rhighval[run]= 1.5/\{$dt\}.I(Vrh)
+let rhighval1[run]= 1.5/\{$dt\}.I(Vrh1)
+setplot $dt
+reset
+let run=run+1 
+end
+***************** LOOP *********************
+
+wrdata mc_res_op.csv \{$scratch\}.rsilval \{$scratch\}.rsilval1 \{$scratch\}.rppdval \{$scratch\}.rppdval1 \{$scratch\}.rhighval \{$scratch\}.rhighval1
+write mc_res_op.raw
+echo
+print \{$scratch\}.rsilval
+print \{$scratch\}.rsilval1
+print \{$scratch\}.rppdval
+print \{$scratch\}.rppdval1
+print \{$scratch\}.rhighval
+print \{$scratch\}.rhighval1
+.endc
+"}
+C {launcher.sym} -320 280 0 0 {name=h1
 descr=SimulateNGSPICE
 tclcommand="
 # Setup the default simulation commands if not already set up
@@ -134,44 +216,36 @@ set sim(spice,default) 0
 xschem netlist
 simulate
 "}
-C {simulator_commands_shown.sym} -410 -630 0 0 {name=Simulator2
-simulator=ngspice
-only_toplevel=false 
-value="
-.param temp=27
-.param mc_ok = 1
-.control 
-let mc_runs = 1000
-let run = 0
-set curplot=new
-set scratch=$curplot
-setplot $scratch
-let rsilval=unitvec(mc_runs)
-let rppdval=unitvec(mc_runs)
-let rhighval=unitvec(mc_runs)
-
-***************** LOOP *********************
-dowhile run < mc_runs
-
-op
-set run=$&run
-set dt=$curplot
-setplot $scratch
-let out\{$run\}=\{$dt\}.I(Vsil)
-let rsilval[run]= 1.5/\{$dt\}.I(Vsil)
-let rppdval[run]= 1.5/\{$dt\}.I(Vppd)
-let rhighval[run]= 1.5/\{$dt\}.I(Vrh)
-setplot $dt
-reset
-let run=run+1 
-end
-***************** LOOP *********************
-
-wrdata mc_res_op.csv \{$scratch\}.rsilval \{$scratch\}.rppdval \{$scratch\}.rhighval
-write mc_res_op.raw
-echo
-print \{$scratch\}.rsilval
-print \{$scratch\}.rppdval
-print \{$scratch\}.rhighval
-.endc
-"}
+C {devices/gnd.sym} 440 320 0 0 {name=l6 lab=GND}
+C {devices/ammeter.sym} 440 190 0 0 {name=Vsil1}
+C {sg13g2_pr/rsil.sym} 440 270 0 0 {name=R4
+w=0.5e-6
+l=0.5e-5
+model=rsil
+spiceprefix=X
+m=1
+R=7.0
+Imax=0.3e-6
+}
+C {devices/gnd.sym} 710 320 0 0 {name=l7 lab=GND}
+C {devices/ammeter.sym} 710 190 0 0 {name=Vppd1}
+C {sg13g2_pr/rppd.sym} 710 270 0 0 {name=R5
+w=0.5e-6
+l=0.5e-6
+model=rppd
+spiceprefix=X
+m=1
+R=7.0
+Imax=0.3e-6
+}
+C {devices/gnd.sym} 990 320 0 0 {name=l8 lab=GND}
+C {sg13g2_pr/rhigh.sym} 990 270 0 0 {name=R6
+w=1.0e-6
+l=1.0e-6
+model=rhigh
+spiceprefix=X
+m=1
+R=3.061e+3
+Imax=0.11e-4
+}
+C {devices/ammeter.sym} 990 190 0 0 {name=Vrh1}

--- a/ihp-sg13g2/libs.tech/xyce/models/capacitors_stat.lib
+++ b/ihp-sg13g2/libs.tech/xyce/models/capacitors_stat.lib
@@ -15,7 +15,14 @@
 * limitations under the License.
 *
 *#######################################################################
+* NOTE:
+* values are one-sigma deviations (1/3 of min-max)
 
-* ngspice MC parameters
-.param  cap_carea  = 'gauss(cap_carea_norm, 0.033, mc_ok)'
-.param  cap_cpara  = 'gauss(cap_cpara_norm, 0.067, mc_ok)'
+.param num_sigmas=1
+
+* ngspice statistical parameters
+.param  mc_cap_carea  = 'gauss(cap_carea_norm, 0.033, num_sigmas)'
+.param  mc_cap_cpara  = 'gauss(cap_cpara_norm, 0.067, num_sigmas)'
+
+.param  cap_carea  = mc_cap_carea
+.param  cap_cpara  = mc_cap_cpara

--- a/ihp-sg13g2/libs.tech/xyce/models/cornerCAP.lib
+++ b/ihp-sg13g2/libs.tech/xyce/models/cornerCAP.lib
@@ -1,13 +1,13 @@
 *#######################################################################
 *
 * Copyright 2023 IHP PDK Authors
-* 
+*
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
-* 
+*
 *    https://www.apache.org/licenses/LICENSE-2.0
-* 
+*
 * Unless required by applicable law or agreed to in writing, software
 *distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,39 +15,55 @@
 * limitations under the License.
 *
 *#######################################################################
-      
-**************** CORNERS OF CAPACITORS ****************  
-* Typical without statistical modeling          
-.LIB cap_typ  
+
+**************** CORNERS OF CAPACITORS ****************
+* Typical without statistical modeling
+.LIB cap_typ
 .param cap_carea = 1.5E-15
 .param cap_cpara  = 1.0
-           
+
 .include capacitors_mod.lib
 .ENDL cap_typ
-  
+
+* Typical with mismatch modeling
+*.LIB cap_typ_mismatch
+*.param cap_carea = 1.5E-15
+*.param cap_cpara  = 1.0
+
+*.include capacitors_mod_mismatch.lib
+*.ENDL cap_typ_mismatch
+
 * Typical with statistical modeling
-.LIB cap_typ_stat  
+.LIB cap_typ_stat
 .param cap_carea_norm = 1.5E-15
 .param cap_cpara_norm  = 1.0
-           
+
 .include capacitors_stat.lib
 .include capacitors_mod.lib
 .ENDL cap_typ_stat
 
+* Typical with statistical and with mismatch modeling
+*.LIB cap_typ_stat_mismatch
+*.param cap_carea_norm = 1.5E-15
+*.param cap_cpara_norm  = 1.0
+
+*.include capacitors_stat.lib
+*.include capacitors_mod_mismatch.lib
+*.ENDL cap_typ_stat_mismatch
+
 * Best Case without statistical modeling
-.LIB cap_bcs  
+.LIB cap_bcs
 .param cap_carea = 0.9*1.5E-15
 .param cap_cpara  = 0.9
-           
+
 .include capacitors_mod.lib
 .ENDL cap_bcs
       
       
 * Worst Case without statistical modeling
-.LIB cap_wcs 
+.LIB cap_wcs
 .param cap_carea = 1.1*1.5E-15
 .param cap_cpara  = 1.1
-           
+
 .include capacitors_mod.lib
 .ENDL cap_wcs
-      

--- a/ihp-sg13g2/libs.tech/xyce/models/cornerHBT.lib
+++ b/ihp-sg13g2/libs.tech/xyce/models/cornerHBT.lib
@@ -37,7 +37,29 @@
 
 .include sg13g2_hbt_mod.lib
 .ENDL hbt_typ
-       
+
+.LIB hbt_typ_mismatch
+.param vbic_cje = 1.0
+.param vbic_cjc = 1.0
+.param vbic_cjcp = 1.0
+.param vbic_is = 1.0
+.param vbic_ibei = 1.0
+.param vbic_re = 1.0
+.param vbic_rcx = 1.0
+.param vbic_rbx = 1.0
+.param vbic_tf = 1.0
+
+.param sgp_mpa_cje = 1.0
+.param sgp_mpa_cjc = 1.0
+.param sgp_mpa_is = 1.0
+.param sgp_mpa_bf = 1.0
+.param sgp_mpa_re = 1.0
+.param sgp_mpa_rb = 1.0
+.param sgp_mpa_rc = 1.0
+
+.include sg13g2_hbt_mod.lib
+.ENDL hbt_typ_mismatch
+
 .LIB hbt_typ_stat
 .param vbic_cje_norm = 1.0 
 .param vbic_cjc_norm = 1.0
@@ -60,6 +82,29 @@
 .include sg13g2_hbt_stat.lib
 .include sg13g2_hbt_mod.lib
 .ENDL hbt_typ_stat
+
+.LIB hbt_typ_stat_mismatch
+.param vbic_cje_norm = 1.0 
+.param vbic_cjc_norm = 1.0
+.param vbic_cjcp_norm = 1.0
+.param vbic_is_norm = 1.0
+.param vbic_ibei_norm = 1.0
+.param vbic_re_norm = 1.0
+.param vbic_rcx_norm = 1.0
+.param vbic_rbx_norm = 1.0
+.param vbic_tf = 1.0
+
+.param sgp_mpa_cje_norm = 1.0
+.param sgp_mpa_cjc_norm = 1.0
+.param sgp_mpa_is_norm = 1.0
+.param sgp_mpa_bf_norm = 1.0
+.param sgp_mpa_re_norm = 1.0
+.param sgp_mpa_rb_norm = 1.0
+.param sgp_mpa_rc_norm = 1.0
+
+.include sg13g2_hbt_mod_mismatch.lib
+.include sg13g2_hbt_mod.lib
+.ENDL hbt_typ_stat_mismatch
            
 .LIB hbt_bcs
 .param vbic_cje = 0.83

--- a/ihp-sg13g2/libs.tech/xyce/models/sg13g2_hbt_mod_mismatch.lib
+++ b/ihp-sg13g2/libs.tech/xyce/models/sg13g2_hbt_mod_mismatch.lib
@@ -1,0 +1,41 @@
+*#######################################################################
+*
+* Copyright 2024 IHP PDK Authors
+* 
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+* 
+*    https://www.apache.org/licenses/LICENSE-2.0
+* 
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*#######################################################################
+* NOTE:
+* values are one-sigma deviations (1/3 of min-max)
+
+.param num_sigmas=1
+
+* process variation parameters
+.param  vbic_cje  = 'gauss(vbic_cje_norm, 0.058, num_sigmas)'
+.param  vbic_cjc  = 'gauss(vbic_cjc_norm, 0.043, num_sigmas)'
+.param  vbic_cjcp = 'gauss(vbic_cjcp_norm, 0.037, num_sigmas)'
+.param  vbic_is   = 'gauss(vbic_is_norm, 0.087, num_sigmas)'
+.param  vbic_ibei = 'gauss(vbic_ibei_norm, 0.11, num_sigmas)'
+.param  vbic_re   = 'gauss(vbic_re_norm, 0.09, num_sigmas)'
+.param  vbic_rcx  = 'gauss(vbic_rcx_norm, 0.069, num_sigmas)'
+.param  vbic_rbx  = 'gauss(vbic_rbx_norm, 0.041, num_sigmas)'
+*.param  vbic_tf   = 'gauss(vbic_tf_norm, 0.037, num_sigmas)'
+
+* pnpMPA device
+.param sgp_mpa_cje = 'gauss(sgp_mpa_cje_norm, 0.015, num_sigmas)'
+.param sgp_mpa_cjc = 'gauss(sgp_mpa_cjc_norm, 0.007, num_sigmas)'
+.param sgp_mpa_is  = 'gauss(sgp_mpa_is_norm, 0.043, num_sigmas)'
+.param sgp_mpa_bf  = 'gauss(sgp_mpa_bf_norm, 0.079, num_sigmas)'
+.param sgp_mpa_re  = 'gauss(sgp_mpa_re_norm, 0.016, num_sigmas)'
+.param sgp_mpa_rb  = 'gauss(sgp_mpa_rb_norm, 0.008, num_sigmas)'
+.param sgp_mpa_rc  = 'gauss(sgp_mpa_rc_norm, 0.017, num_sigmas)'

--- a/ihp-sg13g2/libs.tech/xyce/models/sg13g2_hbt_stat.lib
+++ b/ihp-sg13g2/libs.tech/xyce/models/sg13g2_hbt_stat.lib
@@ -15,23 +15,45 @@
 * limitations under the License.
 *
 *#######################################################################
+* NOTE:
+* values are one-sigma deviations (1/3 of min-max)
 
-* process variation parameters
-.param  vbic_cje  = 'gauss(vbic_cje_norm, 0.058, mc_ok)'
-.param  vbic_cjc  = 'gauss(vbic_cjc_norm, 0.043, mc_ok)'
-.param  vbic_cjcp = 'gauss(vbic_cjcp_norm, 0.037, mc_ok)'
-.param  vbic_is   = 'gauss(vbic_is_norm, 0.087, mc_ok)'
-.param  vbic_ibei = 'gauss(vbic_ibei_norm, 0.11, mc_ok)'
-.param  vbic_re   = 'gauss(vbic_re_norm, 0.09, mc_ok)'
-.param  vbic_rcx  = 'gauss(vbic_rcx_norm, 0.069, mc_ok)'
-.param  vbic_rbx  = 'gauss(vbic_rbx_norm, 0.041, mc_ok)'
-*.param  vbic_tf   = 'gauss(vbic_tf_norm, 0.037, mc_ok)'
+.param num_sigmas=1
+
+* ngspice process variation parameters
+.param  mc_vbic_cje  = 'gauss(vbic_cje_norm, 0.058, num_sigmas)'
+.param  mc_vbic_cjc  = 'gauss(vbic_cjc_norm, 0.043, num_sigmas)'
+.param  mc_vbic_cjcp = 'gauss(vbic_cjcp_norm, 0.037, num_sigmas)'
+.param  mc_vbic_is   = 'gauss(vbic_is_norm, 0.087, num_sigmas)'
+.param  mc_vbic_ibei = 'gauss(vbic_ibei_norm, 0.11, num_sigmas)'
+.param  mc_vbic_re   = 'gauss(vbic_re_norm, 0.09, num_sigmas)'
+.param  mc_vbic_rcx  = 'gauss(vbic_rcx_norm, 0.069, num_sigmas)'
+.param  mc_vbic_rbx  = 'gauss(vbic_rbx_norm, 0.041, num_sigmas)'
+*.param  mc_vbic_tf   = 'gauss(vbic_tf_norm, 0.037, num_sigmas)'
+
+.param  vbic_cje  = mc_vbic_cje
+.param  vbic_cjc  = mc_vbic_cjc
+.param  vbic_cjcp = mc_vbic_cjcp
+.param  vbic_is   = mc_vbic_is
+.param  vbic_ibei = mc_vbic_ibei
+.param  vbic_re   = mc_vbic_re
+.param  vbic_rcx  = mc_vbic_rcx
+.param  vbic_rbx  = mc_vbic_rbx
+*.param  vbic_tf   = mc_vbic_tf
 
 * pnpMPA device
-.param sgp_mpa_cje = 'gauss(sgp_mpa_cje_norm, 0.015, mc_ok)'
-.param sgp_mpa_cjc = 'gauss(sgp_mpa_cjc_norm, 0.007, mc_ok)'
-.param sgp_mpa_is  = 'gauss(sgp_mpa_is_norm, 0.043, mc_ok)'
-.param sgp_mpa_bf  = 'gauss(sgp_mpa_bf_norm, 0.079, mc_ok)'
-.param sgp_mpa_re  = 'gauss(sgp_mpa_re_norm, 0.016, mc_ok)'
-.param sgp_mpa_rb  = 'gauss(sgp_mpa_rb_norm, 0.008, mc_ok)'
-.param sgp_mpa_rc  = 'gauss(sgp_mpa_rc_norm, 0.017, mc_ok)'
+.param mc_sgp_mpa_cje = 'gauss(sgp_mpa_cje_norm, 0.015, num_sigmas)'
+.param mc_sgp_mpa_cjc = 'gauss(sgp_mpa_cjc_norm, 0.007, num_sigmas)'
+.param mc_sgp_mpa_is  = 'gauss(sgp_mpa_is_norm, 0.043, num_sigmas)'
+.param mc_sgp_mpa_bf  = 'gauss(sgp_mpa_bf_norm, 0.079, num_sigmas)'
+.param mc_sgp_mpa_re  = 'gauss(sgp_mpa_re_norm, 0.016, num_sigmas)'
+.param mc_sgp_mpa_rb  = 'gauss(sgp_mpa_rb_norm, 0.008, num_sigmas)'
+.param mc_sgp_mpa_rc  = 'gauss(sgp_mpa_rc_norm, 0.017, num_sigmas)'
+
+.param sgp_mpa_cje = mc_sgp_mpa_cje
+.param sgp_mpa_cjc = mc_sgp_mpa_cjc
+.param sgp_mpa_is  = mc_sgp_mpa_is
+.param sgp_mpa_bf  = mc_sgp_mpa_bf
+.param sgp_mpa_re  = mc_sgp_mpa_re
+.param sgp_mpa_rb  = mc_sgp_mpa_rb
+.param sgp_mpa_rc  = mc_sgp_mpa_rc


### PR DESCRIPTION
Improvements of Monte-Carlo simulations:
- [ ] Added statistical + mismatch modelling
- [ ] Updated example files of HBT, RES, CAP, MOSLV, MOSHV (ngspice) to be able to test no variation, mismatch, statistical variation (process), and mismatch + statistical variation
- [ ] Updated example files of HBT, RES, CAP (Xyce) to be able to test no variation, mismatch, statistical variation (process), and mismatch + statistical variation 
- [ ] Example files of moslv+moshv not updated --- however, mismatch simulation of cap, hbt, and mos not possible in Xyce (opened issue)
- [ ] Xyce MC example files linked in schematic IHP_testcases.sch
![image](https://github.com/user-attachments/assets/c47442ff-f27b-4505-9d4f-87fde8f1a88a)

![image](https://github.com/user-attachments/assets/54d891f6-0853-4505-9a55-cace3f0ae3ca)





