### PR TITLE
Remove verilogprefix for stdcells

### DIFF
--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_a21o_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_a21o_1.sym
@@ -21,7 +21,6 @@ function3="0 1 & 2 |"
 format="@name @@A1 @@A2 @@B1 @VDD @VSS @@X @prefix\\\\a21o_1"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_a21o_2.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_a21o_2.sym
@@ -20,7 +20,6 @@ K {type=primitive
 format="@name @@A1 @@A2 @@B1 @VDD @VSS @@X @prefix\\\\a21o_2"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_a21oi_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_a21oi_1.sym
@@ -21,7 +21,6 @@ function3="0 1 & 2 | ~"
 format="@name @@A1 @@A2 @@B1 @VDD @VSS @@Y @prefix\\\\a21oi_1"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_a21oi_2.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_a21oi_2.sym
@@ -20,7 +20,6 @@ K {type=primitive
 format="@name @@A1 @@A2 @@B1 @VDD @VSS @@Y @prefix\\\\a21oi_2"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_a221oi_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_a221oi_1.sym
@@ -21,7 +21,6 @@ function5="0 1 & 2 3 & 4 | | ~"
 format="@name @@A1 @@A2 @@B1 @@B2 @@C1 @VDD @VSS @@Y @prefix\\\\a221oi_1"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_a22oi_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_a22oi_1.sym
@@ -20,7 +20,6 @@ K {type=primitive
 format="@name @@A1 @@A2 @@B1 @@B2 @VDD @VSS @@Y @prefix\\\\a22oi_1"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_and2_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_and2_1.sym
@@ -21,7 +21,6 @@ function2="0 1 &"
 format="@name @@A @@B @VDD @VSS @@X @prefix\\\\and2_1"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true
 }
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_and2_2.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_and2_2.sym
@@ -20,7 +20,6 @@ K {type=primitive
 format="@name @@A @@B @VDD @VSS @@X @prefix\\\\and2_2"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_and3_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_and3_1.sym
@@ -20,7 +20,6 @@ K {type=primitive
 format="@name @@A @@B @@C @VDD @VSS @@X @prefix\\\\and3_1"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true
 function3="0 1 2 & &"}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_and3_2.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_and3_2.sym
@@ -20,7 +20,6 @@ K {type=primitive
 format="@name @@A @@B @@C @VDD @VSS @@X @prefix\\\\and3_2"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_and4_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_and4_1.sym
@@ -21,7 +21,6 @@ function4="0 1 2 3 & & &"
 format="@name @@A @@B @@C @@D @VDD @VSS @@X @prefix\\\\and4_1"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_and4_2.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_and4_2.sym
@@ -20,7 +20,6 @@ K {type=primitive
 format="@name @@A @@B @@C @@D @VDD @VSS @@X @prefix\\\\and4_2"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_buf_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_buf_1.sym
@@ -20,7 +20,6 @@ K {type=primitive
 format="@name @@A @VDD @VSS @@X @prefix\\\\buf_1"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_buf_16.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_buf_16.sym
@@ -20,7 +20,6 @@ K {type=primitive
 format="@name @@A @VDD @VSS @@X @prefix\\\\buf_16"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_buf_2.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_buf_2.sym
@@ -21,7 +21,6 @@ type=primitive
 format="@name @@A @VDD @VSS @@X @prefix\\\\buf_2"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_buf_4.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_buf_4.sym
@@ -21,7 +21,6 @@ function1="0"
 format="@name @@A @VDD @VSS @@X @prefix\\\\buf_4"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_buf_8.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_buf_8.sym
@@ -21,7 +21,6 @@ function1="0"
 format="@name @@A @VDD @VSS @@X @prefix\\\\buf_8"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_decap_4.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_decap_4.sym
@@ -19,7 +19,6 @@ K {type=primitive
 format="@name @VDD @VSS @prefix\\\\decap_4"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 T {@symname} 0 -6 0 0 0.3 0.3 {hcenter=true}
 T {@name} 75 -22 0 0 0.2 0.2 {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_decap_8.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_decap_8.sym
@@ -19,7 +19,6 @@ K {type=primitive
 format="@name @VDD @VSS @prefix\\\\decap_8"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 T {@symname} 0 -6 0 0 0.3 0.3 {hcenter=true}
 T {@name} 75 -22 0 0 0.2 0.2 {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_dfrbp_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_dfrbp_1.sym
@@ -22,7 +22,6 @@ function4="3 ~"
 format="@name @@CLK @@D @@Q @@Q_N @@RESET_B @VDD @VSS @prefix\\\\dfrbp_1"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 }
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_dfrbp_2.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_dfrbp_2.sym
@@ -19,7 +19,6 @@ K {type=primitive
 format="@name @@CLK @@D @@Q @@Q_N @@RESET_B @VDD @VSS @prefix\\\\dfrbp_2"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 }
 T {@symname} 0 -6 0 0 0.2 0.2 {hcenter=true}
 T {@name} 75 -42 0 0 0.2 0.2 {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_dlhq_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_dlhq_1.sym
@@ -21,7 +21,6 @@ function2="1 d ~ 2 & x 0 & |"
 format="@name @@D @@GATE @@Q @VDD @VSS @prefix\\\\dlhq_1"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 }
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_dlhr_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_dlhr_1.sym
@@ -22,7 +22,6 @@ function4="3 ~"
 format="@name @@D @@GATE @@Q @@Q_N @@@RESET_B VDD @VSS @prefix\\\\dlhr_1"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 }
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_dlhrq_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_dlhrq_1.sym
@@ -21,7 +21,6 @@ function3="1 d ~ 3 & x 0 & | 2 &"
 format="@name @@D @@GATE @@@Q @RESET_B @VDD @VSS @prefix\\\\dlhrq_1"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 }
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_dllr_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_dllr_1.sym
@@ -22,7 +22,6 @@ function4="3 ~"
 format="@name @@D @@GATE_N @@Q @@Q_N @@RESET_B @VDD @VSS @prefix\\\\dllr_1"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 }
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_dllrq_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_dllrq_1.sym
@@ -21,7 +21,6 @@ function3="1 d ~ 0 & x 3 & | 2 &"
 format="@name @@D @@GATE_N @@Q @@RESET_B @VDD @VSS @prefix\\\\dllrq_1"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 }
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_dlygate4sd1_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_dlygate4sd1_1.sym
@@ -20,7 +20,6 @@ K {type=primitive
 format="@name @@A @VDD @VSS @@X @prefix\\\\dlygate4sd1_1"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_dlygate4sd2_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_dlygate4sd2_1.sym
@@ -20,7 +20,6 @@ K {type=primitive
 format="@name @@A @VDD @VSS @@X @prefix\\\\dlygate4sd2_1"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_dlygate4sd3_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_dlygate4sd3_1.sym
@@ -20,7 +20,6 @@ K {type=primitive
 format="@name @@A @VDD @VSS @@X @prefix\\\\dlygate4sd3_1"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_ebufn_2.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_ebufn_2.sym
@@ -21,7 +21,6 @@ function2="0 1 ~ &"
 format="@name @@A @@TE_B @VDD @VSS @@Z @prefix\\\\ebufn_2"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_ebufn_4.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_ebufn_4.sym
@@ -20,7 +20,6 @@ K {type=primitive
 format="@name @@A @@TE_B @VDD @VSS @@Z @prefix\\\\ebufn_4"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_ebufn_8.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_ebufn_8.sym
@@ -20,7 +20,6 @@ K {type=primitive
 format="@name @@A @@TE_B @VDD @VSS @@Z @prefix\\\\ebufn_8"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_einvn_2.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_einvn_2.sym
@@ -20,7 +20,6 @@ K {type=primitive
 format="@name @@A @@TE_B @VDD @VSS @@Z @prefix\\\\einvn_2"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_einvn_4.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_einvn_4.sym
@@ -20,7 +20,6 @@ K {type=primitive
 format="@name @@A @@TE_B @VDD @VSS @@Z @prefix\\\\einvn_4"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_einvn_8.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_einvn_8.sym
@@ -20,7 +20,6 @@ K {type=primitive
 format="@name @@A @@TE_B @VDD @VSS @@Z @prefix\\\\einvn_8"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_inv_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_inv_1.sym
@@ -19,7 +19,6 @@ function1="0 ~"
 format="@name @@A @VDD @VSS @@Y @prefix\\\\inv_1"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true
 }
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_inv_16.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_inv_16.sym
@@ -20,7 +20,6 @@ K {type=primitive
 format="@name @@A @VDD @VSS @@Y @prefix\\\\inv_16"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_inv_2.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_inv_2.sym
@@ -21,7 +21,6 @@ function1="0 ~"
 format="@name @@A @VDD @VSS @@Y @prefix\\\\inv_2"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_inv_4.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_inv_4.sym
@@ -20,7 +20,6 @@ K {type=primitive
 format="@name @@A @VDD @VSS @@Y @prefix\\\\inv_4"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_inv_8.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_inv_8.sym
@@ -20,7 +20,6 @@ K {type=primitive
 format="@name @@A @VDD @VSS @@Y @prefix\\\\inv_8"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_mux2_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_mux2_1.sym
@@ -21,7 +21,6 @@ function3="0 1 2 M"
 format="@name @@A0 @@A1 @@S @VDD @VSS @@X @prefix\\\\mux2_1"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_mux2_2.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_mux2_2.sym
@@ -21,7 +21,6 @@ function3="0 1 2 M"
 format="@name @@A0 @@A1 @@S @VDD @VSS @@X @prefix\\\\mux2_2"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_mux4_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_mux4_1.sym
@@ -21,7 +21,6 @@ function6="0 1 4 M 2 3 4 M 5 M"
 format="@name @@A0 @@A1 @@A2 @@A3 @@S0 @@S1 @VDD @VSS @@X @prefix\\\\mux4_1"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nand2_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nand2_1.sym
@@ -21,7 +21,6 @@ function2="0 1 & ~"
 format="@name @@A @@B @VDD @VSS @@Y @prefix\\\\nand2_1"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true
 }
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nand2_2.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nand2_2.sym
@@ -21,7 +21,6 @@ function2="0 1 & ~"
 format="@name @@A @@B @VDD @VSS @@Y @prefix\\\\nand2_2"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nand2b_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nand2b_1.sym
@@ -20,7 +20,6 @@ K {type=primitive
 format="@name @@A_N @@B @VDD @VSS @@Y @prefix\\\\nand2b_1"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nand2b_2.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nand2b_2.sym
@@ -20,7 +20,6 @@ K {type=primitive
 format="@name @@A_N @@B @VDD @VSS @@Y @prefix\\\\nand2b_2"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nand3_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nand3_1.sym
@@ -21,7 +21,6 @@ function3="0 1 2 & & ~"
 format="@name @@A @@B @@C @VDD @VSS @@Y @prefix\\\\nand3_1"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true
 }
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nand3b_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nand3b_1.sym
@@ -20,7 +20,6 @@ K {type=primitive
 format="@name @@A_N @@B @@C @VDD @VSS @@Y @prefix\\\\nand3b_1"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nand4_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nand4_1.sym
@@ -21,7 +21,6 @@ function4="0 1 2 3 & & & ~"
 format="@name @@A @@B @@C @@D @VDD @VSS @@Y @prefix\\\\nand4_1"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nor2_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nor2_1.sym
@@ -21,7 +21,6 @@ function2="0 1 | ~"
 format="@name @@A @@B @VDD @VSS @@Y @prefix\\\\nor2_1"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nor2_2.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nor2_2.sym
@@ -21,7 +21,6 @@ function2="0 1 | ~"
 format="@name @@A @@B @VDD @VSS @@Y @prefix\\\\nor2_2"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nor2b_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nor2b_1.sym
@@ -21,7 +21,6 @@ function2="0 1 ~ | ~"
 format="@name @@A @@B_N @VDD @VSS @@Y @prefix\\\\nor2b_1"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nor2b_2.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nor2b_2.sym
@@ -20,7 +20,6 @@ K {type=primitive
 format="@name @@A @@B_N @VDD @VSS @@Y @prefix\\\\nor2b_2"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nor3_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nor3_1.sym
@@ -21,7 +21,6 @@ function3="0 1 2 | | ~"
 format="@name @@A @@B @@C @VDD @VSS @@Y @prefix\\\\nor3_1"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nor3_2.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nor3_2.sym
@@ -20,7 +20,6 @@ K {type=primitive
 format="@name @@A @@B @@C @VDD @VSS @@Y @prefix\\\\nor3_2"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nor4_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nor4_1.sym
@@ -20,7 +20,6 @@ K {type=primitive
 format="@name @@A @@B @@C @@D @VDD @VSS @@Y @prefix\\\\nor4_1"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nor4_2.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_nor4_2.sym
@@ -21,7 +21,6 @@ function4="0 1 2 3 | | | ~"
 format="@name @@A @@B @@C @@D @VDD @VSS @@Y @prefix\\\\nor4_2"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_o21ai_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_o21ai_1.sym
@@ -21,7 +21,6 @@ function3="0 1 | 2 & ~"
 format="@name @@A1 @@A2 @@B1 @VDD @VSS @@Y @prefix\\\\o21ai_1"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_or2_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_or2_1.sym
@@ -21,7 +21,6 @@ function2="0 1 |"
 format="@name @@A @@B @VDD @VSS @@X @prefix\\\\or2_1"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_or2_2.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_or2_2.sym
@@ -21,7 +21,6 @@ function2="0 1 |"
 format="@name @@A @@B @VDD @VSS @@X @prefix\\\\or2_2"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_or3_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_or3_1.sym
@@ -20,7 +20,6 @@ K {type=primitive
 format="@name @@A @@B @@C @VDD @VSS @@X @prefix\\\\or3_1"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true
 function3="0 1 2 | |"}
 V {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_or3_2.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_or3_2.sym
@@ -21,7 +21,6 @@ function3="0 1 2 | |"
 format="@name @@A @@B @@C @VDD @VSS @@X @prefix\\\\or3_2"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_or4_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_or4_1.sym
@@ -21,7 +21,6 @@ function4="0 1 2 3 | | |"
 format="@name @@A @@B @@C @@D @VDD @VSS @@X @prefix\\\\or4_1"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_or4_2.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_or4_2.sym
@@ -21,7 +21,6 @@ function4="0 1 2 3 | | |"
 format="@name @@A @@B @@C @@D @VDD @VSS @@X @prefix\\\\or4_2"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_sdfbbp_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_sdfbbp_1.sym
@@ -20,7 +20,6 @@ K {type=primitive
 format="@name @@CLK @@D @@Q @@Q_N @@@RESET_B @@SCD @@SCE @@SET_B VDD @VSS @prefix\\\\sdfbbp_1"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 }
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_xnor2_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_xnor2_1.sym
@@ -20,7 +20,6 @@ K {type=primitive
 format="@name @@A @@B @VDD @VSS @@Y @prefix\\\\xnor2_1"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true}
 V {}
 S {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_xor2_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_xor2_1.sym
@@ -21,7 +21,6 @@ function2="0 1 ^"
 format="@name @@A @@B @VDD @VSS @@X @prefix\\\\xor2_1"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
-verilogprefix=sg13g2_
 highlight=true
 }
 V {}


### PR DESCRIPTION
The additional prefix caused the exported netlist to have a double prefix such as:
sg13g2_sg13_g2_inv_1

See Issue #557

Fixes #557 

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR
