### PR TITLE
Qucs/stdcell: fix port order

### DIFF
--- a/ihp-sg13g2/libs.tech/qucs/user_lib/IHP_PDK_stdcells.lib
+++ b/ihp-sg13g2/libs.tech/qucs/user_lib/IHP_PDK_stdcells.lib
@@ -6,12 +6,12 @@ Author: Mike Brinson,  Feb 2024
 mbrin72043@yahoo.co.uk, or brinsonm@staff.londonmet.ac.uk
   </Description>
   <Model>
-.Def:IHP_PDK_stdcells_sg13g2_and2_1 A B VDD VSS X
+.Def:IHP_PDK_stdcells_sg13g2_and2_1 X A B VDD VSS
 .Def:End
   </Model>
   <Spice>*
-.SUBCKT IHP_PDK_stdcells_sg13g2_and2_1  gnd A B VDD VSS X 
-Xand2_1 A B VDD VSS X sg13g2_and2_1
+.SUBCKT IHP_PDK_stdcells_sg13g2_and2_1  gnd X A B VDD VSS
+Xand2_1 X A B VDD VSS sg13g2_and2_1
 .ENDS
   </Spice>
   <VerilogModel>  </VerilogModel>
@@ -26,13 +26,13 @@ Xand2_1 A B VDD VSS X sg13g2_and2_1
     <Text -115 -185 12 #000000 0 "&">
     <Line -150 -170 20 0 #000080 2 1>
     <Line -150 -130 20 0 #000080 2 1>
-    <.PortSym -150 -170 1 0>
+    <.PortSym -150 -170 2 0>
     <Text -150 -190 12 #000000 0 "A">
     <Text -150 -150 12 #000000 0 "B">
-    <.PortSym -150 -130 2 0>
-    <.PortSym -110 -210 3 0>
-    <.PortSym -110 -90 4 0>
-    <.PortSym -60 -150 5 180>
+    <.PortSym -150 -130 3 0>
+    <.PortSym -110 -210 4 0>
+    <.PortSym -110 -90 5 0>
+    <.PortSym -60 -150 1 180>
     <Text -80 -170 12 #000000 0 "X">
     <.ID -90 -76 AND>
   </Symbol>
@@ -44,12 +44,12 @@ Author: Mike Brinson,  Feb 2024
 mbrin72043@yahoo.co.uk, or brinsonm@staff.londonmet.ac.uk
   </Description>
   <Model>
-.Def:IHP_PDK_stdcells_sg13g2_and3_1 A B C VDD VSS X
+.Def:IHP_PDK_stdcells_sg13g2_and3_1 X A B C VDD VSS
 .Def:End
   </Model>
   <Spice>*
-.SUBCKT IHP_PDK_stdcells_sg13g2_and3_1  gnd A B C VDD VSS X 
-Xand3_1 A B C VDD VSS X sg13g2_and3_1
+.SUBCKT IHP_PDK_stdcells_sg13g2_and3_1  gnd X A B C VDD VSS
+Xand3_1 X A B C VDD VSS sg13g2_and3_1
 .ENDS
   </Spice>
   <VerilogModel>  </VerilogModel>
@@ -62,19 +62,19 @@ Xand3_1 A B C VDD VSS X sg13g2_and3_1
     <Text 10 -70 12 #000000 0 "VDD">
     <Text -5 -35 12 #000000 0 "&">
     <Line -40 -20 20 0 #000080 2 1>
-    <.PortSym -40 -20 1 0>
+    <.PortSym -40 -20 2 0>
     <Text -40 -40 12 #000000 0 "A">
     <Text 30 -20 12 #000000 0 "X">
     <Line -40 0 20 0 #000080 2 1>
     <Line -40 20 20 0 #000080 2 1>
-    <.PortSym -40 20 3 0>
-    <.PortSym -40 0 2 0>
+    <.PortSym -40 20 4 0>
+    <.PortSym -40 0 3 0>
     <Text -40 -20 12 #000000 0 "B">
     <Text -40 0 12 #000000 0 "C">
-    <.PortSym 0 -60 4 0>
+    <.PortSym 0 -60 5 0>
     <Text 10 50 12 #000000 0 "VSS">
-    <.PortSym 50 0 6 180>
-    <.PortSym 0 60 5 0>
+    <.PortSym 50 0 1 180>
+    <.PortSym 0 60 6 0>
     <.ID -40 84 AND>
   </Symbol>
 </Component>
@@ -85,12 +85,12 @@ Author: Mike Brinson,  Feb 2024
 mbrin72043@yahoo.co.uk, or brinsonm@staff.londonmet.ac.uk
   </Description>
   <Model>
-.Def:IHP_PDK_stdcells_sg13g2_and4_1 A B C D VDD VSS X
+.Def:IHP_PDK_stdcells_sg13g2_and4_1 X A B C D VDD VSS
 .Def:End
   </Model>
   <Spice>*
-.SUBCKT IHP_PDK_stdcells_sg13g2_and4_1  gnd A B C D VDD VSS X 
-Xand4_1 A B C D VDD VSS X sg13g2_and4_1
+.SUBCKT IHP_PDK_stdcells_sg13g2_and4_1  gnd X A B C D VDD VSS
+Xand4_1 X A B C D VDD VSS sg13g2_and4_1
 .ENDS
   </Spice>
   <VerilogModel>  </VerilogModel>
@@ -101,23 +101,23 @@ Xand4_1 A B C D VDD VSS X sg13g2_and4_1
     <Text 10 -70 12 #000000 0 "VDD">
     <Text -5 -35 12 #000000 0 "&">
     <Line -40 -20 20 0 #000080 2 1>
-    <.PortSym -40 -20 1 0>
+    <.PortSym -40 -20 2 0>
     <Text -40 -40 12 #000000 0 "A">
     <Line -40 0 20 0 #000080 2 1>
     <Line -40 20 20 0 #000080 2 1>
-    <.PortSym -40 20 3 0>
-    <.PortSym -40 0 2 0>
+    <.PortSym -40 20 4 0>
+    <.PortSym -40 0 3 0>
     <Text -40 -20 12 #000000 0 "B">
     <Text -40 0 12 #000000 0 "C">
     <Line -40 40 20 0 #000080 2 1>
-    <.PortSym -40 40 4 0>
+    <.PortSym -40 40 5 0>
     <Text -40 20 12 #000000 0 "D">
-    <.PortSym 0 -60 5 0>
+    <.PortSym 0 -60 6 0>
     <Line 0 80 0 -20 #000080 2 1>
-    <.PortSym 0 80 6 0>
+    <.PortSym 0 80 7 0>
     <Text 10 70 12 #000000 0 "VSS">
     <Line 20 10 30 0 #000080 2 1>
-    <.PortSym 50 10 7 180>
+    <.PortSym 50 10 1 180>
     <Text 30 -20 12 #000000 0 "X">
     <.ID 50 24 AND>
   </Symbol>
@@ -129,12 +129,12 @@ Author: Mike Brinson,  Feb 2024
 mbrin72043@yahoo.co.uk, or brinsonm@staff.londonmet.ac.uk
   </Description>
   <Model>
-.Def:IHP_PDK_stdcells_sg13g2_buf_1 A VDD VSS X
+.Def:IHP_PDK_stdcells_sg13g2_buf_1 X A VDD VSS
 .Def:End
   </Model>
   <Spice>*
-.SUBCKT IHP_PDK_stdcells_sg13g2_buf_1  gnd A VDD VSS X 
-Xbuf_1 A  VDD VSS X sg13g2_buf_1
+.SUBCKT IHP_PDK_stdcells_sg13g2_buf_1 gnd X A VDD VSS
+Xbuf_1 X A VDD VSS sg13g2_buf_1
 .ENDS
   </Spice>
   <VerilogModel>  </VerilogModel>
@@ -150,11 +150,11 @@ Xbuf_1 A  VDD VSS X sg13g2_buf_1
     <Text 30 -20 12 #000000 0 "X">
     <Line -40 0 20 0 #000080 2 1>
     <Text -40 -20 12 #000000 0 "A">
-    <.PortSym -40 0 1 0>
-    <.PortSym 0 -60 2 0>
-    <.PortSym 0 60 3 0>
+    <.PortSym -40 0 2 0>
+    <.PortSym 0 -60 3 0>
+    <.PortSym 0 60 4 0>
     <.ID 60 24 BUF>
-    <.PortSym 50 0 4 180>
+    <.PortSym 50 0 1 180>
   </Symbol>
 </Component>
 
@@ -164,12 +164,12 @@ Author: Mike Brinson,  Feb 2024
 mbrin72043@yahoo.co.uk, or brinsonm@staff.londonmet.ac.uk
   </Description>
   <Model>
-.Def:IHP_PDK_stdcells_sg13g2_inv_1 A VDD VSS Y
+.Def:IHP_PDK_stdcells_sg13g2_inv_1 Y A VDD VSS
 .Def:End
   </Model>
   <Spice>*
-.SUBCKT IHP_PDK_stdcells_sg13g2_inv_1  gnd A VDD VSS Y 
-Xinv_1 A VDD VSS Y sg13g2_inv_1
+.SUBCKT IHP_PDK_stdcells_sg13g2_inv_1  gnd Y A VDD VSS
+Xinv_1 Y A VDD VSS sg13g2_inv_1
 .ENDS
   </Spice>
   <VerilogModel>  </VerilogModel>
@@ -181,14 +181,14 @@ Xinv_1 A VDD VSS Y sg13g2_inv_1
     <Ellipse 20 -5 10 10 #ff0000 3 1 #c0c0c0 1 0>
     <Line 30 0 20 0 #000080 2 1>
     <Text 10 -70 12 #000000 0 "VDD">
-    <.PortSym 0 60 3 0>
+    <.PortSym 0 60 4 0>
     <Text 10 50 12 #000000 0 "VSS">
     <Text 30 -30 12 #000000 0 "Y">
     <Text -40 -30 12 #000000 0 "A">
     <Text -5 -35 12 #000000 0 "1">
-    <.PortSym -40 0 1 0>
-    <.PortSym 50 0 4 180>
-    <.PortSym 0 -60 2 0>
+    <.PortSym -40 0 2 0>
+    <.PortSym 50 0 1 180>
+    <.PortSym 0 -60 3 0>
     <Rectangle -20 -40 40 80 #ff0000 3 1 #c0c0c0 1 0>
     <.ID 50 24 INV>
   </Symbol>
@@ -200,12 +200,12 @@ Author: Mike Brinson,  Feb 2024
 mbrin72043@yahoo.co.uk, or brinsonm@staff.londonmet.ac.uk
   </Description>
   <Model>
-.Def:IHP_PDK_stdcells_sg13g2_mux2_1 A0 A1 S VDD VSS X
+.Def:IHP_PDK_stdcells_sg13g2_mux2_1 X A0 A1 S VDD VSS
 .Def:End
   </Model>
   <Spice>*
-.SUBCKT IHP_PDK_stdcells_sg13g2_mux2_1  gnd A0 A1 S VDD VSS X 
-Xmux2_1 A0 A1 S VDD VSS X sg13g2_mux2_1
+.SUBCKT IHP_PDK_stdcells_sg13g2_mux2_1  gnd X A0 A1 S VDD VSS
+Xmux2_1 X A0 A1 S VDD VSS sg13g2_mux2_1
 .ENDS
   </Spice>
   <VerilogModel>  </VerilogModel>
@@ -213,23 +213,23 @@ Xmux2_1 A0 A1 S VDD VSS X sg13g2_mux2_1
   <Symbol>
     <Rectangle -20 -40 60 80 #ff0000 3 1 #c0c0c0 1 0>
     <Line -40 -20 20 0 #000080 2 1>
-    <.PortSym -40 -20 1 0>
+    <.PortSym -40 -20 2 0>
     <Text -40 -40 12 #000000 0 "A0">
     <Line -40 0 20 0 #000080 2 1>
     <Line -40 20 20 0 #000080 2 1>
-    <.PortSym -40 0 2 0>
+    <.PortSym -40 0 3 0>
     <Text -40 -20 12 #000000 0 "A1">
     <Line 10 -40 0 -20 #000080 2 1>
     <Line 10 60 0 -20 #000080 2 1>
     <Text 20 50 12 #000000 0 "VSS">
-    <.PortSym 10 -60 4 0>
+    <.PortSym 10 -60 5 0>
     <Text 20 -70 12 #000000 0 "VDD">
     <Line 40 0 20 0 #000080 2 1>
-    <.PortSym 60 0 6 180>
+    <.PortSym 60 0 1 180>
     <Text 50 -20 12 #000000 0 "X">
-    <.PortSym -40 20 3 0>
+    <.PortSym -40 20 4 0>
     <.ID 60 24 MUX>
-    <.PortSym 10 60 5 0>
+    <.PortSym 10 60 6 0>
     <Text 0 10 12 #000000 0 "0/1">
     <Text -15 10 12 #000000 0 "S">
     <Text -10 -35 12 #000000 0 "MUX">
@@ -242,12 +242,12 @@ Author: Mike Brinson,  Feb 2024
 mbrin72043@yahoo.co.uk, or brinsonm@staff.londonmet.ac.uk
   </Description>
   <Model>
-.Def:IHP_PDK_stdcells_sg13g2_nand2_1 A B VDD VSS Y
+.Def:IHP_PDK_stdcells_sg13g2_nand2_1 Y A B VDD VSS
 .Def:End
   </Model>
   <Spice>*
-.SUBCKT IHP_PDK_stdcells_sg13g2_nand2_1  gnd A B VDD VSS Y 
-Xnand_1 A B VDD VSS Y sg13g2_nand2_1
+.SUBCKT IHP_PDK_stdcells_sg13g2_nand2_1  gnd Y A B VDD VSS
+Xnand_1 Y A B VDD VSS sg13g2_nand2_1
 .ENDS
   </Spice>
   <VerilogModel>  </VerilogModel>
@@ -264,13 +264,13 @@ Xnand_1 A B VDD VSS Y sg13g2_nand2_1
     <Text -5 -35 12 #000000 0 "&">
     <Line -40 -20 20 0 #000080 2 1>
     <Line -40 20 20 0 #000080 2 1>
-    <.PortSym -40 -20 1 0>
+    <.PortSym -40 -20 2 0>
     <Text -40 -40 12 #000000 0 "A">
     <Text -40 0 12 #000000 0 "B">
-    <.PortSym -40 20 2 0>
-    <.PortSym 0 -60 3 0>
-    <.PortSym 0 60 4 0>
-    <.PortSym 50 0 5 180>
+    <.PortSym -40 20 3 0>
+    <.PortSym 0 -60 4 0>
+    <.PortSym 0 60 5 0>
+    <.PortSym 50 0 1 180>
     <.ID 50 14 NAND>
   </Symbol>
 </Component>
@@ -281,12 +281,12 @@ Author: Mike Brinson,  Feb 2024
 mbrin72043@yahoo.co.uk, or brinsonm@staff.londonmet.ac.uk
   </Description>
   <Model>
-.Def:Nand3R4_sg13g2_nand3_1 A B C VDD VSS Y
+.Def:Nand3R4_sg13g2_nand3_1 Y A B C VDD VSS
 .Def:End
   </Model>
   <Spice>*
-.SUBCKT Nand3R4_sg13g2_nand3_1  gnd A B C VDD VSS Y 
-Xnand3_1 A B C VDD VSS Y sg13g2_nand3_1
+.SUBCKT Nand3R4_sg13g2_nand3_1  gnd Y A B C VDD VSS
+Xnand3_1 Y A B C VDD VSS sg13g2_nand3_1
 .ENDS
   </Spice>
   <VerilogModel>  </VerilogModel>
@@ -298,22 +298,22 @@ Xnand3_1 A B C VDD VSS Y sg13g2_nand3_1
     <Text 10 -70 12 #000000 0 "VDD">
     <Text -5 -35 12 #000000 0 "&">
     <Line -40 -20 20 0 #000080 2 1>
-    <.PortSym -40 -20 1 0>
+    <.PortSym -40 -20 2 0>
     <Text -40 -40 12 #000000 0 "A">
     <Line -40 0 20 0 #000080 2 1>
     <Line -40 20 20 0 #000080 2 1>
-    <.PortSym -40 20 3 0>
-    <.PortSym -40 0 2 0>
+    <.PortSym -40 20 4 0>
+    <.PortSym -40 0 3 0>
     <Text -40 -20 12 #000000 0 "B">
     <Text -40 0 12 #000000 0 "C">
-    <.PortSym 0 -60 4 0>
+    <.PortSym 0 -60 5 0>
     <Text 10 50 12 #000000 0 "VSS">
-    <.PortSym 50 0 6 180>
+    <.PortSym 50 0 1 180>
     <Line 30 0 20 0 #000080 2 1>
     <Ellipse 20 -5 10 10 #ff0000 3 1 #c0c0c0 1 0>
     <Text 30 -20 12 #000000 0 "Y">
     <.ID 40 14 NAND>
-    <.PortSym 0 60 5 0>
+    <.PortSym 0 60 6 0>
   </Symbol>
 </Component>
 
@@ -323,13 +323,13 @@ Author: Mike Brinson,  Feb 2024
 mbrin72043@yahoo.co.uk, or brinsonm@staff.londonmet.ac.uk
   </Description>
   <Model>
-.Def:IHP_PDK_stdcells_sg13g2_nand4_1 A B C D VDD VSS Y
+.Def:IHP_PDK_stdcells_sg13g2_nand4_1 Y A B C D VDD VSS
 .Def:End
   </Model>
   <Spice>*
 
-.SUBCKT IHP_PDK_stdcells_sg13g2_nand4_1  gnd A B C D VDD VSS Y 
-Xnand4_1 A B C D VDD VSS Y sg13g2_nand4_1
+.SUBCKT IHP_PDK_stdcells_sg13g2_nand4_1 gnd Y A B C D VDD VSS
+Xnand4_1 Y A B C D VDD VSS sg13g2_nand4_1
 .ENDS
   </Spice>
   <VerilogModel>  </VerilogModel>
@@ -339,26 +339,26 @@ Xnand4_1 A B C D VDD VSS Y sg13g2_nand4_1
     <Text 10 -70 12 #000000 0 "VDD">
     <Text -5 -35 12 #000000 0 "&">
     <Line -40 -20 20 0 #000080 2 1>
-    <.PortSym -40 -20 1 0>
+    <.PortSym -40 -20 2 0>
     <Text -40 -40 12 #000000 0 "A">
     <Line -40 0 20 0 #000080 2 1>
     <Line -40 20 20 0 #000080 2 1>
-    <.PortSym -40 20 3 0>
-    <.PortSym -40 0 2 0>
+    <.PortSym -40 20 4 0>
+    <.PortSym -40 0 3 0>
     <Text -40 -20 12 #000000 0 "B">
     <Text -40 0 12 #000000 0 "C">
     <Text 30 -20 12 #000000 0 "Y">
-    <.PortSym -40 40 4 0>
-    <.PortSym 0 -60 5 0>
+    <.PortSym -40 40 5 0>
+    <.PortSym 0 -60 6 0>
     <Rectangle -20 -40 40 100 #ff0000 3 1 #c0c0c0 1 0>
     <Line 0 80 0 -20 #000080 2 1>
-    <.PortSym 0 80 6 0>
+    <.PortSym 0 80 7 0>
     <Text 10 60 12 #000000 0 "VSS">
     <Line -40 40 20 0 #000080 2 1>
     <Text -40 20 12 #000000 0 "D">
     <Ellipse 20 5 10 10 #ff0000 3 1 #c0c0c0 1 0>
     <Line 30 10 20 0 #000080 2 1>
-    <.PortSym 50 10 7 180>
+    <.PortSym 50 10 1 180>
     <.ID 50 34 NAND>
   </Symbol>
 </Component>
@@ -369,12 +369,12 @@ Author: Mike Brinson,  Feb 2024
 mbrin72043@yahoo.co.uk, or brinsonm@staff.londonmet.ac.uk
   </Description>
   <Model>
-.Def:IHP_PDK_stdcells_sg13g2_nor2_1 A B VDD VSS Y
+.Def:IHP_PDK_stdcells_sg13g2_nor2_1 Y A B VDD VSS
 .Def:End
   </Model>
   <Spice>*
-.SUBCKT IHP_PDK_stdcells_sg13g2_nor2_1  gnd A B VDD VSS Y 
-Xnor2_1 A B VDD VSS Y sg13g2_nor2_1
+.SUBCKT IHP_PDK_stdcells_sg13g2_nor2_1 gnd Y A B VDD VSS
+Xnor2_1 Y A B VDD VSS sg13g2_nor2_1
 .ENDS
   </Spice>
   <VerilogModel>  </VerilogModel>
@@ -390,13 +390,13 @@ Xnor2_1 A B VDD VSS Y sg13g2_nor2_1
     <Text 30 -30 12 #000000 0 "Y">
     <Line -40 -20 20 0 #000080 2 1>
     <Line -40 20 20 0 #000080 2 1>
-    <.PortSym -40 -20 1 0>
+    <.PortSym -40 -20 2 0>
     <Text -40 -40 12 #000000 0 "A">
     <Text -40 0 12 #000000 0 "B">
-    <.PortSym -40 20 2 0>
-    <.PortSym 0 -60 3 0>
-    <.PortSym 0 60 4 0>
-    <.PortSym 50 0 5 180>
+    <.PortSym -40 20 3 0>
+    <.PortSym 0 -60 4 0>
+    <.PortSym 0 60 5 0>
+    <.PortSym 50 0 1 180>
     <.ID 50 14 NOR>
     <Text -10 -35 12 #ff0000 0 "   1">
     <Line -10 -30 10 5 #ff0000 3 1>
@@ -412,12 +412,12 @@ Author: Mike Brinson,  Feb 2024
 mbrin72043@yahoo.co.uk, or brinsonm@staff.londonmet.ac.uk
   </Description>
   <Model>
-.Def:V_sg13g2_nor3_1 A B C VDD VSS Y
+.Def:V_sg13g2_nor3_1 Y A B C VDD VSS
 .Def:End
   </Model>
   <Spice>*
-.SUBCKT IHP_PDK_stdcells_sg13g2_nor3_1  gnd A B C VDD VSS Y 
-Xnor3_1 A B C VDD VSS Y sg13g2_nor3_1
+.SUBCKT IHP_PDK_stdcells_sg13g2_nor3_1 gnd Y A B C VDD VSS
+Xnor3_1 Y A B C VDD VSS sg13g2_nor3_1
 .ENDS
   </Spice>
   <VerilogModel>  </VerilogModel>
@@ -428,17 +428,17 @@ Xnor3_1 A B C VDD VSS Y sg13g2_nor3_1
     <Line 0 -40 0 -20 #000080 2 1>
     <Text 10 -70 12 #000000 0 "VDD">
     <Line -40 -20 20 0 #000080 2 1>
-    <.PortSym -40 -20 1 0>
+    <.PortSym -40 -20 2 0>
     <Text -40 -40 12 #000000 0 "A">
     <Line -40 0 20 0 #000080 2 1>
     <Line -40 20 20 0 #000080 2 1>
-    <.PortSym -40 20 3 0>
-    <.PortSym -40 0 2 0>
+    <.PortSym -40 20 4 0>
+    <.PortSym -40 0 3 0>
     <Text -40 -20 12 #000000 0 "B">
     <Text -40 0 12 #000000 0 "C">
-    <.PortSym 0 -60 4 0>
+    <.PortSym 0 -60 5 0>
     <Text 10 50 12 #000000 0 "VSS">
-    <.PortSym 50 0 6 180>
+    <.PortSym 50 0 1 180>
     <Line 30 0 20 0 #000080 2 1>
     <Ellipse 20 -5 10 10 #ff0000 3 1 #c0c0c0 1 0>
     <Text 30 -20 12 #000000 0 "Y">
@@ -447,7 +447,7 @@ Xnor3_1 A B C VDD VSS Y sg13g2_nor3_1
     <Line -10 -30 10 5 #ff0000 3 1>
     <Line 0 -25 -10 5 #ff0000 3 1>
     <Line 0 -20 -10 5 #ff0000 3 1>
-    <.PortSym 0 60 5 0>
+    <.PortSym 0 60 6 0>
   </Symbol>
 </Component>
 
@@ -456,12 +456,12 @@ Xnor3_1 A B C VDD VSS Y sg13g2_nor3_1
 Author: Mike Brinson,  Feb 2024
 mbrin72043@yahoo.co.uk, or brinsonm@staff.londonmet.ac.uk  </Description>
   <Model>
-.Def:IHP_PDK_stdcells_sg13g2_nor4_1 A B C D VDD VSS Y
+.Def:IHP_PDK_stdcells_sg13g2_nor4_1 Y A B C D VDD VSS
 .Def:End
   </Model>
   <Spice>*
-.SUBCKT IHP_PDK_stdcells_sg13g2_nor4_1  gnd A B C D VDD VSS Y 
- Xnor4_1 A B C D VDD VSS Y sg13g2_nor4_1
+.SUBCKT IHP_PDK_stdcells_sg13g2_nor4_1  gnd Y A B C D VDD VSS
+ Xnor4_1 Y A B C D VDD VSS sg13g2_nor4_1
 .ENDS
   </Spice>
   <VerilogModel>  </VerilogModel>
@@ -470,25 +470,25 @@ mbrin72043@yahoo.co.uk, or brinsonm@staff.londonmet.ac.uk  </Description>
     <Line 0 -40 0 -20 #000080 2 1>
     <Text 10 -70 12 #000000 0 "VDD">
     <Line -40 -20 20 0 #000080 2 1>
-    <.PortSym -40 -20 1 0>
+    <.PortSym -40 -20 2 0>
     <Text -40 -40 12 #000000 0 "A">
     <Line -40 0 20 0 #000080 2 1>
     <Line -40 20 20 0 #000080 2 1>
-    <.PortSym -40 20 3 0>
-    <.PortSym -40 0 2 0>
+    <.PortSym -40 20 4 0>
+    <.PortSym -40 0 3 0>
     <Text -40 -20 12 #000000 0 "B">
     <Text -40 0 12 #000000 0 "C">
     <Text 30 -20 12 #000000 0 "Y">
-    <.PortSym -40 40 4 0>
-    <.PortSym 0 -60 5 0>
+    <.PortSym -40 40 5 0>
+    <.PortSym 0 -60 6 0>
     <Rectangle -20 -40 40 100 #ff0000 3 1 #c0c0c0 1 0>
     <Line 0 80 0 -20 #000080 2 1>
-    <.PortSym 0 80 6 0>
+    <.PortSym 0 80 7 0>
     <Line -40 40 20 0 #000080 2 1>
     <Text -40 20 12 #000000 0 "D">
     <Ellipse 20 5 10 10 #ff0000 3 1 #c0c0c0 1 0>
     <Line 30 10 20 0 #000080 2 1>
-    <.PortSym 50 10 7 180>
+    <.PortSym 50 10 1 180>
     <.ID 50 34 NOR>
     <Line -10 -30 10 5 #ff0000 3 1>
     <Line 0 -25 -10 5 #ff0000 3 1>
@@ -504,12 +504,12 @@ Author: Mike Brinson,  Feb 2024
 mbrin72043@yahoo.co.uk, or brinsonm@staff.londonmet.ac.uk
   </Description>
   <Model>
-.Def:IHP_PDK_stdcells_sg13g2_or2_1 A B VDD VSS X
+.Def:IHP_PDK_stdcells_sg13g2_or2_1 X A B VDD VSS
 .Def:End
   </Model>
   <Spice>*
-.SUBCKT IHP_PDK_stdcells_sg13g2_or2_1  gnd A B VDD VSS X 
-Xor2_1 A B VDD VSS X sg13g2_or2_1
+.SUBCKT IHP_PDK_stdcells_sg13g2_or2_1 gnd X A B VDD VSS
+Xor2_1 X A B VDD VSS sg13g2_or2_1
 .ENDS
   </Spice>
   <VerilogModel>  </VerilogModel>
@@ -524,13 +524,13 @@ Xor2_1 A B VDD VSS X sg13g2_or2_1
     <Text 30 -30 12 #000000 0 "X">
     <Line -40 -20 20 0 #000080 2 1>
     <Line -40 20 20 0 #000080 2 1>
-    <.PortSym -40 -20 1 0>
+    <.PortSym -40 -20 2 0>
     <Text -40 -40 12 #000000 0 "A">
     <Text -40 0 12 #000000 0 "B">
-    <.PortSym -40 20 2 0>
-    <.PortSym 0 -60 3 0>
-    <.PortSym 0 60 4 0>
-    <.PortSym 50 0 5 180>
+    <.PortSym -40 20 3 0>
+    <.PortSym 0 -60 4 0>
+    <.PortSym 0 60 5 0>
+    <.PortSym 50 0 1 180>
     <.ID 50 14 OR>
     <Text -10 -40 12 #ff0000 0 "   1">
     <Line -10 -35 10 5 #ff0000 3 1>


### PR DESCRIPTION
What?
---
This synchronizes the port order between the Qucs' stdcell port order and the `sg13g2_stdcell.spice` port order.

Why?
---
The port order got changed as part of #553 

Changes
---
1. Port order/definition changed accordingly
2. Indexing of `PortSym` is rotated by 1 to match the port order