### PR TITLE
Modifications in IO spice netlist in order to support 3 terminal resistor model

### DIFF
--- a/ihp-sg13g2/libs.ref/sg13g2_io/spice/sg13g2_io.spi
+++ b/ihp-sg13g2/libs.ref/sg13g2_io/spice/sg13g2_io.spi
@@ -88,7 +88,7 @@ Xpgate_levelup vdd iovdd vss pgate_core pgate sg13g2_LevelUp
 
 * sg13g2_SecondaryProtection
 .subckt sg13g2_SecondaryProtection iovdd iovss pad core
-XR pad core rppd l=2.0um w=1.0um
+XR pad core sub! rppd l=2.0um w=1.0um
 Xguard1 iovss sg13g2_GuardRing_P576W948HFF
 XDN iovss core dantenna l=3.1um w=0.64um
 Xguard2 iovss sg13g2_GuardRing_P456W948HFF
@@ -361,32 +361,32 @@ XDGATE iovss gate dantenna l=0.64um w=0.48um
 
 * sg13g2_RCClampResistor
 .subckt sg13g2_RCClampResistor pin1 pin2
-Xres_fing[0] pin1 conn_0_1 rppd l=20.0um w=1.0um
-Xres_fing[1] conn_0_1 conn_1_2 rppd l=20.0um w=1.0um
-Xres_fing[2] conn_1_2 conn_2_3 rppd l=20.0um w=1.0um
-Xres_fing[3] conn_2_3 conn_3_4 rppd l=20.0um w=1.0um
-Xres_fing[4] conn_3_4 conn_4_5 rppd l=20.0um w=1.0um
-Xres_fing[5] conn_4_5 conn_5_6 rppd l=20.0um w=1.0um
-Xres_fing[6] conn_5_6 conn_6_7 rppd l=20.0um w=1.0um
-Xres_fing[7] conn_6_7 conn_7_8 rppd l=20.0um w=1.0um
-Xres_fing[8] conn_7_8 conn_8_9 rppd l=20.0um w=1.0um
-Xres_fing[9] conn_8_9 conn_9_10 rppd l=20.0um w=1.0um
-Xres_fing[10] conn_9_10 conn_10_11 rppd l=20.0um w=1.0um
-Xres_fing[11] conn_10_11 conn_11_12 rppd l=20.0um w=1.0um
-Xres_fing[12] conn_11_12 conn_12_13 rppd l=20.0um w=1.0um
-Xres_fing[13] conn_12_13 conn_13_14 rppd l=20.0um w=1.0um
-Xres_fing[14] conn_13_14 conn_14_15 rppd l=20.0um w=1.0um
-Xres_fing[15] conn_14_15 conn_15_16 rppd l=20.0um w=1.0um
-Xres_fing[16] conn_15_16 conn_16_17 rppd l=20.0um w=1.0um
-Xres_fing[17] conn_16_17 conn_17_18 rppd l=20.0um w=1.0um
-Xres_fing[18] conn_17_18 conn_18_19 rppd l=20.0um w=1.0um
-Xres_fing[19] conn_18_19 conn_19_20 rppd l=20.0um w=1.0um
-Xres_fing[20] conn_19_20 conn_20_21 rppd l=20.0um w=1.0um
-Xres_fing[21] conn_20_21 conn_21_22 rppd l=20.0um w=1.0um
-Xres_fing[22] conn_21_22 conn_22_23 rppd l=20.0um w=1.0um
-Xres_fing[23] conn_22_23 conn_23_24 rppd l=20.0um w=1.0um
-Xres_fing[24] conn_23_24 conn_24_25 rppd l=20.0um w=1.0um
-Xres_fing[25] conn_24_25 pin2 rppd l=20.0um w=1.0um
+Xres_fing[0] pin1 conn_0_1 sub! rppd l=20.0um w=1.0um
+Xres_fing[1] conn_0_1 conn_1_2 sub! rppd l=20.0um w=1.0um
+Xres_fing[2] conn_1_2 conn_2_3 sub! rppd l=20.0um w=1.0um
+Xres_fing[3] conn_2_3 conn_3_4 sub! rppd l=20.0um w=1.0um
+Xres_fing[4] conn_3_4 conn_4_5 sub! rppd l=20.0um w=1.0um
+Xres_fing[5] conn_4_5 conn_5_6 sub! rppd l=20.0um w=1.0um
+Xres_fing[6] conn_5_6 conn_6_7 sub! rppd l=20.0um w=1.0um
+Xres_fing[7] conn_6_7 conn_7_8 sub! rppd l=20.0um w=1.0um
+Xres_fing[8] conn_7_8 conn_8_9 sub! rppd l=20.0um w=1.0um
+Xres_fing[9] conn_8_9 conn_9_10 sub! rppd l=20.0um w=1.0um
+Xres_fing[10] conn_9_10 conn_10_11 sub! rppd l=20.0um w=1.0um
+Xres_fing[11] conn_10_11 conn_11_12 sub! rppd l=20.0um w=1.0um
+Xres_fing[12] conn_11_12 conn_12_13 sub! rppd l=20.0um w=1.0um
+Xres_fing[13] conn_12_13 conn_13_14 sub! rppd l=20.0um w=1.0um
+Xres_fing[14] conn_13_14 conn_14_15 sub! rppd l=20.0um w=1.0um
+Xres_fing[15] conn_14_15 conn_15_16 sub! rppd l=20.0um w=1.0um
+Xres_fing[16] conn_15_16 conn_16_17 sub! rppd l=20.0um w=1.0um
+Xres_fing[17] conn_16_17 conn_17_18 sub! rppd l=20.0um w=1.0um
+Xres_fing[18] conn_17_18 conn_18_19 sub! rppd l=20.0um w=1.0um
+Xres_fing[19] conn_18_19 conn_19_20 sub! rppd l=20.0um w=1.0um
+Xres_fing[20] conn_19_20 conn_20_21 sub! rppd l=20.0um w=1.0um
+Xres_fing[21] conn_20_21 conn_21_22 sub! rppd l=20.0um w=1.0um
+Xres_fing[22] conn_21_22 conn_22_23 sub! rppd l=20.0um w=1.0um
+Xres_fing[23] conn_22_23 conn_23_24 sub! rppd l=20.0um w=1.0um
+Xres_fing[24] conn_23_24 conn_24_25 sub! rppd l=20.0um w=1.0um
+Xres_fing[25] conn_24_25 pin2 sub! rppd l=20.0um w=1.0um
 .ends sg13g2_RCClampResistor
 
 * sg13g2_GuardRing_P16000W4466HFT
@@ -778,7 +778,7 @@ Xclamp_g18 iovss off pad iovss sg13_hv_nmos l=0.6um w=4.4um
 Xclamp_g19 pad off iovss iovss sg13_hv_nmos l=0.6um w=4.4um
 XOuterRing iovdd sg13g2_GuardRing_N16000W1980HFF
 XInnerRing iovss sg13g2_GuardRing_P15280W1260HFF
-XRoff iovss off rppd l=3.54um w=0.5um
+XRoff iovss off sub! rppd l=3.54um w=0.5um
 .ends sg13g2_Clamp_N20N0D
 
 * sg13g2_Clamp_P20N0D
@@ -825,7 +825,7 @@ Xclamp_g19_r0 pad off iovdd iovdd sg13_hv_pmos l=0.6um w=6.66um
 Xclamp_g19_r1 pad off iovdd iovdd sg13_hv_pmos l=0.6um w=6.66um
 XOuterRing iovss sg13g2_GuardRing_P16000W3852HFF
 XInnerRing iovdd sg13g2_GuardRing_N15280W3132HTF
-XRoff iovdd off rppd l=12.9um w=0.5um
+XRoff iovdd off sub! rppd l=12.9um w=0.5um
 .ends sg13g2_Clamp_P20N0D
 
 * sg13g2_IOPadAnalog

--- a/ihp-sg13g2/libs.tech/ngspice/.spiceinit
+++ b/ihp-sg13g2/libs.tech/ngspice/.spiceinit
@@ -5,6 +5,7 @@
 * export PDK=ihp-sg13g2 
 
 setcs sourcepath = (  $sourcepath $PDK_ROOT/$PDK/libs.tech/ngspice/models $PDK_ROOT/ihp-sg13g2/libs.ref/sg13g2_stdcell/spice )
+setcs sourcepath = (  $sourcepath $PDK_ROOT/$PDK/libs.tech/ngspice/models $PDK_ROOT/ihp-sg13g2/libs.ref/sg13g2_io/spice )
 *echo $sourcepath
 
 *option tnom=28


### PR DESCRIPTION
 Modifications in IO spice netlist in order to support 3 terminal resistors introduced in this PR #563 and #572.  
 Also a reference to this library was added in the `ngspice`  `.spiceinit` config file.

The changes introduce `sub!` global net as followis:
```
XR1 pad core sub! rppd l=2.0um w=1.0um
``` 
If using `xschem`  a symbol of `sub!` can be added and connected to the `GDN/VSS` in your testbench. 
![image](https://github.com/user-attachments/assets/14b0f44d-8825-47dd-98df-3dad82303a91)

This will result in the annotation of a global net `sub!` in the netlist. 

```
V5 GND sub! 0
.GLOBAL GND
.GLOBAL sub!
```
This PR addresses the issue #574 
