### PR TITLE
Doc: Fix typo in comments of the standard cell techlef file

### DIFF
--- a/ihp-sg13g2/libs.ref/sg13g2_stdcell/lef/sg13g2_tech.lef
+++ b/ihp-sg13g2/libs.ref/sg13g2_stdcell/lef/sg13g2_tech.lef
@@ -425,7 +425,7 @@ Via  Via1_s DEFAULT
       RECT -0.19 -0.19 0.19 0.19 ;
   END Via1_s
 
-####### Definitions of Via1 duoble cut ########
+####### Definitions of Via1 double cut ########
 
 Via Via1_DC1B DEFAULT
     RESISTANCE 20.0 ;
@@ -616,7 +616,7 @@ Via  Via2_s DEFAULT
       RECT -0.19 -0.19 0.19 0.19 ;
   END Via2_s
 
-#######  Definitions of Via2 duoble cut ##############
+#######  Definitions of Via2 double cut ##############
 
 Via Via2_DC1B DEFAULT
     RESISTANCE 20.0 ;
@@ -807,7 +807,7 @@ Via  Via3_s DEFAULT
       RECT -0.19 -0.19 0.19 0.19 ;
   END Via3_s
 
-#######  Definitions of Via3 duoble cut ##############
+#######  Definitions of Via3 double cut ##############
 
 Via Via3_DC1B DEFAULT
     RESISTANCE 20.0 ;
@@ -998,7 +998,7 @@ Via  Via4_s DEFAULT
       RECT -0.19 -0.19 0.19 0.19 ;
   END Via4_s
 
-#######  Definitions of Via4 duoble cut ##############
+#######  Definitions of Via4 double cut ##############
 
 Via Via4_DC1B DEFAULT
     RESISTANCE 20.0 ;


### PR DESCRIPTION
Fixes a small typo I stumbled upon when looking at the standard cell techlef file. Just changes `duoble` to `double` in the comments/headers of the double cut via definitions.


