### PR TITLE
Update on DRC checks for xschem 

### DIFF
--- a/ihp-sg13g2/libs.tech/xschem/xschemrc
+++ b/ihp-sg13g2/libs.tech/xschem/xschemrc
@@ -456,6 +456,9 @@ proc fet_drc {instance symbol model w l ng } {
         if { $l < 0.13 } {
           append res "${instance} ($model): length is too small, l = $l, min l > 0.13u" \n
         }
+        if { $l > 10.0 } {
+          append res "${instance} ($model): length is too big, l = $l, min l > 10.0u" \n
+        }
       }
       {sg13_lv_pmos$} {
         if { $w < 0.13 } {
@@ -466,6 +469,9 @@ proc fet_drc {instance symbol model w l ng } {
         }
         if { $l < 0.13 } {
           append res "${instance} ($model): length is too small, l = $l, min. l > 0.13u" \n
+        }
+        if { $l > 10.0 } {
+          append res "${instance} ($model): length is too big, l = $l, min l > 10.0u" \n
         }
       }
       {sg13_hv_nmos$} {
@@ -478,6 +484,9 @@ proc fet_drc {instance symbol model w l ng } {
         if { $l < 0.45 } {
          append res "${instance} ($model): length is too small, l = $l, min. l > 0.45u" \n
         }
+        if { $l > 10.0 } {
+          append res "${instance} ($model): length is too big, l = $l, min l > 10.0u" \n
+        }
       }
       {sg13_hv_pmos$} {
         if { $w < 0.3 } {
@@ -488,6 +497,9 @@ proc fet_drc {instance symbol model w l ng } {
         }
         if { $l < 0.4 } {
           append res "${instance} ($model): length is too small, l = $l, min. l > 0.4u" \n
+        }
+        if { $l > 10.0 } {
+          append res "${instance} ($model): length is too big, l = $l, min l > 10.0u" \n
         }
       }
     } ;# switch


### PR DESCRIPTION
The file `xschemrc` modified in order to support max length DRC checks on the FET devices.
This PR solves #543 issue. 

