### PR TITLE
Xschem DRC checks added for S-Varicap device.

### DIFF
--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/sg13_svaricap.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/sg13_svaricap.sym
@@ -15,8 +15,15 @@ v {xschem version=3.4.6 file_version=1.2
 }
 G {}
 K {type=capacitor
-format="@spiceprefix@name @pinlist @model W=@W L=@L Nx=@Nx"
-template="name=C1 model=sg13_hv_svaricap W=7.0e-6 L=0.3e-6 Nx=1 spiceprefix=X"
+format="@spiceprefix@name @pinlist @model w=@w l=@l Nx=@Nx"
+template="name=C1 
+model=sg13_hv_svaricap 
+w=3.74e-6 
+l=0.3e-6 
+Nx=1 
+spiceprefix=X
+"
+drc="svaricap_drc @name @symname @model @w @l @Nx"
 }
 V {}
 S {}
@@ -32,13 +39,13 @@ B 5 -42.5 -2.5 -37.5 2.5 {name=G2 dir=inout}
 B 5 -2.5 -32.5 2.5 -27.5 {name=bn dir=inout}
 B 5 37.5 -2.5 42.5 2.5 {name=G1 dir=inout}
 B 5 -2.5 27.5 2.5 32.5 {name=NW dir=inout}
-
 A 4 42.5 0 21.25 151.9275130641471 56.14497387170592 {}
 A 4 -42.5 0 21.25 331.927513064147 56.14497387170592 {}
-T {NW} -12.5 -37.5 0 0 0.15 0.15 {layer=7}
-T {bn} 5 18.75 0 0 0.15 0.15 {layer=7}
+T {NW} -17.5 -37.5 0 0 0.15 0.15 {layer=7}
+T {bn} -15 23.75 0 0 0.15 0.15 {layer=7}
 T {G1} -45 -18 0 0 0.15 0.15 {layer=7}
 T {G2} 35 -17 0 0 0.15 0.15 {layer=7}
-T {@name} 13.75 -46.25 0 0 0.2 0.2 {}
-T {@W / @L} 15 10 0 0 0.2 0.2 {layer=13}
-T {@model} 12.5 -30 0 0 0.2 0.2 {}
+T {@name} 8.75 -41.25 0 0 0.2 0.2 {}
+T {@w / @l} 5 10 0 0 0.2 0.2 {layer=13}
+T {Nx=@Nx} 5 22.5 0 0 0.2 0.2 {layer=13}
+T {@model} 10 -30 0 0 0.2 0.2 {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/sg13_svaricap.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/sg13_svaricap.sym
@@ -18,8 +18,8 @@ K {type=capacitor
 format="@spiceprefix@name @pinlist @model w=@w l=@l Nx=@Nx"
 template="name=C1 
 model=sg13_hv_svaricap 
-w=3.74e-6 
-l=0.3e-6 
+w=3.74u 
+l=0.3u 
 Nx=1 
 spiceprefix=X
 "

--- a/ihp-sg13g2/libs.tech/xschem/xschem-drc
+++ b/ihp-sg13g2/libs.tech/xschem/xschem-drc
@@ -246,11 +246,11 @@ proc svaricap_drc {instance symbol model w l Nx} {
 
 
   # Accept only the two valid (w, l) combinations
-  set valid_comb1 [expr abs($w_clean - 3.74e-6) < 1e-12 && abs($l_clean - 0.3e-6) < 1e-12]
-  set valid_comb2 [expr abs($w_clean - 9.74e-6) < 1e-12 && abs($l_clean - 0.8e-6) < 1e-12]
+  set valid_comb1 [expr abs($w_clean - 3.74) < 1e-6 && abs($l_clean - 0.3) < 1e-6]
+  set valid_comb2 [expr abs($w_clean - 9.74) < 1e-6 && abs($l_clean - 0.8) < 1e-6]
 
   if {!($valid_comb1 || $valid_comb2)} {
-    append res "${instance} ($model): Invalid (w,l) combination. Allowed: (3.74e-6, 0.3e-6) or (9.74, 0.8e-6)" \n
+    append res "${instance} ($model): Invalid (w,l) combination. Allowed: (3.74u, 0.3u) or (9.74u, 0.8u)" \n
     return $res
   }
 

--- a/ihp-sg13g2/libs.tech/xschem/xschem-drc
+++ b/ihp-sg13g2/libs.tech/xschem/xschem-drc
@@ -224,3 +224,35 @@ proc diode_drc {instance symbol model w l } {
   return $res
 }
 
+# IHP SG13G2 S-Varicap checks
+proc svaricap_drc {instance symbol model w l Nx} {
+  set res {}
+
+  # Validate Nx
+  if {![string is integer -strict $Nx] || $Nx < 1 || $Nx > 10} {
+    append res "${instance} ($model): Nx = $Nx is invalid, must be an integer between 1 and 10" \n
+    return $res
+  }
+
+  # Remove 'u' suffix if present
+  regsub {u$} $w {} w_clean
+  regsub {u$} $l {} l_clean
+
+  # Convert to double
+  if {![string is double $w_clean] || ![string is double $l_clean]} {
+    append res "${instance} ($model): Invalid width or length format" \n
+    return $res
+  }
+
+
+  # Accept only the two valid (w, l) combinations
+  set valid_comb1 [expr abs($w_clean - 3.74e-6) < 1e-12 && abs($l_clean - 0.3e-6) < 1e-12]
+  set valid_comb2 [expr abs($w_clean - 9.74e-6) < 1e-12 && abs($l_clean - 0.8e-6) < 1e-12]
+
+  if {!($valid_comb1 || $valid_comb2)} {
+    append res "${instance} ($model): Invalid (w,l) combination. Allowed: (3.74e-6, 0.3e-6) or (9.74, 0.8e-6)" \n
+    return $res
+  }
+
+  return $res
+}


### PR DESCRIPTION
DRC checks for `xschem` added.
Symbol for `S-Varicap` slightly modified.
This PR addresses the issue #577 

