### PR TITLE
Changes in Act and GatPoly filler macro. No_Fill layers were added to

### DIFF
--- a/ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_filler_ActGatP.lym
+++ b/ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_filler_ActGatP.lym
@@ -175,7 +175,8 @@
   NWell_cpy2.size(-sep, -sep, "square_limit")
   AFil_d = NWell_cpy - NWell_cpy2
 
-  exclLayAct = AFil_c | AFil_c1 | AFil_e | AFil_d
+  exclLayAct = AFil_c | AFil_c1 | AFil_e | AFil_d | Activ_nofill
+
 
   ##########################################################################
   # CREATE GatPoly FILLER
@@ -214,7 +215,7 @@
   NWell_gp_cpy2.size(-sep, -sep, "square_limit")
   GFil_e = NWell_gp_cpy - NWell_gp_cpy2
 
-  exclLayGatP = GFil_c | GFil_d | GFil_f | GFil_e
+  exclLayGatP = GFil_c | GFil_d | GFil_f | GFil_e | GatPoly_nofill
 
   ActoutGatP = exclLayGatP - exclLayAct
   GatPoutAct = exclLayAct - exclLayGatP


### PR DESCRIPTION
Changes in Act and GatPoly filler macro `sg13g2_filler_ActGatP.lym`. no_fill layers were added to the exclusion areas.
It solves #547 issue


![image](https://github.com/user-attachments/assets/c99c70dc-1530-40b4-8ca8-f5e985c11854)
