### PR TITLE
nmos_cl symbols for xschem updated

### DIFF
--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/nmoscl_2.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/nmoscl_2.sym
@@ -30,8 +30,8 @@ E {}
 L 4 0 -30 0 -5 {}
 L 4 0 5 0 30 {}
 L 4 -10 -5 10 -5 {}
-B 5 -2.5 -32.5 2.5 -27.5 {name=vdd dir=inout pinnumber=2}
-B 5 -2.5 27.5 2.5 32.5 {name=vss dir=inout propag=1}
+B 5 -2.5 27.5 2.5 32.5 {name=vss dir=inout sim_pinnumber=1}
+B 5 -2.5 -32.5 2.5 -27.5 {name=vdd dir=inout sim_pinnumber=2}
 P 4 4 0 -5 -10 5 10 5 0 -5 {fill=true}
 T {@name} 10 -7.5 2 1 0.2 0.2 {}
 T {@model} 10 2.5 2 1 0.2 0.2 {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/nmoscl_2.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/nmoscl_2.sym
@@ -30,8 +30,8 @@ E {}
 L 4 0 -30 0 -5 {}
 L 4 0 5 0 30 {}
 L 4 -10 -5 10 -5 {}
-B 5 -2.5 27.5 2.5 32.5 {name=vss dir=inout sim_pinnumber=1}
-B 5 -2.5 -32.5 2.5 -27.5 {name=vdd dir=inout sim_pinnumber=2}
+B 5 -2.5 27.5 2.5 32.5 {name=vss dir=inout sim_pinnumber=2}
+B 5 -2.5 -32.5 2.5 -27.5 {name=vdd dir=inout sim_pinnumber=1}
 P 4 4 0 -5 -10 5 10 5 0 -5 {fill=true}
 T {@name} 10 -7.5 2 1 0.2 0.2 {}
 T {@model} 10 2.5 2 1 0.2 0.2 {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/nmoscl_2.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/nmoscl_2.sym
@@ -30,8 +30,8 @@ E {}
 L 4 0 -30 0 -5 {}
 L 4 0 5 0 30 {}
 L 4 -10 -5 10 -5 {}
-B 5 -2.5 27.5 2.5 32.5 {name=vss dir=inout propag=1}
 B 5 -2.5 -32.5 2.5 -27.5 {name=vdd dir=inout pinnumber=2}
+B 5 -2.5 27.5 2.5 32.5 {name=vss dir=inout propag=1}
 P 4 4 0 -5 -10 5 10 5 0 -5 {fill=true}
 T {@name} 10 -7.5 2 1 0.2 0.2 {}
 T {@model} 10 2.5 2 1 0.2 0.2 {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/nmoscl_4.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/nmoscl_4.sym
@@ -30,8 +30,8 @@ E {}
 L 4 0 -30 0 -5 {}
 L 4 0 5 0 30 {}
 L 4 -10 -5 10 -5 {}
-B 5 -2.5 -32.5 2.5 -27.5 {name=vdd dir=inout pinnumber=2}
-B 5 -2.5 27.5 2.5 32.5 {name=vss dir=inout propag=1}
+B 5 -2.5 27.5 2.5 32.5 {name=vss dir=inout sim_pinnumber=1}
+B 5 -2.5 -32.5 2.5 -27.5 {name=vdd dir=inout sim_pinnumber=2}
 P 4 4 0 -5 -10 5 10 5 0 -5 {fill=true}
 T {@name} 10 -7.5 2 1 0.2 0.2 {}
 T {@model} 10 2.5 2 1 0.2 0.2 {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/nmoscl_4.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/nmoscl_4.sym
@@ -30,8 +30,8 @@ E {}
 L 4 0 -30 0 -5 {}
 L 4 0 5 0 30 {}
 L 4 -10 -5 10 -5 {}
-B 5 -2.5 27.5 2.5 32.5 {name=vss dir=inout sim_pinnumber=1}
-B 5 -2.5 -32.5 2.5 -27.5 {name=vdd dir=inout sim_pinnumber=2}
+B 5 -2.5 27.5 2.5 32.5 {name=vss dir=inout sim_pinnumber=2}
+B 5 -2.5 -32.5 2.5 -27.5 {name=vdd dir=inout sim_pinnumber=1}
 P 4 4 0 -5 -10 5 10 5 0 -5 {fill=true}
 T {@name} 10 -7.5 2 1 0.2 0.2 {}
 T {@model} 10 2.5 2 1 0.2 0.2 {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/nmoscl_4.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/nmoscl_4.sym
@@ -30,8 +30,8 @@ E {}
 L 4 0 -30 0 -5 {}
 L 4 0 5 0 30 {}
 L 4 -10 -5 10 -5 {}
-B 5 -2.5 27.5 2.5 32.5 {name=vss dir=inout propag=1}
 B 5 -2.5 -32.5 2.5 -27.5 {name=vdd dir=inout pinnumber=2}
+B 5 -2.5 27.5 2.5 32.5 {name=vss dir=inout propag=1}
 P 4 4 0 -5 -10 5 10 5 0 -5 {fill=true}
 T {@name} 10 -7.5 2 1 0.2 0.2 {}
 T {@model} 10 2.5 2 1 0.2 0.2 {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_esd_nmos_cl.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_esd_nmos_cl.sch
@@ -106,20 +106,20 @@ C {lab_pin.sym} 560 -1050 1 0 {name=p1 sig_type=std_logic lab=Vin1}
 C {devices/gnd.sym} 670 -910 0 0 {name=l9 lab=GND}
 C {devices/ammeter.sym} 670 -1020 0 0 {name=Vmda1}
 C {lab_pin.sym} 670 -1060 1 0 {name=p8 sig_type=std_logic lab=Vin1}
-C {sg13g2_pr/nmoscl_2.sym} 670 -950 2 1 {name=D7
-model=nmoscl_2
-m=1
-spiceprefix=X
-}
 C {isource.sym} 560 -960 2 0 {name=I0 value=1m}
 C {devices/gnd.sym} 850 -910 0 0 {name=l1 lab=GND}
 C {lab_pin.sym} 850 -1050 1 0 {name=p2 sig_type=std_logic lab=Vin2}
 C {devices/gnd.sym} 940 -910 0 0 {name=l4 lab=GND}
 C {devices/ammeter.sym} 940 -1020 0 0 {name=Vmda2}
 C {lab_pin.sym} 940 -1060 1 0 {name=p3 sig_type=std_logic lab=Vin2}
-C {sg13g2_pr/nmoscl_2.sym} 940 -950 2 1 {name=D1
+C {isource.sym} 850 -960 2 0 {name=I1 value=1m}
+C {sg13g2_pr/nmoscl_2.sym} 670 -950 2 0 {name=D1
+model=nmoscl_2
+m=1
+spiceprefix=X
+}
+C {sg13g2_pr/nmoscl_4.sym} 940 -950 2 0 {name=D2
 model=nmoscl_4
 m=1
 spiceprefix=X
 }
-C {isource.sym} 850 -960 2 0 {name=I1 value=1m}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_esd_nmos_cl.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_esd_nmos_cl.sch
@@ -5,7 +5,7 @@ V {}
 S {}
 E {}
 B 2 1030 -1700 1830 -1300 {flags=graph
-y1=-0.92
+y1=-11
 
 ypos1=0
 ypos2=2
@@ -26,11 +26,11 @@ logx=0
 logy=0
 
 
-y2=13
+y2=0.65
 color=4
 node=vin1}
 B 2 1020 -1280 1820 -880 {flags=graph
-y1=12
+y1=0.28
 
 ypos1=0
 ypos2=2
@@ -51,7 +51,7 @@ logx=0
 logy=0
 color=10
 node=vin2
-y2=13}
+y2=0.29}
 N 560 -930 560 -910 {
 lab=GND}
 N 560 -1050 560 -990 {

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests_xyce/dc_esd_nmos_cl.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests_xyce/dc_esd_nmos_cl.sch
@@ -82,22 +82,12 @@ C {lab_pin.sym} 1740 -630 1 0 {name=p1 sig_type=std_logic lab=Vin1}
 C {devices/gnd.sym} 1850 -490 0 0 {name=l9 lab=GND}
 C {devices/ammeter.sym} 1850 -600 0 0 {name=Vmda1}
 C {lab_pin.sym} 1850 -640 1 0 {name=p8 sig_type=std_logic lab=Vin1}
-C {sg13g2_pr/nmoscl_2.sym} 1850 -530 2 1 {name=D7
-model=nmoscl_2
-m=1
-spiceprefix=X
-}
 C {isource.sym} 1740 -540 2 0 {name=I0 value=0}
 C {devices/gnd.sym} 2030 -490 0 0 {name=l1 lab=GND}
 C {lab_pin.sym} 2030 -630 1 0 {name=p2 sig_type=std_logic lab=Vin2}
 C {devices/gnd.sym} 2120 -490 0 0 {name=l4 lab=GND}
 C {devices/ammeter.sym} 2120 -600 0 0 {name=Vmda2}
 C {lab_pin.sym} 2120 -640 1 0 {name=p3 sig_type=std_logic lab=Vin2}
-C {sg13g2_pr/nmoscl_2.sym} 2120 -530 2 1 {name=D1
-model=nmoscl_4
-m=1
-spiceprefix=X
-}
 C {isource.sym} 2030 -540 2 0 {name=I1 value=0}
 C {launcher.sym} 530 -1240 0 0 {name=h2
 descr=SimulateXyce
@@ -186,3 +176,13 @@ value="
 .print dc format=raw file=dc_esd_nmos_cl.raw i(Vmda1)  i(Vmda2) v(Vin1) v(Vin2) 
 "
 "}
+C {sg13g2_pr/nmoscl_2.sym} 1850 -530 2 0 {name=D1
+model=nmoscl_2
+m=1
+spiceprefix=X
+}
+C {sg13g2_pr/nmoscl_4.sym} 2120 -530 2 0 {name=D2
+model=nmoscl_4
+m=1
+spiceprefix=X
+}


### PR DESCRIPTION
Fixes #594 
Port order changed for `xschem` symbols. 