### PR TITLE
klayout(metal fill): fix minimum distance check for metal layers

### DIFF
--- a/ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_filler_Metal.lym
+++ b/ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_filler_Metal.lym
@@ -173,22 +173,22 @@
 			distances['distance_m1'] = 0.42
 		end
 		distances['distance_m2'] = dialog.layout.itemAt(3).widget.text.to_f
-		if 0.42 > distances['distance_m1']
+		if 0.42 > distances['distance_m2']
 			print("M2fil.b is defined with min. 0.42. Setting 0.42 as distance for Metal2:Filler\n")
 			distances['distance_m2'] = 0.42
 		end
 		distances['distance_m3'] = dialog.layout.itemAt(5).widget.text.to_f
-		if 0.42 > distances['distance_m1']
+		if 0.42 > distances['distance_m3']
 			print("M3fil.b is defined with min. 0.42. Setting 0.42 as distance for Metal3:Filler\n")
 			distances['distance_m3'] = 0.42
 		end
 		distances['distance_m4'] = dialog.layout.itemAt(7).widget.text.to_f
-		if 0.42 > distances['distance_m1']
+		if 0.42 > distances['distance_m4']
 			print("M4fil.b is defined with min. 0.42. Setting 0.42 as distance for Metal4:Filler\n")
 			distances['distance_m4'] = 0.42
 		end
 		distances['distance_m5'] = dialog.layout.itemAt(9).widget.text.to_f
-		if 0.42 > distances['distance_m1']
+		if 0.42 > distances['distance_m5']
 			print("M5fil.b is defined with min. 0.42. Setting 0.42 as distance for Metal5:Filler\n")
 			distances['distance_m5'] = 0.42
 		end


### PR DESCRIPTION
Currently, the input checks for metal filler distances are all against `distances['distance_m1']`.

This commit fixes the checks to validate each respective metal layer's distance.
