### PR TITLE
libs.tech/xschem: Fix typos in dfrbp_1 and dlhrq_1 symbols

### DIFF
--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_dfrbp_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_dfrbp_1.sym
@@ -19,7 +19,7 @@ G {}
 K {type=primitive
 function3="1 0 2 & & 0 ~ 2 3 & & |"
 function4="3 ~"
-format="@name @@Q @@Q_N @@CLK @@D@@RESET_B @VDD @VSS @prefix\\\\dfrbp_1"
+format="@name @@Q @@Q_N @@CLK @@D @@RESET_B @VDD @VSS @prefix\\\\dfrbp_1"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
 }

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_dlhrq_1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_stdcells/sg13g2_dlhrq_1.sym
@@ -18,7 +18,7 @@ v {xschem version=3.1.0 file_version=1.0
 G {}
 K {type=primitive
 function3="1 d ~ 3 & x 0 & | 2 &"
-format="@name @@Q @@D @@GATE @RESET_B @VDD @VSS @prefix\\\\dlhrq_1"
+format="@name @@Q @@D @@GATE @@RESET_B @VDD @VSS @prefix\\\\dlhrq_1"
 template="name=x1 VDD=VDD VSS=VSS prefix=sg13g2_ "
 extra="VDD VSS prefix"
 }


### PR DESCRIPTION
Obvious typos
