### PR TITLE
Corrected the magic tech file "lef" section, which was missing definitions for Via obstructions.

### DIFF
--- a/ihp-sg13g2/libs.tech/magic/ihp-sg13g2.tech
+++ b/ihp-sg13g2/libs.tech/magic/ihp-sg13g2.tech
@@ -4589,6 +4589,13 @@ obs obsm5	Metal5
 obs obsm6	TopMetal1
 obs obsm7	TopMetal2
 
+obs obsm1,obsm2	Via1
+obs obsm2,obsm3	Via2
+obs obsm3,obsm4	Via3
+obs obsm4,obsm5	Via4
+obs obsm5,obsm6	TopVia1
+obs obsm6,obsm7	TopVia2
+
 end
 
 #-----------------------------------------------------


### PR DESCRIPTION
Corrected the magic tech file "lef" section, which was missing definitions for Via obstructions.  The missing obstruction layers resulted in incorrect reading of the LEF views of the I/O cells when doing "lef read" in magic, causing pins in the I/O cells to be shorted.

Fixes #623

- [X] Tests pass
- [ ] Appropriate changes to README are included in PR

Nothing needs changing in the README file, although I just noticed that the README file does not include Magic and netgen as supported tools;  I will fix this in an upcoming unrelated pull request.

Signed-off-by: R. Timothy Edwards <tim@opencircuitdesign.com>