### PR TITLE
klayout(metal density fill): exlude `NoMetFiller:drawing`

### DIFF
--- a/ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_filler_Metal.lym
+++ b/ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_filler_Metal.lym
@@ -266,7 +266,7 @@
 	M1Fil_c.size(0.42, 0.42, "square_limit")
 	M1Fil_d = TRANS.dup
 	M1Fil_d.size(1.0, 1.0, "square_limit")
-	M1Fil = EdgeSeal.holes - (M1Fil_b | M1Fil_c | M1Fil_d | Metal1_nofill | Metal1_slit | TRANS)
+	M1Fil = EdgeSeal.holes - (M1Fil_b | M1Fil_c | M1Fil_d | Metal1_nofill | Metal1_slit | TRANS | NoMetFiller)
 	M1Fil_left = M1Fil.fill_with_left(pattern_m1_m, hstep(width_m1_m + distance_m1_m), vstep(height_m1_m + distance_m1_m))
 	M1Fil_left.fill(pattern_m1_s, hstep(width_m1_s + distance_m1_s), vstep(height_m1_s + distance_m1_s))
 
@@ -277,7 +277,7 @@
 	M2Fil_c.size(0.42, 0.42, "square_limit")
 	M2Fil_d = TRANS.dup
 	M2Fil_d.size(1.0, 1.0, "square_limit")
-	M2Fil = EdgeSeal.holes - (M2Fil_b | M2Fil_c | M2Fil_d | Metal2_nofill | Metal2_slit | TRANS)
+	M2Fil = EdgeSeal.holes - (M2Fil_b | M2Fil_c | M2Fil_d | Metal2_nofill | Metal2_slit | TRANS | NoMetFiller)
 	M2Fil_left = M2Fil.fill_with_left(pattern_m2_m, hstep(width_m2_m + distance_m2_m), vstep(height_m2_m + distance_m2_m))
 	M2Fil_left.fill(pattern_m2_s, hstep(width_m2_s + distance_m2_s), vstep(height_m2_s + distance_m2_s))
 
@@ -288,7 +288,7 @@
 	M3Fil_c.size(0.42, 0.42, "square_limit")
 	M3Fil_d = TRANS.dup
 	M3Fil_d.size(1.0, 1.0, "square_limit")
-	M3Fil = EdgeSeal.holes - (M3Fil_b | M3Fil_c | M3Fil_d | Metal3_nofill | Metal3_slit | TRANS)
+	M3Fil = EdgeSeal.holes - (M3Fil_b | M3Fil_c | M3Fil_d | Metal3_nofill | Metal3_slit | TRANS | NoMetFiller)
 	M3Fil_left = M3Fil.fill_with_left(pattern_m3_m, hstep(width_m3_m + distance_m3_m), vstep(height_m3_m + distance_m3_m))
 	M3Fil_left.fill(pattern_m3_s, hstep(width_m3_s + distance_m3_s), vstep(height_m3_s + distance_m3_s))
 
@@ -299,7 +299,7 @@
 	M4Fil_c.size(0.42, 0.42, "square_limit")
 	M4Fil_d = TRANS.dup
 	M4Fil_d.size(1.0, 1.0, "square_limit")
-	M4Fil = EdgeSeal.holes - (M4Fil_b | M4Fil_c | M4Fil_d | Metal4_nofill | Metal4_slit | TRANS)
+	M4Fil = EdgeSeal.holes - (M4Fil_b | M4Fil_c | M4Fil_d | Metal4_nofill | Metal4_slit | TRANS | NoMetFiller)
 	M4Fil_left = M4Fil.fill_with_left(pattern_m4_m, hstep(width_m4_m + distance_m4_m), vstep(height_m4_m + distance_m4_m))
 	M4Fil_left.fill(pattern_m4_s, hstep(width_m4_s + distance_m4_s), vstep(height_m4_s + distance_m4_s))
 
@@ -310,7 +310,7 @@
 	M5Fil_c.size(0.42, 0.42, "square_limit")
 	M5Fil_d = TRANS.dup
 	M5Fil_d.size(1.0, 1.0, "square_limit")
-	M5Fil = EdgeSeal.holes - (M5Fil_b | M5Fil_c | M5Fil_d | Metal5_nofill | Metal5_slit | TRANS)
+	M5Fil = EdgeSeal.holes - (M5Fil_b | M5Fil_c | M5Fil_d | Metal5_nofill | Metal5_slit | TRANS | NoMetFiller)
 	M5Fil_left = M5Fil.fill_with_left(pattern_m5_m, hstep(width_m5_m + distance_m5_m), vstep(height_m5_m + distance_m5_m))
 	M5Fil_left.fill(pattern_m5_s, hstep(width_m5_s + distance_m5_s), vstep(height_m5_s + distance_m5_s))
 	</text>

--- a/ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_filler_TopMetal.lym
+++ b/ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_filler_TopMetal.lym
@@ -125,13 +125,13 @@
 	TM1Fil_c.size(3.0, 3.0, "square_limit")
 	TM1Fil_d = TRANS.dup
 	TM1Fil_d.size(4.9, 4.9, "square_limit")
-	exclLayTM1 = TM1Fil_c | TM1Fil_d | TopMetal1_filler | TopMetal1_nofill | TopMetal1_slit | TRANS
+	exclLayTM1 = TM1Fil_c | TM1Fil_d | TopMetal1_filler | TopMetal1_nofill | TopMetal1_slit | TRANS | NoMetFiller
 
 	TM2Fil_c = TopMetal2.dup
 	TM2Fil_c.size(3.0, 3.0, "square_limit")
 	TM2Fil_d = TRANS.dup
 	TM2Fil_d.size(4.9, 4.9, "square_limit")
-	exclLayTM2 = TM2Fil_c | TM2Fil_d | TopMetal2_filler | TopMetal2_nofill | TopMetal2_slit | TRANS
+	exclLayTM2 = TM2Fil_c | TM2Fil_d | TopMetal2_filler | TopMetal2_nofill | TopMetal2_slit | TRANS | NoMetFiller
 
 	# perform fill
 	(EdgeSeal.holes - exclLayTM1).fill(pattern_tm1, hstep(width + distance), vstep(height + distance))


### PR DESCRIPTION
# What

This adds the `noMetFiller:drawing` layer as part of the exclusion layers when doing metal density fill

# Why

According to the manual:

> **Metal(n):filler** must be generated prior to the tape out procedure. For sensitive areas of the circuit,
designers should exclude Metal(n):filler using the **Metal(n):nofill** or **NoMetFiller** exclusion layer, or
should place defined metal structures to prevent metal fill.

Hence, the expectation is that the `NoMetFiller:drawing` is supposed to be part of the exclusion layers.


# Comparison

Reference:
---
<img width="515" height="493" alt="image" src="https://github.com/user-attachments/assets/05b394a5-ab24-4836-8032-f8cf4801b748" />

As reference I used an edge-seal cut-out with an outer boundary of 100x100 µm and an inner box with `NoMetFiller:drawing` of 50x50 µm centered at (50, 50) µm.

---

<img width="45%" height="521" alt="image" src="https://github.com/user-attachments/assets/e545b2bd-b3d3-49ba-9b56-be0c593efae6" />

<img width="45%" height="641" alt="image" src="https://github.com/user-attachments/assets/054f7118-be28-4937-b2e5-f17505ab281c" />

**Left:** Running metal density fill with default settings using `dev` branch
**Right:** Running metal density fill with default settings using this PR.

