### PR TITLE
Klayout DRC Updates

### DIFF
--- a/ihp-sg13g2/libs.tech/klayout/tech/drc/rule_decks/antenna.drc
+++ b/ihp-sg13g2/libs.tech/klayout/tech/drc/rule_decks/antenna.drc
@@ -91,10 +91,6 @@ def setup_run_mode(run_mode)
   end
 end
 
-# Run mode
-setup_run_mode($run_mode)
-logger.info("#{$run_mode} mode is enabled for #{TABLE_NAME} table.")
-
 #================================================
 #------------- LAYERS DEFINITIONS ---------------
 #================================================

--- a/ihp-sg13g2/libs.tech/klayout/tech/drc/run_drc.py
+++ b/ihp-sg13g2/libs.tech/klayout/tech/drc/run_drc.py
@@ -542,8 +542,7 @@ def build_switches_string(sws: dict) -> str:
     str
         A space-separated string of -rd key=value pairs.
     """
-    return " ".join(f"-rd {k}={v}" for k, v in sws.items())
-
+    return " ".join(f"-rd {k}='{v}'" for k, v in sws.items())
 
 def run_check(
     drc_file: str,
@@ -590,7 +589,7 @@ def run_check(
     sws_str = build_switches_string(new_sws)
     sws_str += f" -rd table_name={drc_table}"
 
-    run_cmd = f"klayout -b -r {drc_file} {sws_str}"
+    run_cmd = f"klayout -b -r '{drc_file}' {sws_str}"
     check_call(run_cmd, shell=True)
 
     return str(report_path)

--- a/ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_drc.lym
+++ b/ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_drc.lym
@@ -137,10 +137,10 @@ end
 
 # Extract and format options
 cmd_opts = [
-  "--path=#{gds_path}",
+  "--path='#{gds_path}'",
   "--run_mode=#{options['run_mode']}",
-  "--topcell=#{top_cell}",
-  "--run_dir=#{run_dir}",
+  "--topcell='#{top_cell}'",
+  "--run_dir='#{run_dir}'",
   "--mp=#{options['parallel_runs']}",
   "--density_thr=#{options['density_thr']}"
 ]
@@ -149,7 +149,7 @@ cmd_opts = [
   cmd_opts &lt;&lt; "--#{flag}" if options[flag]
 end
 
-cmd_opts &lt;&lt; "--table=#{options['table']}" if options['table'] &amp;&amp; !options['table'].empty? &amp;&amp; options['table'] != 'all'
+cmd_opts &lt;&lt; "--table='#{options['table']}'" if options['table'] &amp;&amp; !options['table'].empty? &amp;&amp; options['table'] != 'all'
 
 # Run DRC with options
 cmd = "nohup python3 #{File.join(project_root, 'drc', 'run_drc.py')} #{cmd_opts.join(' ')}"


### PR DESCRIPTION
- Fixes #656 
    - Cleaning up the antenna rule deck placeholder; this file will be updated once antenna checks are supported.

- Fixes #654
   - Supporting using spaces in the drc options for GUI run
