### PR TITLE
lv and hv mos: Split ngspice simulation library for cmos and rf-cmos applications

### DIFF
--- a/ihp-sg13g2/libs.tech/ngspice/.spiceinit
+++ b/ihp-sg13g2/libs.tech/ngspice/.spiceinit
@@ -24,6 +24,7 @@ setcs sourcepath = (  $sourcepath $PDK_ROOT/$PDK/libs.tech/ngspice/models $PDK_R
 *set noinit
 
 * add OSDI 
+osdi  '$PDK_ROOT/$PDK/libs.tech/ngspice/osdi/psp103.osdi'
 osdi  '$PDK_ROOT/$PDK/libs.tech/ngspice/osdi/psp103_nqs.osdi'
 osdi  '$PDK_ROOT/$PDK/libs.tech/ngspice/osdi/r3_cmc.osdi'
 osdi  '$PDK_ROOT/$PDK/libs.tech/ngspice/osdi/mosvar.osdi'

--- a/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moshv_mod.lib
+++ b/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moshv_mod.lib
@@ -71,43 +71,84 @@
 
 .include sg13g2_moshv_parm.lib
 
-.if (as <= 1e-50)
-    .if (floor(floor(ng/2+0.501)*2+0.001) != ng)
-        Nsg13_hv_nmos d g s b sg13g2_hv_nmos_psp
-          + w=w
-          + l=l
-          + nf='ng' mult='m'
-          + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
-          + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
-          + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
-          + pd='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
-          + dta=trise
-          + ngcon=2
-          + delvto=0
-          + factuo=1
+.if (rfmode == 0)
+    .if (as <= 1e-50)
+        .if (floor(floor(ng/2+0.501)*2+0.001) != ng)
+            Nsg13_hv_nmos d g s b sg13g2_hv_nmos_psp
+              + w=w
+              + l=l
+              + nf='ng' mult='m'
+              + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
+              + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
+              + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+              + pd='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+              + dta=trise
+              + ngcon=2
+              + delvto=0
+              + factuo=1
+        .else
+            Nsg13_hv_nmos d g s b sg13g2_hv_nmos_psp
+              + w=w
+              + l=l
+              + nf='ng' mult='m'
+              + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)'
+              + ad='max(w/ng,wmin)*z2/2*ng'
+              + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)'
+              + pd='(max(w/ng,wmin)+z2)*ng'
+              + dta=trise
+              + ngcon=2
+              + delvto=0
+              + factuo=1
+        .endif
     .else
         Nsg13_hv_nmos d g s b sg13g2_hv_nmos_psp
           + w=w
           + l=l
-          + nf='ng' mult='m'
-          + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)'
-          + ad='max(w/ng,wmin)*z2/2*ng'
-          + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)'
-          + pd='(max(w/ng,wmin)+z2)*ng'
+          + as='as' ad='ad' pd='pd' ps='ps' nf='ng' mult='m'
           + dta=trise
           + ngcon=2
           + delvto=0
           + factuo=1
     .endif
 .else
-    Nsg13_hv_nmos d g s b sg13g2_hv_nmos_psp
-      + w=w
-      + l=l
-      + as='as' ad='ad' pd='pd' ps='ps' nf='ng' mult='m'
-      + dta=trise
-      + ngcon=2
-      + delvto=0
-      + factuo=1
+    .if (as <= 1e-50)
+        .if (floor(floor(ng/2+0.501)*2+0.001) != ng)
+            Nsg13_hv_nmos d g s b sg13g2_hv_nmos_psp_rf
+              + w=w
+              + l=l
+              + nf='ng' mult='m'
+              + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
+              + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
+              + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+              + pd='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+              + dta=trise
+              + ngcon=2
+              + delvto=0
+              + factuo=1
+        .else
+            Nsg13_hv_nmos d g s b sg13g2_hv_nmos_psp_rf
+              + w=w
+              + l=l
+              + nf='ng' mult='m'
+              + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)'
+              + ad='max(w/ng,wmin)*z2/2*ng'
+              + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)'
+              + pd='(max(w/ng,wmin)+z2)*ng'
+              + dta=trise
+              + ngcon=2
+              + delvto=0
+              + factuo=1
+        .endif
+    .else
+        Nsg13_hv_nmos d g s b sg13g2_hv_nmos_psp_rf
+          + w=w
+          + l=l
+          + as='as' ad='ad' pd='pd' ps='ps' nf='ng' mult='m'
+          + dta=trise
+          + ngcon=2
+          + delvto=0
+          + factuo=1
+    .endif
 .endif
 .ends
 
@@ -116,42 +157,83 @@
 
 .include sg13g2_moshv_parm.lib
 
-.if (as <= 1e-50)
-    .if (floor(floor(ng/2+0.501)*2+0.001) != ng)
-        Nsg13_hv_pmos d g s b sg13g2_hv_pmos_psp
-          + w=w
-          + l=l
-          + nf='ng' mult='m'
-          + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
-          + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
-          + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
-          + pd='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
-          + dta=trise
-          + ngcon=2
-          + delvto=0
-          + factuo=1
+.if (rfmode == 0)
+    .if (as <= 1e-50)
+        .if (floor(floor(ng/2+0.501)*2+0.001) != ng)
+            Nsg13_hv_pmos d g s b sg13g2_hv_pmos_psp
+              + w=w
+              + l=l
+              + nf='ng' mult='m'
+              + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
+              + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
+              + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+              + pd='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+              + dta=trise
+              + ngcon=2
+              + delvto=0
+              + factuo=1
+        .else
+            Nsg13_hv_pmos d g s b sg13g2_hv_pmos_psp
+              + w=w
+              + l=l
+              + nf='ng' mult='m'
+              + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)'
+              + ad='max(w/ng,wmin)*z2/2*ng'
+              + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)'
+              + pd='(max(w/ng,wmin)+z2)*ng'
+              + dta=trise
+              + ngcon=2
+              + delvto=0
+              + factuo=1
+        .endif
     .else
         Nsg13_hv_pmos d g s b sg13g2_hv_pmos_psp
           + w=w
           + l=l
-          + nf='ng' mult='m'
-          + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)'
-          + ad='max(w/ng,wmin)*z2/2*ng'
-          + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)'
-          + pd='(max(w/ng,wmin)+z2)*ng'
+          + as='as' ad='ad' pd='pd' ps='ps' nf='ng' mult='m'
           + dta=trise
           + ngcon=2
           + delvto=0
           + factuo=1
     .endif
 .else
-    Nsg13_hv_pmos d g s b sg13g2_hv_pmos_psp
-      + w=w
-      + l=l
-      + as='as' ad='ad' pd='pd' ps='ps' nf='ng' mult='m'
-      + dta=trise
-      + ngcon=2
-      + delvto=0
-      + factuo=1
+    .if (as <= 1e-50)
+        .if (floor(floor(ng/2+0.501)*2+0.001) != ng)
+            Nsg13_hv_pmos d g s b sg13g2_hv_pmos_psp_rf
+              + w=w
+              + l=l
+              + nf='ng' mult='m'
+              + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
+              + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
+              + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+              + pd='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+              + dta=trise
+              + ngcon=2
+              + delvto=0
+              + factuo=1
+        .else
+            Nsg13_hv_pmos d g s b sg13g2_hv_pmos_psp_rf
+              + w=w
+              + l=l
+              + nf='ng' mult='m'
+              + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)'
+              + ad='max(w/ng,wmin)*z2/2*ng'
+              + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)'
+              + pd='(max(w/ng,wmin)+z2)*ng'
+              + dta=trise
+              + ngcon=2
+              + delvto=0
+              + factuo=1
+        .endif
+    .else
+        Nsg13_hv_pmos d g s b sg13g2_hv_pmos_psp_rf
+          + w=w
+          + l=l
+          + as='as' ad='ad' pd='pd' ps='ps' nf='ng' mult='m'
+          + dta=trise
+          + ngcon=2
+          + delvto=0
+          + factuo=1
+    .endif
 .endif
 .ends

--- a/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moshv_mod_mismatch.lib
+++ b/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moshv_mod_mismatch.lib
@@ -71,43 +71,84 @@
 
 .include sg13g2_moshv_parm.lib
 
-.if (as <= 1e-50)
-    .if (floor(floor(ng/2+0.501)*2+0.001) != ng)
-        Nsg13_hv_nmos d g s b sg13g2_hv_nmos_psp
-          + w='agauss(w, sg13g2_hv_nmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
-          + l='agauss(l, sg13g2_hv_nmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
-          + nf='ng' mult='m'
-          + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
-          + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
-          + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
-          + pd='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
-          + dta=trise
-          + ngcon=2
-          + delvto='agauss(0, sg13g2_hv_nmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
-          + factuo='agauss(1, sg13g2_hv_nmos_factuo_mm, (mm_ok != 1 ? 0 : 1))'
+.if (rfmode == 0)
+    .if (as <= 1e-50)
+        .if (floor(floor(ng/2+0.501)*2+0.001) != ng)
+            Nsg13_hv_nmos d g s b sg13g2_hv_nmos_psp
+              + w='agauss(w, sg13g2_hv_nmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
+              + l='agauss(l, sg13g2_hv_nmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
+              + nf='ng' mult='m'
+              + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
+              + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
+              + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+              + pd='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+              + dta=trise
+              + ngcon=2
+              + delvto='agauss(0, sg13g2_hv_nmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
+              + factuo='agauss(1, sg13g2_hv_nmos_factuo_mm, (mm_ok != 1 ? 0 : 1))'
+        .else
+            Nsg13_hv_nmos d g s b sg13g2_hv_nmos_psp
+              + w='agauss(w, sg13g2_hv_nmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
+              + l='agauss(l, sg13g2_hv_nmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
+              + nf='ng' mult='m'
+              + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)'
+              + ad='max(w/ng,wmin)*z2/2*ng'
+              + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)'
+              + pd='(max(w/ng,wmin)+z2)*ng'
+              + dta=trise
+              + ngcon=2
+              + delvto='agauss(0, sg13g2_hv_nmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
+              + factuo='agauss(1, sg13g2_hv_nmos_factuo_mm, (mm_ok != 1 ? 0 : 1))'
+        .endif
     .else
         Nsg13_hv_nmos d g s b sg13g2_hv_nmos_psp
           + w='agauss(w, sg13g2_hv_nmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
           + l='agauss(l, sg13g2_hv_nmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
-          + nf='ng' mult='m'
-          + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)'
-          + ad='max(w/ng,wmin)*z2/2*ng'
-          + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)'
-          + pd='(max(w/ng,wmin)+z2)*ng'
+          + as='as' ad='ad' pd='pd' ps='ps' nf='ng' mult='m'
           + dta=trise
           + ngcon=2
           + delvto='agauss(0, sg13g2_hv_nmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
           + factuo='agauss(1, sg13g2_hv_nmos_factuo_mm, (mm_ok != 1 ? 0 : 1))'
     .endif
 .else
-    Nsg13_hv_nmos d g s b sg13g2_hv_nmos_psp
-      + w='agauss(w, sg13g2_hv_nmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
-      + l='agauss(l, sg13g2_hv_nmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
-      + as='as' ad='ad' pd='pd' ps='ps' nf='ng' mult='m'
-      + dta=trise
-      + ngcon=2
-      + delvto='agauss(0, sg13g2_hv_nmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
-      + factuo='agauss(1, sg13g2_hv_nmos_factuo_mm, (mm_ok != 1 ? 0 : 1))'
+    .if (as <= 1e-50)
+        .if (floor(floor(ng/2+0.501)*2+0.001) != ng)
+            Nsg13_hv_nmos d g s b sg13g2_hv_nmos_psp_rf
+              + w='agauss(w, sg13g2_hv_nmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
+              + l='agauss(l, sg13g2_hv_nmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
+              + nf='ng' mult='m'
+              + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
+              + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
+              + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+              + pd='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+              + dta=trise
+              + ngcon=2
+              + delvto='agauss(0, sg13g2_hv_nmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
+              + factuo='agauss(1, sg13g2_hv_nmos_factuo_mm, (mm_ok != 1 ? 0 : 1))'
+        .else
+            Nsg13_hv_nmos d g s b sg13g2_hv_nmos_psp_rf
+              + w='agauss(w, sg13g2_hv_nmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
+              + l='agauss(l, sg13g2_hv_nmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
+              + nf='ng' mult='m'
+              + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)'
+              + ad='max(w/ng,wmin)*z2/2*ng'
+              + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)'
+              + pd='(max(w/ng,wmin)+z2)*ng'
+              + dta=trise
+              + ngcon=2
+              + delvto='agauss(0, sg13g2_hv_nmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
+              + factuo='agauss(1, sg13g2_hv_nmos_factuo_mm, (mm_ok != 1 ? 0 : 1))'
+        .endif
+    .else
+        Nsg13_hv_nmos d g s b sg13g2_hv_nmos_psp_rf
+          + w='agauss(w, sg13g2_hv_nmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
+          + l='agauss(l, sg13g2_hv_nmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
+          + as='as' ad='ad' pd='pd' ps='ps' nf='ng' mult='m'
+          + dta=trise
+          + ngcon=2
+          + delvto='agauss(0, sg13g2_hv_nmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
+          + factuo='agauss(1, sg13g2_hv_nmos_factuo_mm, (mm_ok != 1 ? 0 : 1))'
+    .endif
 .endif
 .ends
 
@@ -116,42 +157,83 @@
 
 .include sg13g2_moshv_parm.lib
 
-.if (as <= 1e-50)
-    .if (floor(floor(ng/2+0.501)*2+0.001) != ng)
-        Nsg13_hv_pmos d g s b sg13g2_hv_pmos_psp
-          + w='agauss(w, sg13g2_hv_pmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
-          + l='agauss(l, sg13g2_hv_pmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
-          + nf='ng' mult='m'
-          + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
-          + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
-          + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
-          + pd='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
-          + dta=trise
-          + ngcon=2
-          + delvto='agauss(0, sg13g2_hv_pmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
-          + factuo='agauss(1, sg13g2_hv_pmos_factuo_mm, (mm_ok != 1 ? 0 : 1))'
+.if (rfmode == 0)
+    .if (as <= 1e-50)
+        .if (floor(floor(ng/2+0.501)*2+0.001) != ng)
+            Nsg13_hv_pmos d g s b sg13g2_hv_pmos_psp
+              + w='agauss(w, sg13g2_hv_pmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
+              + l='agauss(l, sg13g2_hv_pmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
+              + nf='ng' mult='m'
+              + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
+              + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
+              + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+              + pd='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+              + dta=trise
+              + ngcon=2
+              + delvto='agauss(0, sg13g2_hv_pmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
+              + factuo='agauss(1, sg13g2_hv_pmos_factuo_mm, (mm_ok != 1 ? 0 : 1))'
+        .else
+            Nsg13_hv_pmos d g s b sg13g2_hv_pmos_psp
+              + w='agauss(w, sg13g2_hv_pmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
+              + l='agauss(l, sg13g2_hv_pmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
+              + nf='ng' mult='m'
+              + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)'
+              + ad='max(w/ng,wmin)*z2/2*ng'
+              + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)'
+              + pd='(max(w/ng,wmin)+z2)*ng'
+              + dta=trise
+              + ngcon=2
+              + delvto='agauss(0, sg13g2_hv_pmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
+              + factuo='agauss(1, sg13g2_hv_pmos_factuo_mm, (mm_ok != 1 ? 0 : 1))'
+        .endif
     .else
         Nsg13_hv_pmos d g s b sg13g2_hv_pmos_psp
           + w='agauss(w, sg13g2_hv_pmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
           + l='agauss(l, sg13g2_hv_pmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
-          + nf='ng' mult='m'
-          + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)'
-          + ad='max(w/ng,wmin)*z2/2*ng'
-          + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)'
-          + pd='(max(w/ng,wmin)+z2)*ng'
+          + as='as' ad='ad' pd='pd' ps='ps' nf='ng' mult='m'
           + dta=trise
           + ngcon=2
           + delvto='agauss(0, sg13g2_hv_pmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
           + factuo='agauss(1, sg13g2_hv_pmos_factuo_mm, (mm_ok != 1 ? 0 : 1))'
     .endif
 .else
-    Nsg13_hv_pmos d g s b sg13g2_hv_pmos_psp
-      + w='agauss(w, sg13g2_hv_pmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
-      + l='agauss(l, sg13g2_hv_pmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
-      + as='as' ad='ad' pd='pd' ps='ps' nf='ng' mult='m'
-      + dta=trise
-      + ngcon=2
-      + delvto='agauss(0, sg13g2_hv_pmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
-      + factuo='agauss(1, sg13g2_hv_pmos_factuo_mm, (mm_ok != 1 ? 0 : 1))'
+    .if (as <= 1e-50)
+        .if (floor(floor(ng/2+0.501)*2+0.001) != ng)
+            Nsg13_hv_pmos d g s b sg13g2_hv_pmos_psp_rf
+              + w='agauss(w, sg13g2_hv_pmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
+              + l='agauss(l, sg13g2_hv_pmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
+              + nf='ng' mult='m'
+              + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
+              + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
+              + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+              + pd='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+              + dta=trise
+              + ngcon=2
+              + delvto='agauss(0, sg13g2_hv_pmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
+              + factuo='agauss(1, sg13g2_hv_pmos_factuo_mm, (mm_ok != 1 ? 0 : 1))'
+        .else
+            Nsg13_hv_pmos d g s b sg13g2_hv_pmos_psp_rf
+              + w='agauss(w, sg13g2_hv_pmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
+              + l='agauss(l, sg13g2_hv_pmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
+              + nf='ng' mult='m'
+              + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)'
+              + ad='max(w/ng,wmin)*z2/2*ng'
+              + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)'
+              + pd='(max(w/ng,wmin)+z2)*ng'
+              + dta=trise
+              + ngcon=2
+              + delvto='agauss(0, sg13g2_hv_pmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
+              + factuo='agauss(1, sg13g2_hv_pmos_factuo_mm, (mm_ok != 1 ? 0 : 1))'
+        .endif
+    .else
+        Nsg13_hv_pmos d g s b sg13g2_hv_pmos_psp_rf
+          + w='agauss(w, sg13g2_hv_pmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
+          + l='agauss(l, sg13g2_hv_pmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
+          + as='as' ad='ad' pd='pd' ps='ps' nf='ng' mult='m'
+          + dta=trise
+          + ngcon=2
+          + delvto='agauss(0, sg13g2_hv_pmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
+          + factuo='agauss(1, sg13g2_hv_pmos_factuo_mm, (mm_ok != 1 ? 0 : 1))'
+    .endif
 .endif
 .ends

--- a/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moshv_parm.lib
+++ b/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moshv_parm.lib
@@ -59,7 +59,138 @@
 *
 *******************************************************************************
 
-.model sg13g2_hv_nmos_psp pspnqs103va           type          =  +1
+.model sg13g2_hv_nmos_psp psp103va             type          =  +1
++ level         =  103.60                      tr            =  27.0                        dta           =  0.0
++ swgeo         =  1.0                         swigate       =  1.0                         swimpact      =  1.0
++ swgidl        =  0.0                         swjuncap      =  3.0                         swjunasym     =  0.0
++ swnud         =  0.0                         swedge        =  0.0                         swdelvtac     =  0.0
++ swign         =  1.0                         qmc           =  1.0                         lvaro         =  3.499e-08
++ lvarl         = -0.09125                     lvarw         =  0.0                         lap           =  6.3866e-08
++ wvaro         =  0.0                         wvarl         =  0.0                         wvarw         =  0.0
++ wot           =  3e-08                       dlq           =  '5.2202e-08 -((1-pre_layout)*0.0 )'      dwq           =  3e-08
++ vfbo          = '-0.89839*sg13g2_hv_nmos_vfbo'            vfbl          =  0.15096                     vfbw          =  0.0017033
++ vfblw         =  0.019398                    stvfbo        =  0.0008739                   stvfbl        =  0.00014864
++ stvfbw        = -4.6174e-05                  stvfblw       = -2.445e-06                   st2vfbo       =  0.0
++ toxo          =  '7.4256e-09*sg13g2_hv_nmos_toxo'                                         epsroxo       =  3.9                         nsubo         =  1.8552e+23
++ nsubw         = -0.0050198                   wseg          =  1.098e-10                   npck          =  3.178e+23
++ npckw         = -2.7604                      wsegp         =  1e-08                       lpck          =  1e-08
++ lpckw         =  0.0                         fol1          =  0.21033                     fol2          =  0.0026472
++ facneffaco    =  1.0                         facneffacl    =  0.0                         facneffacw    =  0.0
++ facneffaclw   =  0.0                         gfacnudo      =  1.0                         gfacnudl      =  0.0
++ gfacnudlexp   =  1.0                         gfacnudw      =  0.0                         gfacnudlw     =  0.0
++ vsbnudo       =  0.0                         dvsbnudo      =  1.0                         vnsubo        =  0.0
++ nslpo         =  0.05                        dnsubo        =  0.025686                    dphibo        = '-0.042228*sg13g2_hv_nmos_dphibo'
++ dphibl        = '-0.0035715*sg13g2_hv_nmos_dphibl'                                        dphiblexp     =  2.3956                      dphibw        =  '0.014614*sg13g2_hv_nmos_dphibw'
++ dphiblw       = '-0.02006*sg13g2_hv_nmos_dphiblw'                                         delvtaco      =  0.0                         delvtacl      =  0.0
++ delvtaclexp   =  1.0                         delvtacw      =  0.0                         delvtaclw     =  0.0
++ npo           =  3.897e+26                   npl           = -0.1215                      toxovo        =  '7.4256e-09*sg13g2_hv_nmos_toxovo'
++ toxovdo       =  2e-09                       lov           =  '6.3866e-08 -((1-pre_layout)*1e-08 )'                                      lovd          =  0.0
++ novo          =  5.5814e+24                  novdo         =  5e+25                       cto           = -0.061658
++ ctl           =  '0.025*sg13g2_hv_nmos_ctl'    ctlexp        =  1.6063                      ctw         = -0.044911
++ ctlw          = -0.0077386                   ctgo          =  0.0                         ctbo          =  0.0
++ stcto         =  1.0                         cfl           =  0.0048288                   cflexp        =  1.3328
++ cfw           =  0.037319                    cfbo          =  0.26069                     cfdo          =  0.0
++ pscel         =  0.0                         pscelexp      =  2.0                         pscew         =  0.0
++ pscebo        =  0.0                         pscedo        =  0.0                         uo            =  0.046687
++ fbet1         = -0.35712                     fbet1w        = -0.14995                     lp1           =  4.5615e-08
++ lp1w          =  0.4189                      fbet2         = -1.0245                      lp2           =  9.42e-09
++ betw1         =  0.6567                      betw2         = -0.083639                    wbet          =  1.0063e-10
++ stbeto        =  1.6942                      stbetl        = -0.0065587                   stbetw        = -0.060053
++ stbetlw       =  0.00036994                  mueo          =  '0.85058*sg13g2_hv_nmos_mueo' muew          = -0.018226
++ stmueo        =  0.34067                     themuo        =  2.5509                      stthemuo      =  0.63756
++ cso           =  2.0494                      csl           = -0.97261                     cslexp        =  0.0
++ csw           =  0.044205                    cslw          = -1.0021                      stcso         =  2.5545
++ thecso        =  2.0                         stthecso      =  0.0                         xcoro         =  0.04872
++ xcorl         = -0.27137                     xcorw         = -0.1948                      xcorlw        =  0.0
++ stxcoro       =  1.1327                      fetao         =  1.0706                      rsw1          =  '407.81*sg13g2_hv_nmos_rsw1'
++ rsw2          = -0.07                        strso         = -0.058157                    rsbo          = -0.0025425
++ rsgo          =  '0.10986*sg13g2_hv_nmos_rsgo' thesato       =  '0.1*sg13g2_hv_nmos_thesato'  thesatl       =  '0.4314*sg13g2_hv_nmos_thesatl'
++ thesatlexp    =  1.0973                      thesatw       =  '0.082797*sg13g2_hv_nmos_thesatw'                                          thesatlw      = '-0.020497*sg13g2_hv_nmos_thesatlw'
++ stthesato     =  0.48396                     stthesatl     =  0.50226                     stthesatw     =  0.049985
++ stthesatlw    = -0.059487                    thesatbo      =  0.06                        thesatgo      =  0.050814
++ axo           =  8.7694                      axl           =  2.3029                      alpl          =  0.0019702
++ alplexp       =  1.4003                      alpw          =  1.1052                      alp1l1        =  0.007475
++ alp1lexp      =  0.80983                     alp1l2        =  0.719                       alp1w         =  0.56703
++ alp2l1        =  5.413e-07                   alp2lexp      =  0.2541                      alp2l2        =  0.0
++ alp2w         = -10.0                        vpo           =  0.06567                     a1o           =  4.7288
++ a1l           =  0.052459                    a1w           =  0.024056                    a2o           =  22.013
++ sta2o         =  0.018532                    a3o           =  1.2047                      a3l           = -0.10308
++ a3w           =  0.0069117                   a4o           =  0.12894                     a4l           = -0.05413
++ a4w           = -0.06197                     gcoo          =  0.0                         iginvlw       =  '0.0 *(1+0.0 /l)*(1+0.0 /w)'
++ igovw         =  0.0                         igovdw        =  0.0                         stigo         =  2.0
++ gc2o          =  0.375                       gc3o          =  0.063                       chibo         =  3.1
++ agidlw        =  70.0                        agidldw       =  0.0                         bgidlo        =  13.0
++ bgidldo       =  41.0                        stbgidlo      = -0.001067                    stbgidldo     =  0.0
++ cgidlo        =  0.0                         cgidldo       =  0.0                         cgbovl        =  2.522e-16
++ cfrdw         =  0.0                         fnto          =  1.0
++ fntexcl       =  0.0                         nfalw         =  1.42e+25                    nfblw         =  574300000.0
++ nfclw         = -3.015e-08                   efo           =  1.0                         lintnoi       = -3.158e-08
++ alpnoi        =  2.708                       wedge         =  1e-08                       wedgew        =  0.0
++ vfbedgeo      = -1.0                         stvfbedgeo    =  0.0005                      stvfbedgel    =  0.0
++ stvfbedgew    =  0.0                         stvfbedgelw   =  0.0                         dphibedgeo    =  0.0
++ dphibedgel    =  0.0                         dphibedgelexp =  1.0                         dphibedgew    =  0.0
++ dphibedgelw   =  0.0                         nsubedgeo     =  5e+23                       nsubedgel     =  0.0
++ nsubedgelexp                                               =  1.0                         nsubedgew     =  0.0                         nsubedgelw    =  0.0
++ ctedgeo       =  0.0                         ctedgel       =  0.0                         ctedgelexp    =  1.0
++ fbetedge      =  0.0                         lpedge        =  1e-08                       betedgew      =  0.0
++ stbetedgeo    =  1.0                         stbetedgel    =  0.0                         stbetedgew    =  0.0
++ stbetedgelw   =  0.0                         psceedgel     =  0.0                         psceedgelexp  =  2.0
++ psceedgew     =  0.0                         pscebedgeo    =  0.0                         pscededgeo    =  0.0
++ cfedgel       =  0.0                         cfedgelexp    =  2.0                         cfedgew       =  0.0
++ cfdedgeo      =  0.0                         cfbedgeo      =  0.0                         fntedgeo      =  1.0
++ nfaedgelw     =  8e+22                       nfbedgelw     =  30000000.0                  nfcedgelw     =  0.0
++ efedgeo       =  1.0                         saref         =  1e-06                       sbref         =  1e-06
++ wlod          =  0.0                         kuo           =  0.0                         kvsat         =  0.0
++ tkuo          =  0.0                         lkuo          =  0.0                         wkuo          =  0.0
++ pkuo          =  0.0                         llodkuo       =  0.0                         wlodkuo       =  0.0
++ kvtho         =  0.0                         lkvtho        =  0.0                         wkvtho        =  0.0
++ pkvtho        =  0.0                         llodvth       =  0.0                         wlodvth       =  0.0
++ stetao        =  0.0                         lodetao       =  1.0                         scref         =  1e-06
++ web           =  0.0                         wec           =  0.0                         kvthoweo      =  0.0
++ kvthowel      =  0.0                         kvthowew      =  0.0                         kvthowelw     =  0.0
++ kuoweo        =  0.0                         kuowel        =  0.0                         kuowew        =  0.0
++ kuowelw       =  0.0                         trj           =  21.0                        swjunexp      =  0.0
++ imax          =  0.0020128                   frev          =  1000.0                      cjorbot       =  '0.00085856*sg13g2_hv_nmos_cjorbot'
++ cjorsti       =  '2.4557e-11*sg13g2_hv_nmos_cjorsti'                                        cjorgat       =  '1.3846e-11*sg13g2_hv_nmos_cjorgat'                                        vbirbot       =  0.74373
++ vbirsti       =  1.597                       vbirgat       =  0.6629                      pbot          =  0.27424
++ psti          =  0.16571                     pgat          =  0.1451                      cjorbotd      =  0.001
++ cjorstid      =  1e-09                       cjorgatd      =  1e-09                       vbirbotd      =  1.0
++ vbirstid      =  1.0                         vbirgatd      =  1.0                         pbotd         =  0.5
++ pstid         =  0.5                         pgatd         =  0.5                         phigbot       =  1.1984
++ phigsti       =  1.006                       phiggat       =  0.3                         idsatrbot     =  5.397e-08
++ idsatrsti     =  4.0612e-15                  idsatrgat     =  0.0                         csrhbot       =  100.0
++ csrhsti       =  0.0001                      csrhgat       =  0.0001                      xjunsti       =  1.61e-08
++ xjungat       =  6.134e-07                   phigbotd      =  1.16                        phigstid      =  1.16
++ phiggatd      =  1.16                        idsatrbotd    =  1e-12                       idsatrstid    =  1e-18
++ idsatrgatd    =  1e-18                       csrhbotd      =  100.0                       csrhstid      =  0.0001
++ csrhgatd      =  0.0001                      xjunstid      =  1e-07                       xjungatd      =  1e-07
++ ctatbot       =  100.0                       ctatsti       =  0.0001                      ctatgat       =  0.0001
++ mefftatbot    =  0.25                        mefftatsti    =  0.25                        mefftatgat    =  0.25
++ ctatbotd      =  100.0                       ctatstid      =  0.0001                      ctatgatd      =  0.0001
++ mefftatbotd   =  0.25                        mefftatstid   =  0.25                        mefftatgatd   =  0.25
++ cbbtbot       =  1e-12                       cbbtsti       =  1e-21                       cbbtgat       =  1e-18
++ fbbtrbot      =  1000000000.0                fbbtrsti      =  1000000000.0                fbbtrgat      =  1000000000.0
++ stfbbtbot     = -0.001                       stfbbtsti     = -0.001                       stfbbtgat     = -0.001
++ cbbtbotd      =  1e-12                       cbbtstid      =  1e-18                       cbbtgatd      =  1e-18
++ fbbtrbotd     =  1000000000.0                fbbtrstid     =  1000000000.0                fbbtrgatd     =  1000000000.0
++ stfbbtbotd    = -0.001                       stfbbtstid    = -0.001                       stfbbtgatd    = -0.001
++ vbrbot        =  10.0                        vbrsti        =  10.0                        vbrgat        =  10.0
++ pbrbot        =  4.0                         pbrsti        =  4.0                         pbrgat        =  4.0
++ vbrbotd       =  10.0                        vbrstid       =  10.0                        vbrgatd       =  10.0
++ pbrbotd       =  4.0                         pbrstid       =  4.0                         pbrgatd       =  4.0
++ vjunref       =  2.5                         fjunq         =  0.03                        vjunrefd      =  2.5
++ fjunqd        =  0.03                        rint          =  3.0856e-12
++ rvpoly        =  0.0                         dlsil         =  0.0
++ rsh           =  0.0                         rshd          =  0.0
++ cfrw          =  'pre_layout * 1.2e-16/ng'
++ rshg          =  '20.0'                      rgo           =  '35.0'
++ rbulko        =  '0.002 * ng/w'              rwello        =  '0.002 * ng/w'
++ rjunso        =  '5000.0 * l/w'              rjundo        =  '5000.0 * l/w'
++ SWSOA = 'SWSOA'
++ VGS_MAX = 3.0 VGD_MAX = 3.0 VGB_MAX = 3.0
++ VDS_MAX = 3.0 VDB_MAX = 1.6 VSB_MAX = 1.6
+
+.model sg13g2_hv_nmos_psp_rf pspnqs103va       type          =  +1
 + level         =  103.60                      tr            =  27.0                        dta           =  0.0
 + swgeo         =  1.0                         swigate       =  1.0                         swimpact      =  1.0
 + swgidl        =  0.0                         swjuncap      =  3.0                         swjunasym     =  0.0
@@ -183,10 +314,10 @@
 + rvpoly        =  0.0                         dlsil         =  0.0
 + rsh           =  0.0                         rshd          =  0.0
 + munqso        =  1.0
-+ swnqs         =  'rfmode * 5.0'                cfrw          =  '(pre_layout * (1-rfmode)*1.2e-16 + rfmode * (0.0 + pre_layout * (ng>0 ? 4.1214e-16 : 0)))/ng'
-+ rshg          =  'rfmode * 20.0'               rgo           =  'rfmode * 35.0'
-+ rbulko        =  'rfmode * 0.002 * ng/w'       rwello        =  'rfmode * 0.002 * ng/w'
-+ rjunso        =  'rfmode * 5000.0 * l/w'       rjundo        =  'rfmode * 5000.0 * l/w'
++ swnqs         =  'rfmode * 5.0'              cfrw          =  '(pre_layout * (1-rfmode)*1.2e-16 + rfmode * (0.0 + pre_layout * (ng>0 ? 4.1214e-16 : 0)))/ng'
++ rshg          =  'rfmode * 20.0'             rgo           =  'rfmode * 35.0'
++ rbulko        =  'rfmode * 0.002 * ng/w'     rwello        =  'rfmode * 0.002 * ng/w'
++ rjunso        =  'rfmode * 5000.0 * l/w'     rjundo        =  'rfmode * 5000.0 * l/w'
 + SWSOA = 'SWSOA'
 + VGS_MAX = 3.0 VGD_MAX = 3.0 VGB_MAX = 3.0
 + VDS_MAX = 3.0 VDB_MAX = 1.6 VSB_MAX = 1.6
@@ -211,7 +342,138 @@
 *
 *******************************************************************************
 
-.model sg13g2_hv_pmos_psp pspnqs103va           type          =  -1
+.model sg13g2_hv_pmos_psp psp103va             type          =  -1
++ level         =  103.60                      tr            =  27.0                        dta           =  0.0
++ swgeo         =  1.0                         swigate       =  1.0                         swimpact      =  1.0
++ swgidl        =  1.0                         swjuncap      =  3.0                         swjunasym     =  0.0
++ swnud         =  0.0                         swedge        =  0.0                         swdelvtac     =  0.0
++ swign         =  1.0                         qmc           =  1.0                         lvaro         = -1.735e-09
++ lvarl         =  0.0                         lvarw         =  0.0                         lap           =  3.471e-08
++ wvaro         =  0.0                         wvarl         =  0.0                         wvarw         =  0.0
++ wot           =  0.0                         dlq           =  '3.537e-08 -((1-pre_layout)*1e-07 )'       dwq           =  3e-08
++ vfbo          = '-1.0717*sg13g2_hv_pmos_vfbo'               vfbl          = -0.03                        vfbw          =  0.0
++ vfblw         =  0.0                         stvfbo        =  0.00057379                  stvfbl        =  8.6794e-05
++ stvfbw        =  4.9309e-05                  stvfblw       = -3.6436e-05                  st2vfbo       =  0.0
++ toxo          =  '6.945e-09*sg13g2_hv_pmos_toxo'                                            epsroxo       =  3.9                         nsubo         =  4.2268e+23
++ nsubw         =  0.01112                     wseg          =  5.362e-08                   npck          =  8.0711e+23
++ npckw         = -0.011403                    wsegp         =  1e-06                       lpck          =  8.3733e-09
++ lpckw         =  0.077499                    fol1          =  0.065253                    fol2          =  0.010199
++ facneffaco    =  1.0                         facneffacl    =  0.0                         facneffacw    =  0.0
++ facneffaclw   =  0.0                         gfacnudo      =  1.0                         gfacnudl      =  0.0
++ gfacnudlexp   =  1.0                         gfacnudw      =  0.0                         gfacnudlw     =  0.0
++ vsbnudo       =  0.0                         dvsbnudo      =  1.0                         vnsubo        =  0.0
++ nslpo         =  0.05                        dnsubo        =  0.03585                     dphibo        = '-0.077807*sg13g2_hv_pmos_dphibo'
++ dphibl        =  '0.0055386*sg13g2_hv_pmos_dphibl'                                          dphiblexp     =  2.1893                      dphibw        = '-0.007913*sg13g2_hv_pmos_dphibw '
++ dphiblw       =  '0.00055473*sg13g2_hv_pmos_dphiblw'                                        delvtaco      =  0.0                         delvtacl      =  0.0
++ delvtaclexp   =  1.0                         delvtacw      =  0.0                         delvtaclw     =  0.0
++ npo           =  1.092e+26                   npl           =  0.2188                      toxovo        =  '6.945e-09*sg13g2_hv_pmos_toxovo'
++ toxovdo       =  2e-09                       lov           =  '3.471e-08 -((1-pre_layout)*2.4e-08 )'                                     lovd          =  0.0
++ novo          =  1.99e+26                    novdo         =  5e+25                       cto           = -0.006328
++ ctl           =  0.0                         ctlexp        =  1.0                         ctw           =  0.3006
++ ctlw          = -0.01196                     ctgo          =  0.0                         ctbo          =  0.0
++ stcto         =  1.0                         cfl           =  0.00045884                  cflexp        =  2.2055
++ cfw           =  0.45909                     cfbo          =  1.0                         cfdo          =  0.0
++ pscel         =  0.0                         pscelexp      =  2.0                         pscew         =  0.0
++ pscebo        =  0.0                         pscedo        =  0.0                         uo            =  0.018428
++ fbet1         =  0.15952                     fbet1w        = -2.1872                      lp1           =  9.9822e-08
++ lp1w          = -1.0871                      fbet2         = -2.7066                      lp2           =  5.8401e-08
++ betw1         = -0.097534                    betw2         =  0.022314                    wbet          =  7.9844e-10
++ stbeto        =  1.6489                      stbetl        =  0.029528                    stbetw        =  0.037078
++ stbetlw       =  0.046991                    mueo          =  '1.8162*sg13g2_hv_pmos_mueo'  muew          = -0.06367
++ stmueo        =  1.0816                      themuo        =  1.0324                      stthemuo      =  0.26337
++ cso           =  0.18648                     csl           =  '0.21903*sg13g2_hv_pmos_csl'  cslexp        =  2.0917
++ csw           =  0.0072837                   cslw          =  0.02                        stcso         =  2.0
++ thecso        =  2.0                         stthecso      =  0.0                         xcoro         =  0.001363
++ xcorl         =  8.0                         xcorw         =  0.0060537                   xcorlw        =  0.058951
++ stxcoro       = -6.939e-18                   fetao         =  1.2853                      rsw1          =  '1970.0*sg13g2_hv_pmos_rsw1'
++ rsw2          = -0.057547                    strso         = -0.24812                     rsbo          =  0.074639
++ rsgo          =  '0.21144*sg13g2_hv_pmos_rsgo' thesato     =  '8.4917e-05*sg13g2_hv_pmos_thesato'        thesatl       =  '0.014*sg13g2_hv_pmos_thesatl'
++ thesatlexp    =  2.395                       thesatw       =  '0.2*sg13g2_hv_pmos_thesatw'  thesatlw      = '-0.01*sg13g2_hv_pmos_thesatlw'
++ stthesato     =  3.0405                      stthesatl     = -0.16001                     stthesatw     = -0.96988
++ stthesatlw    =  0.36213                     thesatbo      =  0.1                         thesatgo      =  0.6304
++ axo           =  16.822                      axl           =  3.0092                      alpl          =  0.0058454
++ alplexp       =  0.47562                     alpw          = -0.065973                    alp1l1        =  4.4409e-16
++ alp1lexp      =  1.347                       alp1l2        =  1.0                         alp1w         =  2.0
++ alp2l1        =  3.6779e-06                  alp2lexp      =  0.2531                      alp2l2        =  2.2204e-15
++ alp2w         =  0.9582                      vpo           =  1.8436e-06                  a1o           =  47.788
++ a1l           =  0.029145                    a1w           =  0.01435                     a2o           =  38.581
++ sta2o         = -0.0049931                   a3o           =  1.1753                      a3l           = -0.069795
++ a3w           =  0.0032538                   a4o           =  0.12593                     a4l           = -0.07
++ a4w           = -0.04811                     gcoo          =  0.0                         iginvlw       =  '0.0 *(1+0.0 /l)*(1+0.0 /w)'
++ igovw         =  0.0                         igovdw        =  0.0                         stigo         =  2.0
++ gc2o          =  0.375                       gc3o          =  0.063                       chibo         =  3.1
++ agidlw        =  6e-10                       agidldw       =  0.0                         bgidlo        =  '6.656*sg13g2_hv_pmos_bgidlo'
++ bgidldo       =  41.0                        stbgidlo      = -0.0049461                   stbgidldo     =  0.0
++ cgidlo        =  0.23693                     cgidldo       =  0.0                         cgbovl        = -4.669e-16
++ cfrdw         =  0.0                         fnto          =  1.0
++ fntexcl       =  0.0                         nfalw         =  1.3e+25                     nfblw         =  5289000000.0
++ nfclw         =  2e-07                       efo           =  1.152                       lintnoi       =  2.5e-08
++ alpnoi        =  2.0                         wedge         =  1e-08                       wedgew        =  0.0
++ vfbedgeo      = -1.0                         stvfbedgeo    =  0.0005                      stvfbedgel    =  0.0
++ stvfbedgew    =  0.0                         stvfbedgelw   =  0.0                         dphibedgeo    =  0.0
++ dphibedgel    =  0.0                         dphibedgelexp =  1.0                         dphibedgew    =  0.0
++ dphibedgelw   =  0.0                         nsubedgeo     =  5e+23                       nsubedgel     =  0.0
++ nsubedgelexp                                               =  1.0                         nsubedgew     =  0.0                         nsubedgelw    =  0.0
++ ctedgeo       =  0.0                         ctedgel       =  0.0                         ctedgelexp    =  1.0
++ fbetedge      =  0.0                         lpedge        =  1e-08                       betedgew      =  0.0
++ stbetedgeo    =  1.0                         stbetedgel    =  0.0                         stbetedgew    =  0.0
++ stbetedgelw   =  0.0                         psceedgel     =  0.0                         psceedgelexp  =  2.0
++ psceedgew     =  0.0                         pscebedgeo    =  0.0                         pscededgeo    =  0.0
++ cfedgel       =  0.0                         cfedgelexp    =  2.0                         cfedgew       =  0.0
++ cfdedgeo      =  0.0                         cfbedgeo      =  0.0                         fntedgeo      =  1.0
++ nfaedgelw     =  8e+22                       nfbedgelw     =  30000000.0                  nfcedgelw     =  0.0
++ efedgeo       =  1.0                         saref         =  1e-06                       sbref         =  1e-06
++ wlod          =  0.0                         kuo           =  0.0                         kvsat         =  0.0
++ tkuo          =  0.0                         lkuo          =  0.0                         wkuo          =  0.0
++ pkuo          =  0.0                         llodkuo       =  0.0                         wlodkuo       =  0.0
++ kvtho         =  0.0                         lkvtho        =  0.0                         wkvtho        =  0.0
++ pkvtho        =  0.0                         llodvth       =  0.0                         wlodvth       =  0.0
++ stetao        =  0.0                         lodetao       =  1.0                         scref         =  1e-06
++ web           =  0.0                         wec           =  0.0                         kvthoweo      =  0.0
++ kvthowel      =  0.0                         kvthowew      =  0.0                         kvthowelw     =  0.0
++ kuoweo        =  0.0                         kuowel        =  0.0                         kuowew        =  0.0
++ kuowelw       =  0.0                         trj           =  21.0                        swjunexp      =  0.0
++ imax          =  0.0024527                   frev          =  1000.0                      cjorbot       =  '0.0008095*sg13g2_hv_pmos_cjorbot'
++ cjorsti       =  '4.2583e-11*sg13g2_hv_pmos_cjorsti'                                      cjorgat       =  '3.1e-11*sg13g2_hv_pmos_cjorgat'  vbirbot       =  0.72606
++ vbirsti       =  0.69819                     vbirgat       =  1.199                       pbot          =  0.33078
++ psti          =  0.22409                     pgat          =  0.4474                      cjorbotd      =  0.001
++ cjorstid      =  1e-09                       cjorgatd      =  1e-09                       vbirbotd      =  1.0
++ vbirstid      =  1.0                         vbirgatd      =  1.0                         pbotd         =  0.5
++ pstid         =  0.5                         pgatd         =  0.5                         phigbot       =  1.0641
++ phigsti       =  1.3946                      phiggat       =  1.83                        idsatrbot     =  3.0606e-08
++ idsatrsti     =  3.6127e-15                  idsatrgat     =  0.0                         csrhbot       =  100.0
++ csrhsti       =  0.0001                      csrhgat       =  0.0001                      xjunsti       =  4.93e-08
++ xjungat       =  7.062e-07                   phigbotd      =  1.16                        phigstid      =  1.16
++ phiggatd      =  1.16                        idsatrbotd    =  1e-12                       idsatrstid    =  1e-18
++ idsatrgatd    =  1e-18                       csrhbotd      =  100.0                       csrhstid      =  0.0001
++ csrhgatd      =  0.0001                      xjunstid      =  1e-07                       xjungatd      =  1e-07
++ ctatbot       =  100.0                       ctatsti       =  0.0001                      ctatgat       =  0.0001
++ mefftatbot    =  0.25                        mefftatsti    =  0.25                        mefftatgat    =  0.25
++ ctatbotd      =  100.0                       ctatstid      =  0.0001                      ctatgatd      =  0.0001
++ mefftatbotd   =  0.25                        mefftatstid   =  0.25                        mefftatgatd   =  0.25
++ cbbtbot       =  1e-12                       cbbtsti       =  1e-21                       cbbtgat       =  1e-18
++ fbbtrbot      =  1000000000.0                fbbtrsti      =  1000000000.0                fbbtrgat      =  1000000000.0
++ stfbbtbot     = -0.001                       stfbbtsti     = -0.001                       stfbbtgat     = -0.001
++ cbbtbotd      =  1e-12                       cbbtstid      =  1e-18                       cbbtgatd      =  1e-18
++ fbbtrbotd     =  1000000000.0                fbbtrstid     =  1000000000.0                fbbtrgatd     =  1000000000.0
++ stfbbtbotd    = -0.001                       stfbbtstid    = -0.001                       stfbbtgatd    = -0.001
++ vbrbot        =  10.0                        vbrsti        =  10.0                        vbrgat        =  10.0
++ pbrbot        =  4.0                         pbrsti        =  4.0                         pbrgat        =  4.0
++ vbrbotd       =  10.0                        vbrstid       =  10.0                        vbrgatd       =  10.0
++ pbrbotd       =  4.0                         pbrstid       =  4.0                         pbrgatd       =  4.0
++ vjunref       =  2.5                         fjunq         =  0.03                        vjunrefd      =  2.5
++ fjunqd        =  0.03                        rint          =  0.0
++ rvpoly        =  0.0                         dlsil         =  0.0
++ rsh           =  0.0                         rshd          =  0.0
++ cfrw          =  'pre_layout * 0.0/ng'
++ rshg          =  '40.0'                      rgo           =  '15.0'
++ rbulko        =  '0.002 * ng/w'              rwello        =  '0.001 * ng/w'
++ rjunso        =  '5000.0 * l/w'              rjundo        =  '5000.0 * l/w'
++ SWSOA = 'SWSOA'
++ VGS_MAX = 3.0 VGD_MAX = 3.0 VGB_MAX = 3.0
++ VDS_MAX = 3.0 VDB_MAX = 1.6 VSB_MAX = 1.6
+
+.model sg13g2_hv_pmos_psp_rf pspnqs103va       type          =  -1
 + level         =  103.60                      tr            =  27.0                        dta           =  0.0
 + swgeo         =  1.0                         swigate       =  1.0                         swimpact      =  1.0
 + swgidl        =  1.0                         swjuncap      =  3.0                         swjunasym     =  0.0
@@ -335,10 +597,10 @@
 + rvpoly        =  0.0                         dlsil         =  0.0
 + rsh           =  0.0                         rshd          =  0.0
 + munqso        =  1.0
-+ swnqs         =  'rfmode * 5.0'                cfrw          =  '(pre_layout * 0.0 + rfmode * (2.01e-17 + pre_layout * (ng>0 ? 3.5e-17 : 0)))/ng'
-+ rshg          =  'rfmode * 40.0'               rgo           =  'rfmode * 15.0'
-+ rbulko        =  'rfmode * 0.002 * ng/w'       rwello        =  'rfmode * 0.001 * ng/w'
-+ rjunso        =  'rfmode * 5000.0 * l/w'       rjundo        =  'rfmode * 5000.0 * l/w'
++ swnqs         =  'rfmode * 5.0'              cfrw          =  '(pre_layout * 0.0 + rfmode * (2.01e-17 + pre_layout * (ng>0 ? 3.5e-17 : 0)))/ng'
++ rshg          =  'rfmode * 40.0'             rgo           =  'rfmode * 15.0'
++ rbulko        =  'rfmode * 0.002 * ng/w'     rwello        =  'rfmode * 0.001 * ng/w'
++ rjunso        =  'rfmode * 5000.0 * l/w'     rjundo        =  'rfmode * 5000.0 * l/w'
 + SWSOA = 'SWSOA'
 + VGS_MAX = 3.0 VGD_MAX = 3.0 VGB_MAX = 3.0
 + VDS_MAX = 3.0 VDB_MAX = 1.6 VSB_MAX = 1.6

--- a/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moslv_mod.lib
+++ b/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moslv_mod.lib
@@ -71,43 +71,84 @@
 
 .include sg13g2_moslv_parm.lib
 
-.if (as <= 1e-50)
-    .if (floor(floor(ng/2+0.501)*2+0.001) != ng)
-        Nsg13_lv_nmos d g s b sg13g2_lv_nmos_psp
-          + w=w 
-          + l=l
-          + nf='ng' mult='m'
-          + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
-          + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
-          + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
-          + pd='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
-          + dta=trise
-          + ngcon=2
-          + delvto=0
-          + factuo=1
+.if (rfmode == 0)
+    .if (as <= 1e-50)
+        .if (floor(floor(ng/2+0.501)*2+0.001) != ng)
+            Nsg13_lv_nmos d g s b sg13g2_lv_nmos_psp
+              + w=w 
+              + l=l
+              + nf='ng' mult='m'
+              + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
+              + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
+              + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+              + pd='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+              + dta=trise
+              + ngcon=2
+              + delvto=0
+              + factuo=1
+        .else
+            Nsg13_lv_nmos d g s b sg13g2_lv_nmos_psp
+              + w=w
+              + l=l
+              + nf='ng' mult='m'
+              + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)'
+              + ad='max(w/ng,wmin)*z2/2*ng'
+              + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)'
+              + pd='(max(w/ng,wmin)+z2)*ng'
+              + dta=trise
+              + ngcon=2
+              + delvto=0
+              + factuo=1
+        .endif
     .else
         Nsg13_lv_nmos d g s b sg13g2_lv_nmos_psp
           + w=w
           + l=l
-          + nf='ng' mult='m'
-          + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)'
-          + ad='max(w/ng,wmin)*z2/2*ng'
-          + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)'
-          + pd='(max(w/ng,wmin)+z2)*ng'
+          + as='as' ad='ad' pd='pd' ps='ps' nf='ng' mult='m'
           + dta=trise
           + ngcon=2
           + delvto=0
           + factuo=1
     .endif
 .else
-    Nsg13_lv_nmos d g s b sg13g2_lv_nmos_psp
-      + w=w
-      + l=l
-      + as='as' ad='ad' pd='pd' ps='ps' nf='ng' mult='m'
-      + dta=trise
-      + ngcon=2
-      + delvto=0
-      + factuo=1
+    .if (as <= 1e-50)
+        .if (floor(floor(ng/2+0.501)*2+0.001) != ng)
+            Nsg13_lv_nmos d g s b sg13g2_lv_nmos_psp_rf
+              + w=w 
+              + l=l
+              + nf='ng' mult='m'
+              + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
+              + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
+              + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+              + pd='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+              + dta=trise
+              + ngcon=2
+              + delvto=0
+              + factuo=1
+        .else
+            Nsg13_lv_nmos d g s b sg13g2_lv_nmos_psp_rf
+              + w=w
+              + l=l
+              + nf='ng' mult='m'
+              + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)'
+              + ad='max(w/ng,wmin)*z2/2*ng'
+              + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)'
+              + pd='(max(w/ng,wmin)+z2)*ng'
+              + dta=trise
+              + ngcon=2
+              + delvto=0
+              + factuo=1
+        .endif
+    .else
+        Nsg13_lv_nmos d g s b sg13g2_lv_nmos_psp_rf
+          + w=w
+          + l=l
+          + as='as' ad='ad' pd='pd' ps='ps' nf='ng' mult='m'
+          + dta=trise
+          + ngcon=2
+          + delvto=0
+          + factuo=1
+    .endif
 .endif
 .ends
 
@@ -116,43 +157,84 @@
 
 .include sg13g2_moslv_parm.lib
 
-.if (as <= 1e-50)
-    .if (floor(floor(ng/2+0.501)*2+0.001) != ng)
-        Nsg13_lv_pmos d g s b sg13g2_lv_pmos_psp
-          + w=w
-          + l=l
-          + nf='ng' mult='m'
-          + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
-          + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
-          + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
-          + pd='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
-          + dta=trise
-          + ngcon=2
-          + delvto=0
-          + factuo=1
+.if (rfmode == 0)
+    .if (as <= 1e-50)
+        .if (floor(floor(ng/2+0.501)*2+0.001) != ng)
+            Nsg13_lv_pmos d g s b sg13g2_lv_pmos_psp
+              + w=w
+              + l=l
+              + nf='ng' mult='m'
+              + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
+              + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
+              + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+              + pd='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+              + dta=trise
+              + ngcon=2
+              + delvto=0
+              + factuo=1
+        .else
+            Nsg13_lv_pmos d g s b sg13g2_lv_pmos_psp
+              + w=w
+              + l=l
+              + nf='ng' mult='m'
+              + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)'
+              + ad='max(w/ng,wmin)*z2/2*ng'
+              + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)'
+              + pd='(max(w/ng,wmin)+z2)*ng'
+              + dta=trise
+              + ngcon=2
+              + delvto=0
+              + factuo=1
+        .endif
     .else
         Nsg13_lv_pmos d g s b sg13g2_lv_pmos_psp
           + w=w
           + l=l
-          + nf='ng' mult='m'
-          + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)'
-          + ad='max(w/ng,wmin)*z2/2*ng'
-          + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)'
-          + pd='(max(w/ng,wmin)+z2)*ng'
+          + as='as' ad='ad' pd='pd' ps='ps' nf='ng' mult='m'
           + dta=trise
           + ngcon=2
           + delvto=0
           + factuo=1
     .endif
 .else
-    Nsg13_lv_pmos d g s b sg13g2_lv_pmos_psp
-      + w=w
-      + l=l
-      + as='as' ad='ad' pd='pd' ps='ps' nf='ng' mult='m'
-      + dta=trise
-      + ngcon=2
-      + delvto=0
-      + factuo=1
+    .if (as <= 1e-50)
+        .if (floor(floor(ng/2+0.501)*2+0.001) != ng)
+            Nsg13_lv_pmos d g s b sg13g2_lv_pmos_psp_rf
+              + w=w
+              + l=l
+              + nf='ng' mult='m'
+              + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
+              + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
+              + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+              + pd='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+              + dta=trise
+              + ngcon=2
+              + delvto=0
+              + factuo=1
+        .else
+            Nsg13_lv_pmos d g s b sg13g2_lv_pmos_psp_rf
+              + w=w
+              + l=l
+              + nf='ng' mult='m'
+              + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)'
+              + ad='max(w/ng,wmin)*z2/2*ng'
+              + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)'
+              + pd='(max(w/ng,wmin)+z2)*ng'
+              + dta=trise
+              + ngcon=2
+              + delvto=0
+              + factuo=1
+        .endif
+    .else
+        Nsg13_lv_pmos d g s b sg13g2_lv_pmos_psp_rf
+          + w=w
+          + l=l
+          + as='as' ad='ad' pd='pd' ps='ps' nf='ng' mult='m'
+          + dta=trise
+          + ngcon=2
+          + delvto=0
+          + factuo=1
+    .endif
 .endif
 .ends
 
@@ -163,14 +245,22 @@
 
 .include sg13g2_moslv_parm.lib
 
- Nsg13_lv_pmos VDD VSS VSS VSS nmoscl_psp w='w' l='l' nf='ng' as='as' ad='ad' pd='pd' ps='ps' mult='m'  dta=trise ngcon=2
+.if (rfmode == 0)
+    Nsg13_lv_pmos VDD VSS VSS VSS nmoscl_psp w='w' l='l' nf='ng' as='as' ad='ad' pd='pd' ps='ps' mult='m'  dta=trise ngcon=2
+.else
+    Nsg13_lv_pmos VDD VSS VSS VSS nmoscl_psp_rf w='w' l='l' nf='ng' as='as' ad='ad' pd='pd' ps='ps' mult='m'  dta=trise ngcon=2
+.endif
 .ends nmoscl_2
 
 .subckt nmoscl_4  VDD VSS
 + l=0.36u w=168u m=1 ng=1 trise=0 as = 114e-12  ad = 114e-12 pd = 672u ps = 672u rfmode=0 pre_layout=1
 .include sg13g2_moslv_parm.lib
 
-Nsg13_lv_pmos VDD VSS VSS VSS nmoscl_psp w='w' l='l' nf='ng' as='as' ad='ad' pd='pd' ps='ps' mult='m'  dta=trise ngcon=2
+.if (rfmode == 0)
+    Nsg13_lv_pmos VDD VSS VSS VSS nmoscl_psp w='w' l='l' nf='ng' as='as' ad='ad' pd='pd' ps='ps' mult='m'  dta=trise ngcon=2
+.else
+    Nsg13_lv_pmos VDD VSS VSS VSS nmoscl_psp_rf w='w' l='l' nf='ng' as='as' ad='ad' pd='pd' ps='ps' mult='m'  dta=trise ngcon=2
+.endif
 .ends nmoscl_4
 
 *****************************************************************

--- a/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moslv_mod_mismatch.lib
+++ b/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moslv_mod_mismatch.lib
@@ -71,43 +71,84 @@
 
 .include sg13g2_moslv_parm.lib
 
-.if (as <= 1e-50)
-    .if (floor(floor(ng/2+0.501)*2+0.001) != ng)
-        Nsg13_lv_nmos d g s b sg13g2_lv_nmos_psp
-          + w='agauss(w, sg13g2_lv_nmos_dw_mm, (mm_ok != 1 ? 0 : 1))' 
-          + l='agauss(l, sg13g2_lv_nmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
-          + nf='ng' mult='m'
-          + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
-          + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
-          + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
-          + pd='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
-          + dta=trise
-          + ngcon=2
-          + delvto='agauss(0, sg13g2_lv_nmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
-          + factuo='agauss(1, sg13g2_lv_nmos_factuo_mm, (mm_ok != 1 ? 0 : 1))'
+.if (rfmode == 0)
+    .if (as <= 1e-50)
+        .if (floor(floor(ng/2+0.501)*2+0.001) != ng)
+            Nsg13_lv_nmos d g s b sg13g2_lv_nmos_psp
+              + w='agauss(w, sg13g2_lv_nmos_dw_mm, (mm_ok != 1 ? 0 : 1))' 
+              + l='agauss(l, sg13g2_lv_nmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
+              + nf='ng' mult='m'
+              + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
+              + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
+              + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+              + pd='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+              + dta=trise
+              + ngcon=2
+              + delvto='agauss(0, sg13g2_lv_nmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
+              + factuo='agauss(1, sg13g2_lv_nmos_factuo_mm, (mm_ok != 1 ? 0 : 1))'
+        .else
+            Nsg13_lv_nmos d g s b sg13g2_lv_nmos_psp
+              + w='agauss(w, sg13g2_lv_nmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
+              + l='agauss(l, sg13g2_lv_nmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
+              + nf='ng' mult='m'
+              + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)'
+              + ad='max(w/ng,wmin)*z2/2*ng'
+              + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)'
+              + pd='(max(w/ng,wmin)+z2)*ng'
+              + dta=trise
+              + ngcon=2
+              + delvto='agauss(0, sg13g2_lv_nmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
+              + factuo='agauss(1, sg13g2_lv_nmos_factuo_mm, (mm_ok != 1 ? 0 : 1))'
+        .endif
     .else
         Nsg13_lv_nmos d g s b sg13g2_lv_nmos_psp
           + w='agauss(w, sg13g2_lv_nmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
           + l='agauss(l, sg13g2_lv_nmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
-          + nf='ng' mult='m'
-          + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)'
-          + ad='max(w/ng,wmin)*z2/2*ng'
-          + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)'
-          + pd='(max(w/ng,wmin)+z2)*ng'
+          + as='as' ad='ad' pd='pd' ps='ps' nf='ng' mult='m'
           + dta=trise
           + ngcon=2
           + delvto='agauss(0, sg13g2_lv_nmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
           + factuo='agauss(1, sg13g2_lv_nmos_factuo_mm, (mm_ok != 1 ? 0 : 1))'
     .endif
 .else
-    Nsg13_lv_nmos d g s b sg13g2_lv_nmos_psp
-      + w='agauss(w, sg13g2_lv_nmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
-      + l='agauss(l, sg13g2_lv_nmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
-      + as='as' ad='ad' pd='pd' ps='ps' nf='ng' mult='m'
-      + dta=trise
-      + ngcon=2
-      + delvto='agauss(0, sg13g2_lv_nmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
-      + factuo='agauss(1, sg13g2_lv_nmos_factuo_mm, (mm_ok != 1 ? 0 : 1))'
+    .if (as <= 1e-50)
+        .if (floor(floor(ng/2+0.501)*2+0.001) != ng)
+            Nsg13_lv_nmos d g s b sg13g2_lv_nmos_psp_rf
+              + w='agauss(w, sg13g2_lv_nmos_dw_mm, (mm_ok != 1 ? 0 : 1))' 
+              + l='agauss(l, sg13g2_lv_nmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
+              + nf='ng' mult='m'
+              + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
+              + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
+              + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+              + pd='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+              + dta=trise
+              + ngcon=2
+              + delvto='agauss(0, sg13g2_lv_nmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
+              + factuo='agauss(1, sg13g2_lv_nmos_factuo_mm, (mm_ok != 1 ? 0 : 1))'
+        .else
+            Nsg13_lv_nmos d g s b sg13g2_lv_nmos_psp_rf
+              + w='agauss(w, sg13g2_lv_nmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
+              + l='agauss(l, sg13g2_lv_nmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
+              + nf='ng' mult='m'
+              + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)'
+              + ad='max(w/ng,wmin)*z2/2*ng'
+              + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)'
+              + pd='(max(w/ng,wmin)+z2)*ng'
+              + dta=trise
+              + ngcon=2
+              + delvto='agauss(0, sg13g2_lv_nmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
+              + factuo='agauss(1, sg13g2_lv_nmos_factuo_mm, (mm_ok != 1 ? 0 : 1))'
+        .endif
+    .else
+        Nsg13_lv_nmos d g s b sg13g2_lv_nmos_psp_rf
+          + w='agauss(w, sg13g2_lv_nmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
+          + l='agauss(l, sg13g2_lv_nmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
+          + as='as' ad='ad' pd='pd' ps='ps' nf='ng' mult='m'
+          + dta=trise
+          + ngcon=2
+          + delvto='agauss(0, sg13g2_lv_nmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
+          + factuo='agauss(1, sg13g2_lv_nmos_factuo_mm, (mm_ok != 1 ? 0 : 1))'
+    .endif
 .endif
 .ends
 
@@ -116,43 +157,84 @@
 
 .include sg13g2_moslv_parm.lib
 
-.if (as <= 1e-50)
-    .if (floor(floor(ng/2+0.501)*2+0.001) != ng)
-        Nsg13_lv_pmos d g s b sg13g2_lv_pmos_psp
-          + w='agauss(w, sg13g2_lv_pmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
-          + l='agauss(l, sg13g2_lv_pmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
-          + nf='ng' mult='m'
-          + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
-          + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
-          + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
-          + pd='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
-          + dta=trise
-          + ngcon=2
-          + delvto='agauss(0, sg13g2_lv_pmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
-          + factuo='agauss(1, sg13g2_lv_pmos_factuo_mm, (mm_ok != 1 ? 0 : 1))'
+.if (rfmode == 0)
+    .if (as <= 1e-50)
+        .if (floor(floor(ng/2+0.501)*2+0.001) != ng)
+            Nsg13_lv_pmos d g s b sg13g2_lv_pmos_psp
+              + w='agauss(w, sg13g2_lv_pmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
+              + l='agauss(l, sg13g2_lv_pmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
+              + nf='ng' mult='m'
+              + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
+              + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
+              + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+              + pd='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+              + dta=trise
+              + ngcon=2
+              + delvto='agauss(0, sg13g2_lv_pmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
+              + factuo='agauss(1, sg13g2_lv_pmos_factuo_mm, (mm_ok != 1 ? 0 : 1))'
+        .else
+            Nsg13_lv_pmos d g s b sg13g2_lv_pmos_psp
+              + w='agauss(w, sg13g2_lv_pmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
+              + l='agauss(l, sg13g2_lv_pmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
+              + nf='ng' mult='m'
+              + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)'
+              + ad='max(w/ng,wmin)*z2/2*ng'
+              + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)'
+              + pd='(max(w/ng,wmin)+z2)*ng'
+              + dta=trise
+              + ngcon=2
+              + delvto='agauss(0, sg13g2_lv_pmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
+              + factuo='agauss(1, sg13g2_lv_pmos_factuo_mm, (mm_ok != 1 ? 0 : 1))'
+        .endif
     .else
         Nsg13_lv_pmos d g s b sg13g2_lv_pmos_psp
           + w='agauss(w, sg13g2_lv_pmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
           + l='agauss(l, sg13g2_lv_pmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
-          + nf='ng' mult='m'
-          + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)'
-          + ad='max(w/ng,wmin)*z2/2*ng'
-          + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)'
-          + pd='(max(w/ng,wmin)+z2)*ng'
+          + as='as' ad='ad' pd='pd' ps='ps' nf='ng' mult='m'
           + dta=trise
           + ngcon=2
           + delvto='agauss(0, sg13g2_lv_pmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
           + factuo='agauss(1, sg13g2_lv_pmos_factuo_mm, (mm_ok != 1 ? 0 : 1))'
     .endif
 .else
-    Nsg13_lv_pmos d g s b sg13g2_lv_pmos_psp
-      + w='agauss(w, sg13g2_lv_pmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
-      + l='agauss(l, sg13g2_lv_pmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
-      + as='as' ad='ad' pd='pd' ps='ps' nf='ng' mult='m'
-      + dta=trise
-      + ngcon=2
-      + delvto='agauss(0, sg13g2_lv_pmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
-      + factuo='agauss(1, sg13g2_lv_pmos_factuo_mm, (mm_ok != 1 ? 0 : 1))'
+    .if (as <= 1e-50)
+        .if (floor(floor(ng/2+0.501)*2+0.001) != ng)
+            Nsg13_lv_pmos d g s b sg13g2_lv_pmos_psp_rf
+              + w='agauss(w, sg13g2_lv_pmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
+              + l='agauss(l, sg13g2_lv_pmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
+              + nf='ng' mult='m'
+              + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
+              + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
+              + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+              + pd='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+              + dta=trise
+              + ngcon=2
+              + delvto='agauss(0, sg13g2_lv_pmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
+              + factuo='agauss(1, sg13g2_lv_pmos_factuo_mm, (mm_ok != 1 ? 0 : 1))'
+        .else
+            Nsg13_lv_pmos d g s b sg13g2_lv_pmos_psp_rf
+              + w='agauss(w, sg13g2_lv_pmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
+              + l='agauss(l, sg13g2_lv_pmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
+              + nf='ng' mult='m'
+              + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)'
+              + ad='max(w/ng,wmin)*z2/2*ng'
+              + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)'
+              + pd='(max(w/ng,wmin)+z2)*ng'
+              + dta=trise
+              + ngcon=2
+              + delvto='agauss(0, sg13g2_lv_pmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
+              + factuo='agauss(1, sg13g2_lv_pmos_factuo_mm, (mm_ok != 1 ? 0 : 1))'
+        .endif
+    .else
+        Nsg13_lv_pmos d g s b sg13g2_lv_pmos_psp_rf
+          + w='agauss(w, sg13g2_lv_pmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
+          + l='agauss(l, sg13g2_lv_pmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
+          + as='as' ad='ad' pd='pd' ps='ps' nf='ng' mult='m'
+          + dta=trise
+          + ngcon=2
+          + delvto='agauss(0, sg13g2_lv_pmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
+          + factuo='agauss(1, sg13g2_lv_pmos_factuo_mm, (mm_ok != 1 ? 0 : 1))'
+    .endif
 .endif
 .ends
 
@@ -163,14 +245,22 @@
 
 .include sg13g2_moslv_parm.lib
 
- Nsg13_lv_pmos VDD VSS VSS VSS nmoscl_psp w='w' l='l' nf='ng' as='as' ad='ad' pd='pd' ps='ps' mult='m'  dta=trise ngcon=2
+.if (rfmode == 0)
+    Nsg13_lv_pmos VDD VSS VSS VSS nmoscl_psp w='w' l='l' nf='ng' as='as' ad='ad' pd='pd' ps='ps' mult='m'  dta=trise ngcon=2
+.else
+    Nsg13_lv_pmos VDD VSS VSS VSS nmoscl_psp_rf w='w' l='l' nf='ng' as='as' ad='ad' pd='pd' ps='ps' mult='m'  dta=trise ngcon=2
+.endif
 .ends nmoscl_2
 
 .subckt nmoscl_4  VDD VSS
 + l=0.36u w=168u m=1 ng=1 trise=0 as = 114e-12  ad = 114e-12 pd = 672u ps = 672u rfmode=0 pre_layout=1
 .include sg13g2_moslv_parm.lib
 
-Nsg13_lv_pmos VDD VSS VSS VSS nmoscl_psp w='w' l='l' nf='ng' as='as' ad='ad' pd='pd' ps='ps' mult='m'  dta=trise ngcon=2
+.if (rfmode == 0)
+    Nsg13_lv_pmos VDD VSS VSS VSS nmoscl_psp w='w' l='l' nf='ng' as='as' ad='ad' pd='pd' ps='ps' mult='m'  dta=trise ngcon=2
+.else
+    Nsg13_lv_pmos VDD VSS VSS VSS nmoscl_psp_rf w='w' l='l' nf='ng' as='as' ad='ad' pd='pd' ps='ps' mult='m'  dta=trise ngcon=2
+.endif
 .ends nmoscl_4
 
 *****************************************************************

--- a/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moslv_parm.lib
+++ b/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moslv_parm.lib
@@ -58,7 +58,135 @@
 *
 *******************************************************************************
 
-.model sg13g2_lv_nmos_psp pspnqs103va          type          =  +1
+.model sg13g2_lv_nmos_psp psp103va             type          =  +1
++ level         =  103.60                      tr            =  27.0                        dta           =  0.0
++ swgeo         =  1.0                         swigate       =  1.0                         swimpact      =  1.0
++ swgidl        =  1.0                         swjuncap      =  3.0                         swjunasym     =  0.0
++ swnud         =  0.0                         swedge        =  0.0                         swdelvtac     =  0.0
++ swign         =  1.0                         qmc           =  1.0                         lvaro         =  0.0
++ lvarl         =  0.0                         lvarw         =  0.0                         lap           =  2.9423e-08
++ wvaro         =  0.0                         wvarl         =  0.0                         wvarw         =  0.0
++ wot           = -1e-08                       dlq           = '-1.3721e-08 -((1-pre_layout)*2e-08 )'     dwq           = -1e-08
++ vfbo          = '-0.94312*sg13g2_lv_nmos_vfbo'             vfbl          =  0.013965                    vfbw          = -0.027122
++ vfblw         =  0.0044814                   stvfbo        =  0.00068785                  stvfbl        =  2.8624e-05
++ stvfbw        = -1.8689e-05                  stvfblw       =  5.1435e-07                  st2vfbo       =  0.0
++ toxo          =  '2.2404e-09*sg13g2_lv_nmos_toxo'                                           epsroxo       =  3.9                         nsubo         =  1.0483e+23
++ nsubw         =  7.5708                      wseg          =  5.3426e-06                  npck          =  1.743e+21
++ npckw         = -1.484                       wsegp         =  1e-08                       lpck          =  3.171e-07
++ lpckw         =  0.0                         fol1          = -0.0091066                   fol2          =  0.0021139
++ facneffaco    =  1.0                         facneffacl    =  0.0                         facneffacw    =  0.0
++ facneffaclw   =  0.0                         gfacnudo      =  1.0                         gfacnudl      =  0.0
++ gfacnudlexp   =  1.0                         gfacnudw      =  0.0                         gfacnudlw     =  0.0
++ vsbnudo       =  0.0                         dvsbnudo      =  1.0                         vnsubo        =  0.0
++ nslpo         =  0.05                        dnsubo        =  4.4409e-16                  dphibo        = '-0.25737*sg13g2_lv_nmos_dphibo'
++ dphibl        =  '0.24027*sg13g2_lv_nmos_dphibl'                                            dphiblexp     =  0.068979                    dphibw        =  '0.0168*sg13g2_lv_nmos_dphibw'
++ dphiblw       = '-0.0036959*sg13g2_lv_nmos_dphiblw'                                         delvtaco      =  0.0                         delvtacl      =  0.0
++ delvtaclexp   =  1.0                         delvtacw      =  0.0                         delvtaclw     =  0.0
++ npo           =  4.6457e+26                  npl           =  0.0                         toxovo        =  '2.2404e-09*sg13g2_lv_nmos_toxovo'
++ toxovdo       =  2e-09                       lov           =  '2.9423e-08 -((1-pre_layout)*9e-09 )'                                      lovd          =  0.0
++ novo          =  3.5714e+25                  novdo         =  5e+25                       cto           =  0.054556
++ ctl           =  '0.015058*sg13g2_lv_nmos_ctl' ctlexp        =  0.85719                     ctw           = -0.096878
++ ctlw          =  0.008767                    ctgo          =  0.0                         ctbo          =  0.0
++ stcto         =  1.0                         cfl           =  8.9001e-08                  cflexp        =  3.9688
++ cfw           = -0.17956                     cfbo          =  0.6952                      cfdo          =  0.0
++ pscel         =  0.0                         pscelexp      =  2.0                         pscew         =  0.0
++ pscebo        =  0.0                         pscedo        =  0.0                         uo            =  0.045582
++ fbet1         =  12.168                      fbet1w        =  0.38931                     lp1           =  5.1674e-09
++ lp1w          = -0.1544                      fbet2         = -2.302                       lp2           =  1.9441e-08
++ betw1         = -0.020925                    betw2         =  0.0087681                   wbet          =  5.9171e-08
++ stbeto        =  2.4165                      stbetl        = -0.036997                    stbetw        =  0.0046613
++ stbetlw       =  0.0062828                   mueo          =  0.77874                     muew          =  '0.030943*sg13g2_lv_nmos_muew '
++ stmueo        =  0.98971                     themuo        =  '2.0546*sg13g2_lv_nmos_themuo'                                             stthemuo      =  4.441e-15
++ cso           =  0.3164                      csl           =  0.12341                     cslexp        =  1.1398
++ csw           =  0.19805                     cslw          = -0.00044184                  stcso         =  2.9406
++ thecso        =  1.1822                      stthecso      =  0.0                         xcoro         =  0.053934
++ xcorl         = -0.11292                     xcorw         = -0.10913                     xcorlw        = -0.014959
++ stxcoro       =  2.0                         fetao         =  1.0                         rsw1          =  '130.0*sg13g2_lv_nmos_rsw1'
++ rsw2          =  0.0                         strso         = -0.49693                     rsbo          = -0.099725
++ rsgo          =  0.074518                    thesato       =  0.39843                     thesatl       =  '0.43388*sg13g2_lv_nmos_thesatl'
++ thesatlexp    =  1.0316                      thesatw       =  '0.12825*sg13g2_lv_nmos_thesatw'                                           thesatlw      = '-0.0044*sg13g2_lv_nmos_thesatlw'
++ stthesato     =  2.7784                      stthesatl     = -0.091893                    stthesatw     = -0.065908
++ stthesatlw    =  0.01292                     thesatbo      =  0.08213                     thesatgo      =  0.1146
++ axo           =  13.547                      axl           =  1.0186                      alpl          =  0.0088345
++ alplexp       =  0.68143                     alpw          =  1.0825                      alp1l1        =  0.021138
++ alp1lexp      =  0.25                        alp1l2        =  0.04044                     alp1w         = -0.077622
++ alp2l1        =  2.6817                      alp2lexp      =  0.25                        alp2l2        =  0.0
++ alp2w         = -0.13012                     vpo           =  0.32224                     a1o           =  6.239
++ a1l           =  0.052176                    a1w           = -0.052179                    a2o           =  17.75
++ sta2o         =  0.068723                    a3o           =  0.708                       a3l           = -0.045201
++ a3w           = -0.041992                    a4o           =  0.04649                     a4l           =  0.0
++ a4w           =  1.581e-16                   gcoo          =  10.0                        iginvlw       =  '121290.0 *(1+2.4761e-07 /l)*(1+-2.1167e-08 /w)'
++ igovw         =  3026.8                      igovdw        =  0.0                         stigo         =  2.9949
++ gc2o          =  0.8413                      gc3o          = -0.4698                      chibo         =  3.1
++ agidlw        =  0.001262                    agidldw       =  0.0                         bgidlo        =  19.92
++ bgidldo       =  41.0                        stbgidlo      =  0.0                         stbgidldo     =  0.0
++ cgidlo        =  0.06641                     cgidldo       =  0.0                         cgbovl        =  4.4409e-28
++ cfrdw         =  0.0                         fnto          =  1.0
++ fntexcl       =  0.0                         nfalw         =  7.616e+25                   nfblw         =  1026000000.0
++ nfclw         = -5e-08                       efo           =  1.0                         lintnoi       = -3.7e-08
++ alpnoi        =  1.869                       wedge         =  1e-08                       wedgew        =  0.0
++ vfbedgeo      = -1.0                         stvfbedgeo    =  0.0005                      stvfbedgel    =  0.0
++ stvfbedgew    =  0.0                         stvfbedgelw   =  0.0                         dphibedgeo    =  0.0
++ dphibedgel    =  0.0                         dphibedgelexp =  1.0                         dphibedgew    =  0.0
++ dphibedgelw   =  0.0                         nsubedgeo     =  5e+23                       nsubedgel     =  0.0
++ nsubedgelexp                                               =  1.0                         nsubedgew     =  0.0                         nsubedgelw    =  0.0
++ ctedgeo       =  0.0                         ctedgel       =  0.0                         ctedgelexp    =  1.0
++ fbetedge      =  0.0                         lpedge        =  1e-08                       betedgew      =  0.0
++ stbetedgeo    =  1.0                         stbetedgel    =  0.0                         stbetedgew    =  0.0
++ stbetedgelw   =  0.0                         psceedgel     =  0.0                         psceedgelexp  =  2.0
++ psceedgew     =  0.0                         pscebedgeo    =  0.0                         pscededgeo    =  0.0
++ cfedgel       =  0.0                         cfedgelexp    =  2.0                         cfedgew       =  0.0
++ cfdedgeo      =  0.0                         cfbedgeo      =  0.0                         fntedgeo      =  1.0
++ nfaedgelw     =  8e+22                       nfbedgelw     =  30000000.0                  nfcedgelw     =  0.0
++ efedgeo       =  1.0                         saref         =  1e-06                       sbref         =  1e-06
++ wlod          =  0.0                         kuo           =  0.0                         kvsat         =  0.0
++ tkuo          =  0.0                         lkuo          =  0.0                         wkuo          =  0.0
++ pkuo          =  0.0                         llodkuo       =  0.0                         wlodkuo       =  0.0
++ kvtho         =  0.0                         lkvtho        =  0.0                         wkvtho        =  0.0
++ pkvtho        =  0.0                         llodvth       =  0.0                         wlodvth       =  0.0
++ stetao        =  0.0                         lodetao       =  1.0                         scref         =  1e-06
++ web           =  0.0                         wec           =  0.0                         kvthoweo      =  0.0
++ kvthowel      =  0.0                         kvthowew      =  0.0                         kvthowelw     =  0.0
++ kuoweo        =  0.0                         kuowel        =  0.0                         kuowew        =  0.0
++ kuowelw       =  0.0                         trj           =  21.0                        swjunexp      =  0.0
++ imax          =  0.0015358                   frev          =  1000.0                      cjorbot       =  '0.00097636*sg13g2_lv_nmos_cjorbot'
++ cjorsti       =  '2.5279e-11*sg13g2_lv_nmos_cjorsti'                                        cjorgat       =  '3e-11*sg13g2_lv_nmos_cjorgat'                                             vbirbot       =  0.70829
++ vbirsti       =  0.79368                     vbirgat       =  2.0                         pbot          =  0.31309
++ psti          =  0.27362                     pgat          =  0.5424                      cjorbotd      =  0.001
++ cjorstid      =  1e-09                       cjorgatd      =  1e-09                       vbirbotd      =  1.0
++ vbirstid      =  1.0                         vbirgatd      =  1.0                         pbotd         =  0.5
++ pstid         =  0.5                         pgatd         =  0.5                         phigbot       =  1.1136
++ phigsti       =  1.3844                      phiggat       =  1.16                        idsatrbot     =  6.3087e-08
++ idsatrsti     =  1.9278e-15                  idsatrgat     =  0.0                         csrhbot       =  100.0
++ csrhsti       =  0.0001                      csrhgat       =  6.682e-06                   xjunsti       =  1.5783e-07
++ xjungat       =  0.0001                      phigbotd      =  1.16                        phigstid      =  1.16
++ phiggatd      =  1.16                        idsatrbotd    =  1e-12                       idsatrstid    =  1e-18
++ idsatrgatd    =  1e-18                       csrhbotd      =  100.0                       csrhstid      =  0.0001
++ csrhgatd      =  0.0001                      xjunstid      =  1e-07                       xjungatd      =  1e-07
++ ctatbot       =  100.0                       ctatsti       =  0.0001                      ctatgat       =  0.0001
++ mefftatbot    =  5.204                       mefftatsti    =  3.364                       mefftatgat    =  0.25
++ ctatbotd      =  100.0                       ctatstid      =  0.0001                      ctatgatd      =  0.0001
++ mefftatbotd   =  0.25                        mefftatstid   =  0.25                        mefftatgatd   =  0.25
++ cbbtbot       =  1e-12                       cbbtsti       =  1e-21                       cbbtgat       =  1e-18
++ fbbtrbot      =  1000000000.0                fbbtrsti      =  1000000000.0                fbbtrgat      =  1000000000.0
++ stfbbtbot     = -0.001                       stfbbtsti     = -0.001                       stfbbtgat     = -0.001
++ cbbtbotd      =  1e-12                       cbbtstid      =  1e-18                       cbbtgatd      =  1e-18
++ fbbtrbotd     =  1000000000.0                fbbtrstid     =  1000000000.0                fbbtrgatd     =  1000000000.0
++ stfbbtbotd    = -0.001                       stfbbtstid    = -0.001                       stfbbtgatd    = -0.001
++ vbrbot        =  10.0                        vbrsti        =  10.0                        vbrgat        =  10.0
++ pbrbot        =  4.0                         pbrsti        =  4.0                         pbrgat        =  4.0
++ vbrbotd       =  10.0                        vbrstid       =  10.0                        vbrgatd       =  10.0
++ pbrbotd       =  4.0                         pbrstid       =  4.0                         pbrgatd       =  4.0
++ vjunref       =  2.5                         fjunq         =  0.03                        vjunrefd      =  2.5
++ fjunqd        =  0.03                        rint          =  1.3025e-11
++ rvpoly        =  0.0                         dlsil         =  0.0
++ rsh           =  0.0                         rshd          =  0.0
++ cfrw          =  '2e-16 / ng'
++ SWSOA = 'SWSOA'
++ VGS_MAX = 1.6 VGD_MAX = 1.6 VGB_MAX = 1.6
++ VDS_MAX = 1.6 VDB_MAX = 1.6 VSB_MAX = 1.6
+
+.model sg13g2_lv_nmos_psp_rf pspnqs103va       type          =  +1
 + level         =  103.60                      tr            =  27.0                        dta           =  0.0
 + swgeo         =  1.0                         swigate       =  1.0                         swimpact      =  1.0
 + swgidl        =  1.0                         swjuncap      =  3.0                         swjunasym     =  0.0
@@ -182,10 +310,10 @@
 + rvpoly        =  0.0                         dlsil         =  0.0
 + rsh           =  0.0                         rshd          =  0.0
 + munqso        =  1.0
-+ swnqs         =  'rfmode * 5.0'                cfrw          =  '((1-rfmode)*2e-16 + rfmode * (1e-18 + pre_layout * (ng>0 ? 3.8525e-17 : 0)))/ng'
-+ rshg          =  'rfmode * 3.0'                rgo           =  'rfmode * 40.0'
-+ rbulko        =  'rfmode * 0.002 * ng/w'       rwello        =  'rfmode * 0.002 * ng/w'
-+ rjunso        =  'rfmode * 5000.0 * l/w'       rjundo        =  'rfmode * 5000.0 * l/w'
++ swnqs         =  'rfmode * 5.0'              cfrw          =  '((1-rfmode)*2e-16 + rfmode * (1e-18 + pre_layout * (ng>0 ? 3.8525e-17 : 0)))/ng'
++ rshg          =  'rfmode * 3.0'              rgo           =  'rfmode * 40.0'
++ rbulko        =  'rfmode * 0.002 * ng/w'     rwello        =  'rfmode * 0.002 * ng/w'
++ rjunso        =  'rfmode * 5000.0 * l/w'     rjundo        =  'rfmode * 5000.0 * l/w'
 + SWSOA = 'SWSOA'
 + VGS_MAX = 1.6 VGD_MAX = 1.6 VGB_MAX = 1.6
 + VDS_MAX = 1.6 VDB_MAX = 1.6 VSB_MAX = 1.6
@@ -211,7 +339,136 @@
 * - change parameter rint from 1.3323e-26 to 1e-12
 *******************************************************************************
 
-.model sg13g2_lv_pmos_psp pspnqs103va             type          =  -1
+.model sg13g2_lv_pmos_psp psp103va             type          =  -1
++ level         =  103.60                      tr            =  27.0                        dta           =  0.0
++ swgeo         =  1.0                         swigate       =  1.0                         swimpact      =  1.0
++ swgidl        =  1.0                         swjuncap      =  3.0                         swjunasym     =  0.0
++ swnud         =  0.0                         swedge        =  0.0                         swdelvtac     =  0.0
++ swign         =  1.0                         qmc           =  1.0                         lvaro         =  9.695e-08
++ lvarl         = -0.03438                     lvarw         =  0.0                         lap           =  2.5254e-08
++ wvaro         =  0.0                         wvarl         =  0.0                         wvarw         =  0.0
++ wot           =  1.5e-08                     dlq           = '-9.5922e-08 -((1-pre_layout)*3e-08 )'      dwq           =  1.5e-08
++ vfbo          = '-0.88703*sg13g2_lv_pmos_vfbo'              vfbl          =  0.0089886                   vfbw          =  0.0071805
++ vfblw         =  0.004075                    stvfbo        =  0.00075111                  stvfbl        =  2.4487e-06
++ stvfbw        =  6.217e-06                   stvfblw       =  2.2668e-07                  st2vfbo       =  0.0
++ toxo          =  '1.9704e-09*sg13g2_lv_pmos_toxo'                                           epsroxo       =  3.9                         nsubo         =  4.6011e+23
++ nsubw         = -0.013639                    wseg          =  1.058e-08                   npck          =  5.7416e+24
++ npckw         = -1.0                         wsegp         =  1e-10                       lpck          =  1.1576e-10
++ lpckw         = -0.022414                    fol1          = -0.0081173                   fol2          =  0.0081347
++ facneffaco    =  1.0                         facneffacl    =  0.0                         facneffacw    =  0.0
++ facneffaclw   =  0.0                         gfacnudo      =  1.0                         gfacnudl      =  0.0
++ gfacnudlexp   =  1.0                         gfacnudw      =  0.0                         gfacnudlw     =  0.0
++ vsbnudo       =  0.0                         dvsbnudo      =  1.0                         vnsubo        =  0.0
++ nslpo         =  0.05                        dnsubo        =  0.039707                    dphibo        = '-0.099209*sg13g2_lv_pmos_dphibo'
++ dphibl        =  '0.00020745*sg13g2_lv_pmos_dphibl'                                         dphiblexp     =  2.9957                      dphibw        = '-0.00069395*sg13g2_lv_pmos_dphibw'
++ dphiblw       = '-0.0030829*sg13g2_lv_pmos_dphiblw'                                         delvtaco      =  0.0                         delvtacl      =  0.0
++ delvtaclexp   =  1.0                         delvtacw      =  0.0                         delvtaclw     =  0.0
++ npo           =  1.2699e+26                  npl           = -0.095923                    toxovo        =  '1.9704e-09*sg13g2_lv_pmos_toxovo'
++ toxovdo       =  2e-09                       lov           =  '2.5254e-08 -((1-pre_layout)*8.85e-09 ) '                                  lovd          =  0.0
++ novo          =  3.104e+25                   novdo         =  5e+25                       cto           =  1.1814e-05
++ ctl           =  '0.0069387*sg13g2_lv_pmos_ctl'                                             ctlexp        =  1.4316                      ctw           =  0.36122
++ ctlw          = -0.014902                    ctgo          =  0.0                         ctbo          =  0.0
++ stcto         =  1.0                         cfl           =  0.00011247                  cflexp        =  3.0355
++ cfw           = -0.012199                    cfbo          =  0.57877                     cfdo          =  0.0
++ pscel         =  0.0                         pscelexp      =  2.0                         pscew         =  0.0
++ pscebo        =  0.0                         pscedo        =  0.0                         uo            =  0.017232
++ fbet1         = -0.2152                      fbet1w        = -0.065541                    lp1           =  0.00019766
++ lp1w          =  0.0                         fbet2         = -6.171                       lp2           =  1.2564e-08
++ betw1         = -0.3268                      betw2         =  0.060181                    wbet          =  5.424e-10
++ stbeto        =  1.6974                      stbetl        = -0.037605                    stbetw        = -0.0083384
++ stbetlw       =  0.0013663                   mueo          =  2.3326                      muew          = '-0.067414*sg13g2_lv_pmos_muew'
++ stmueo        =  0.84805                     themuo        =  '1.3169*sg13g2_lv_pmos_themuo'                                             stthemuo      =  4.441e-15
++ cso           =  0.94214                     csl           =  0.34682                     cslexp        =  1.5813
++ csw           = -0.11045                     cslw          =  0.014762                    stcso         =  1.0269
++ thecso        =  1.4566                      stthecso      =  0.0                         xcoro         =  0.092591
++ xcorl         =  0.11698                     xcorw         = -0.095907                    xcorlw        =  0.029574
++ stxcoro       =  2.7756e-17                  fetao         =  1.0                         rsw1          =  '697.38*sg13g2_lv_pmos_rsw1'
++ rsw2          = -0.088444                    strso         = -0.3508                      rsbo          =  0.06
++ rsgo          =  0.495                       thesato       =  0.099164                    thesatl       =  '0.010142*sg13g2_lv_pmos_thesatl'
++ thesatlexp    =  2.4434                      thesatw       = '-0.13745*sg13g2_lv_pmos_thesatw'                                           thesatlw      = '-0.103*sg13g2_lv_pmos_thesatlw'
++ stthesato     =  12.733                      stthesatl     = -1.9651                      stthesatw     = -0.047465
++ stthesatlw    =  0.07117                     thesatbo      =  0.0                         thesatgo      =  0.0
++ axo           =  8.1825                      axl           =  0.58095                     alpl          =  0.0047346
++ alplexp       =  0.8468                      alpw          = -0.21042                     alp1l1        =  0.0040221
++ alp1lexp      =  0.6408                      alp1l2        =  1.611e-08                   alp1w         = -0.057981
++ alp2l1        =  0.005286                    alp2lexp      =  0.25                        alp2l2        =  0.0
++ alp2w         =  0.063581                    vpo           =  7.3803e-06                  a1o           =  0.0001107
++ a1l           =  5.741                       a1w           =  5.78                        a2o           =  13.33
++ sta2o         =  2.0                         a3o           =  1.526                       a3l           = -0.08391
++ a3w           = -0.004911                    a4o           = -0.005545                    a4l           =  0.2771
++ a4w           =  0.7101                      gcoo          =  0.01231                     iginvlw       =  '4880.4 *(1+-5.803e-09 /l)*(1+5.1659e-08 /w)'
++ igovw         =  1327.0                      igovdw        =  0.0                         stigo         =  2.3506
++ gc2o          =  0.54762                     gc3o          = -0.29543                     chibo         =  3.1
++ agidlw        =  7.371e-05                   agidldw       =  0.0                         bgidlo        =  15.12
++ bgidldo       =  41.0                        stbgidlo      = -0.0014941                   stbgidldo     =  0.0
++ cgidlo        =  0.02068                     cgidldo       =  0.0                         cgbovl        =  2.186e-17
++ cfrdw         =  0.0                         fnto          =  1.85
++ fntexcl       =  0.0                         nfalw         =  2.209e+26                   nfblw         =  572300000.0
++ nfclw         =  5.641e-07                   efo           =  1.0                         lintnoi       =  1e-08
++ alpnoi        =  2.118                       wedge         =  1e-08                       wedgew        =  0.0
++ vfbedgeo      = -1.0                         stvfbedgeo    =  0.0005                      stvfbedgel    =  0.0
++ stvfbedgew    =  0.0                         stvfbedgelw   =  0.0                         dphibedgeo    =  0.0
++ dphibedgel    =  0.0                         dphibedgelexp =  1.0                         dphibedgew    =  0.0
++ dphibedgelw   =  0.0                         nsubedgeo     =  5e+23                       nsubedgel     =  0.0
++ nsubedgelexp                                               =  1.0                         nsubedgew     =  0.0                         nsubedgelw    =  0.0
++ ctedgeo       =  0.0                         ctedgel       =  0.0                         ctedgelexp    =  1.0
++ fbetedge      =  0.0                         lpedge        =  1e-08                       betedgew      =  0.0
++ stbetedgeo    =  1.0                         stbetedgel    =  0.0                         stbetedgew    =  0.0
++ stbetedgelw   =  0.0                         psceedgel     =  0.0                         psceedgelexp  =  2.0
++ psceedgew     =  0.0                         pscebedgeo    =  0.0                         pscededgeo    =  0.0
++ cfedgel       =  0.0                         cfedgelexp    =  2.0                         cfedgew       =  0.0
++ cfdedgeo      =  0.0                         cfbedgeo      =  0.0                         fntedgeo      =  1.0
++ nfaedgelw     =  8e+22                       nfbedgelw     =  30000000.0                  nfcedgelw     =  0.0
++ efedgeo       =  1.0                         saref         =  1e-06                       sbref         =  1e-06
++ wlod          =  0.0                         kuo           =  0.0                         kvsat         =  0.0
++ tkuo          =  0.0                         lkuo          =  0.0                         wkuo          =  0.0
++ pkuo          =  0.0                         llodkuo       =  0.0                         wlodkuo       =  0.0
++ kvtho         =  0.0                         lkvtho        =  0.0                         wkvtho        =  0.0
++ pkvtho        =  0.0                         llodvth       =  0.0                         wlodvth       =  0.0
++ stetao        =  0.0                         lodetao       =  1.0                         scref         =  1e-06
++ web           =  0.0                         wec           =  0.0                         kvthoweo      =  0.0
++ kvthowel      =  0.0                         kvthowew      =  0.0                         kvthowelw     =  0.0
++ kuoweo        =  0.0                         kuowel        =  0.0                         kuowew        =  0.0
++ kuowelw       =  0.0                         trj           =  21.0                        swjunexp      =  0.0
++ imax          =  0.0016551                   frev          =  1000.0                      cjorbot       =  '0.00086306*sg13g2_lv_pmos_cjorbot'
++ cjorsti       =  '3.1915e-11*sg13g2_lv_pmos_cjorsti'                                        cjorgat       =  '2.7474e-11*sg13g2_lv_pmos_cjorgat'                                        vbirbot       =  0.7686
++ vbirsti       =  1.7036                      vbirgat       =  1.399                       pbot          =  0.3618
++ psti          =  0.2548                      pgat          =  0.6475                      cjorbotd      =  0.001
++ cjorstid      =  1e-09                       cjorgatd      =  1e-09                       vbirbotd      =  1.0
++ vbirstid      =  1.0                         vbirgatd      =  1.0                         pbotd         =  0.5
++ pstid         =  0.5                         pgatd         =  0.5                         phigbot       =  1.204
++ phigsti       =  0.8186                      phiggat       =  1.65                        idsatrbot     =  2.6746e-08
++ idsatrsti     =  1.1115e-15                  idsatrgat     =  0.0                         csrhbot       =  100.0
++ csrhsti       =  0.0001                      csrhgat       =  0.0001                      xjunsti       =  6.292e-08
++ xjungat       =  9.105e-05                   phigbotd      =  1.16                        phigstid      =  1.16
++ phiggatd      =  1.16                        idsatrbotd    =  1e-12                       idsatrstid    =  1e-18
++ idsatrgatd    =  1e-18                       csrhbotd      =  100.0                       csrhstid      =  0.0001
++ csrhgatd      =  0.0001                      xjunstid      =  1e-07                       xjungatd      =  1e-07
++ ctatbot       =  100.0                       ctatsti       =  0.0001                      ctatgat       =  0.0001
++ mefftatbot    =  10.0                        mefftatsti    =  4.363                       mefftatgat    =  0.25
++ ctatbotd      =  100.0                       ctatstid      =  0.0001                      ctatgatd      =  0.0001
++ mefftatbotd   =  0.25                        mefftatstid   =  0.25                        mefftatgatd   =  0.25
++ cbbtbot       =  1e-12                       cbbtsti       =  1e-21                       cbbtgat       =  1e-18
++ fbbtrbot      =  1000000000.0                fbbtrsti      =  1000000000.0                fbbtrgat      =  1000000000.0
++ stfbbtbot     = -0.001                       stfbbtsti     = -0.001                       stfbbtgat     = -0.001
++ cbbtbotd      =  1e-12                       cbbtstid      =  1e-18                       cbbtgatd      =  1e-18
++ fbbtrbotd     =  1000000000.0                fbbtrstid     =  1000000000.0                fbbtrgatd     =  1000000000.0
++ stfbbtbotd    = -0.001                       stfbbtstid    = -0.001                       stfbbtgatd    = -0.001
++ vbrbot        =  10.0                        vbrsti        =  10.0                        vbrgat        =  10.0
++ pbrbot        =  4.0                         pbrsti        =  4.0                         pbrgat        =  4.0
++ vbrbotd       =  10.0                        vbrstid       =  10.0                        vbrgatd       =  10.0
++ pbrbotd       =  4.0                         pbrstid       =  4.0                         pbrgatd       =  4.0
++ vjunref       =  2.5                         fjunq         =  0.03                        vjunrefd      =  2.5
++ fjunqd        =  0.03                        rint          =  1e-12
++ rvpoly        =  0.0                         dlsil         =  0.0
++ rsh           =  0.0                         rshd          =  0.0
++ cfrw          =  '1e-16 / ng'
++ SWSOA = 'SWSOA'
++ VGS_MAX = 1.6 VGD_MAX = 1.6 VGB_MAX = 1.6
++ VDS_MAX = 1.6 VDB_MAX = 1.6 VSB_MAX = 1.6
+
+
+.model sg13g2_lv_pmos_psp_rf pspnqs103va       type          =  -1
 + level         =  103.60                      tr            =  27.0                        dta           =  0.0
 + swgeo         =  1.0                         swigate       =  1.0                         swimpact      =  1.0
 + swgidl        =  1.0                         swjuncap      =  3.0                         swjunasym     =  0.0
@@ -335,16 +592,143 @@
 + rvpoly        =  0.0                         dlsil         =  0.0
 + rsh           =  0.0                         rshd          =  0.0
 + munqso        =  1.0
-+ swnqs         =  'rfmode * 5.0'                cfrw          =  '(1e-16 + rfmode * (1e-18 + pre_layout * (ng>0 ? 1.2382e-16 : 0)))/ng'
-+ rshg          =  'rfmode * 20.0'               rgo           =  'rfmode * 22.0'
-+ rbulko        =  'rfmode * 0.002 * ng/w'       rwello        =  'rfmode * 0.001 * ng/w'
-+ rjunso        =  'rfmode * 5000.0 * l/w'       rjundo        =  'rfmode * 5000.0 * l/w'
++ swnqs         =  'rfmode * 5.0'              cfrw          =  '(1e-16 + rfmode * (1e-18 + pre_layout * (ng>0 ? 1.2382e-16 : 0)))/ng'
++ rshg          =  'rfmode * 20.0'             rgo           =  'rfmode * 22.0'
++ rbulko        =  'rfmode * 0.002 * ng/w'     rwello        =  'rfmode * 0.001 * ng/w'
++ rjunso        =  'rfmode * 5000.0 * l/w'     rjundo        =  'rfmode * 5000.0 * l/w'
++ SWSOA = 'SWSOA'
++ VGS_MAX = 1.6 VGD_MAX = 1.6 VGB_MAX = 1.6
++ VDS_MAX = 1.6 VDB_MAX = 1.6 VSB_MAX = 1.6
+                
+.model nmoscl_psp psp103va                     type          =  +1
++ tr            =  27.0                        dta           =  0.0
++ swgeo         =  1.0                         swigate       =  1.0                         swimpact      =  1.0
++ swgidl        =  1.0                         swjuncap      =  3.0                         swjunasym     =  0.0
++ swnud         =  0.0                         swedge        =  0.0                         swdelvtac     =  0.0
++ swign         =  1.0                         qmc           =  1.0                         lvaro         =  0.0
++ lvarl         =  0.0                         lvarw         =  0.0                         lap           =  2.9423e-08
++ wvaro         =  0.0                         wvarl         =  0.0                         wvarw         =  0.0
++ wot           = -1e-08                       dlq           = '-1.3721e-08 -((1-pre_layout)*2e-08 )'                  dwq           = -1e-08
++ vfbo          = '-0.94312*sg13g2_lv_nmos_vfbo'                                            vfbl          =  0.013965                    vfbw          = -0.027122
++ vfblw         =  0.0044814                   stvfbo        =  0.00068785                  stvfbl        =  2.8624e-05
++ stvfbw        = -1.8689e-05                  stvfblw       =  5.1435e-07                  st2vfbo       =  0.0
++ toxo          =  '2.2404e-09*sg13g2_lv_nmos_toxo'                                           epsroxo       =  3.9                         nsubo         =  1.0483e+23
++ nsubw         =  7.5708                      wseg          =  5.3426e-06                  npck          =  1.743e+21
++ npckw         = -1.484                       wsegp         =  1e-08                       lpck          =  3.171e-07
++ lpckw         =  0.0                         fol1          = -0.0091066                   fol2          =  0.0021139
++ facneffaco    =  1.0                         facneffacl    =  0.0                         facneffacw    =  0.0
++ facneffaclw   =  0.0                         gfacnudo      =  1.0                         gfacnudl      =  0.0
++ gfacnudlexp   =  1.0                         gfacnudw      =  0.0                         gfacnudlw     =  0.0
++ vsbnudo       =  0.0                         dvsbnudo      =  1.0                         vnsubo        =  0.0
++ nslpo         =  0.05                        dnsubo        =  4.4409e-16                  dphibo        = '-0.25737*sg13g2_lv_nmos_dphibo'
++ dphibl        =  '0.24027*sg13g2_lv_nmos_dphibl'                                            dphiblexp     =  0.068979                    dphibw        =  '0.0168*sg13g2_lv_nmos_dphibw'
++ dphiblw       = '-0.0036959*sg13g2_lv_nmos_dphiblw'                                         delvtaco      =  0.0                         delvtacl      =  0.0
++ delvtaclexp   =  1.0                         delvtacw      =  0.0                         delvtaclw     =  0.0
++ npo           =  4.6457e+26                  npl           =  0.0                         toxovo        =  '2.2404e-09*sg13g2_lv_nmos_toxovo'
++ toxovdo       =  2e-09                       lov           =  '2.9423e-08 -((1-pre_layout)*9e-09 )'                                      lovd          =  0.0
++ novo          =  3.5714e+25                  novdo         =  5e+25                       cto           =  0.054556
++ ctl           =  '0.015058*sg13g2_lv_nmos_ctl' ctlexp        =  0.85719                     ctw           = -0.096878
++ ctlw          =  0.008767                    ctgo          =  0.0                         ctbo          =  0.0
++ stcto         =  1.0                         cfl           =  8.9001e-08                  cflexp        =  3.9688
++ cfw           = -0.17956                     cfbo          =  0.6952                      cfdo          =  0.0
++ pscel         =  0.0                         pscelexp      =  2.0                         pscew         =  0.0
++ pscebo        =  0.0                         pscedo        =  0.0                         uo            =  0.045582
++ fbet1         =  12.168                      fbet1w        =  0.38931                     lp1           =  5.1674e-09
++ lp1w          = -0.1544                      fbet2         = -2.302                       lp2           =  1.9441e-08
++ betw1         = -0.020925                    betw2         =  0.0087681                   wbet          =  5.9171e-08
++ stbeto        =  2.4165                      stbetl        = -0.036997                    stbetw        =  0.0046613
++ stbetlw       =  0.0062828                   mueo          =  0.77874                     muew          =  '0.030943*sg13g2_lv_nmos_muew '
++ stmueo        =  0.98971                     themuo        =  '2.0546*sg13g2_lv_nmos_themuo'                                             stthemuo      =  4.441e-15
++ cso           =  0.3164                      csl           =  0.12341                     cslexp        =  1.1398
++ csw           =  0.19805                     cslw          = -0.00044184                  stcso         =  2.9406
++ thecso        =  1.1822                      stthecso      =  0.0                         xcoro         =  0.053934
++ xcorl         = -0.11292                     xcorw         = -0.10913                     xcorlw        = -0.014959
++ stxcoro       =  2.0                         fetao         =  1.0                         rsw1          =  '130.0*sg13g2_lv_nmos_rsw1'
++ rsw2          =  0.0                         strso         = -0.49693                     rsbo          = -0.099725
++ rsgo          =  0.074518                    thesato       =  0.39843                     thesatl       =  '0.43388*sg13g2_lv_nmos_thesatl'
++ thesatlexp    =  1.0316                      thesatw       =  '0.12825*sg13g2_lv_nmos_thesatw'                                           thesatlw      = '-0.0044*sg13g2_lv_nmos_thesatlw'
++ stthesato     =  2.7784                      stthesatl     = -0.091893                    stthesatw     = -0.065908
++ stthesatlw    =  0.01292                     thesatbo      =  0.08213                     thesatgo      =  0.1146
++ axo           =  13.547                      axl           =  1.0186                      alpl          =  0.0088345
++ alplexp       =  0.68143                     alpw          =  1.0825                      alp1l1        =  0.021138
++ alp1lexp      =  0.25                        alp1l2        =  0.04044                     alp1w         = -0.077622
++ alp2l1        =  2.6817                      alp2lexp      =  0.25                        alp2l2        =  0.0
++ alp2w         = -0.13012                     vpo           =  0.32224                     a1o           =  6.239
++ a1l           =  0.052176                    a1w           = -0.052179                    a2o           =  17.75
++ sta2o         =  0.068723                    a3o           =  0.708                       a3l           = -0.045201
++ a3w           = -0.041992                    a4o           =  0.04649                     a4l           =  0.0
++ a4w           =  1.581e-16                   gcoo          =  10.0                        iginvlw       =  '121290.0 *(1+2.4761e-07 /l)*(1+-2.1167e-08 /w)'
++ igovw         =  3026.8                      igovdw        =  0.0                         stigo         =  2.9949
++ gc2o          =  0.8413                      gc3o          = -0.4698                      chibo         =  3.1
++ agidlw        =  0.001262                    agidldw       =  0.0                         bgidlo        =  19.92
++ bgidldo       =  41.0                        stbgidlo      =  0.0                         stbgidldo     =  0.0
++ cgidlo        =  0.06641                     cgidldo       =  0.0                         cgbovl        =  4.4409e-28
++ cfrdw         =  0.0                         fnto          =  1.0
++ fntexcl       =  0.0                         nfalw         =  7.616e+25                   nfblw         =  1026000000.0
++ nfclw         = -5e-08                       efo           =  1.0                         lintnoi       = -3.7e-08
++ alpnoi        =  1.869                       wedge         =  1e-08                       wedgew        =  0.0
++ vfbedgeo      = -1.0                         stvfbedgeo    =  0.0005                      stvfbedgel    =  0.0
++ stvfbedgew    =  0.0                         stvfbedgelw   =  0.0                         dphibedgeo    =  0.0
++ dphibedgel    =  0.0                         dphibedgelexp =  1.0                         dphibedgew    =  0.0
++ dphibedgelw   =  0.0                         nsubedgeo     =  5e+23                       nsubedgel     =  0.0
++ nsubedgelexp                                               =  1.0                         nsubedgew     =  0.0                         nsubedgelw    =  0.0
++ ctedgeo       =  0.0                         ctedgel       =  0.0                         ctedgelexp    =  1.0
++ fbetedge      =  0.0                         lpedge        =  1e-08                       betedgew      =  0.0
++ stbetedgeo    =  1.0                         stbetedgel    =  0.0                         stbetedgew    =  0.0
++ stbetedgelw   =  0.0                         psceedgel     =  0.0                         psceedgelexp  =  2.0
++ psceedgew     =  0.0                         pscebedgeo    =  0.0                         pscededgeo    =  0.0
++ cfedgel       =  0.0                         cfedgelexp    =  2.0                         cfedgew       =  0.0
++ cfdedgeo      =  0.0                         cfbedgeo      =  0.0                         fntedgeo      =  1.0
++ nfaedgelw     =  8e+22                       nfbedgelw     =  30000000.0                  nfcedgelw     =  0.0
++ efedgeo       =  1.0                         saref         =  1e-06                       sbref         =  1e-06
++ wlod          =  0.0                         kuo           =  0.0                         kvsat         =  0.0
++ tkuo          =  0.0                         lkuo          =  0.0                         wkuo          =  0.0
++ pkuo          =  0.0                         llodkuo       =  0.0                         wlodkuo       =  0.0
++ kvtho         =  0.0                         lkvtho        =  0.0                         wkvtho        =  0.0
++ pkvtho        =  0.0                         llodvth       =  0.0                         wlodvth       =  0.0
++ stetao        =  0.0                         lodetao       =  1.0                         scref         =  1e-06
++ web           =  0.0                         wec           =  0.0                         kvthoweo      =  0.0
++ kvthowel      =  0.0                         kvthowew      =  0.0                         kvthowelw     =  0.0
++ kuoweo        =  0.0                         kuowel        =  0.0                         kuowew        =  0.0
++ kuowelw       =  0.0                         trj           =  21.0                        swjunexp      =  0.0
++ imax          =  0.0015358                   frev          =  1000.0                      cjorbot       =  '0.00097636*sg13g2_lv_nmos_cjorbot'
++ cjorsti       =  '2.5279e-11*sg13g2_lv_nmos_cjorsti'                                        cjorgat       =  '3e-11*sg13g2_lv_nmos_cjorgat'                                             vbirbot       =  0.70829
++ vbirsti       =  0.79368                     vbirgat       =  2.0                         pbot          =  0.31309
++ psti          =  0.27362                     pgat          =  0.5424                      cjorbotd      =  0.001
++ cjorstid      =  1e-09                       cjorgatd      =  1e-09                       vbirbotd      =  1.0
++ vbirstid      =  1.0                         vbirgatd      =  1.0                         pbotd         =  0.5
++ pstid         =  0.5                         pgatd         =  0.5                         phigbot       =  1.1136
++ phigsti       =  1.3844                      phiggat       =  1.16                        idsatrbot     =  6.3087e-08
++ idsatrsti     =  1.9278e-15                  idsatrgat     =  0.0                         csrhbot       =  100.0
++ csrhsti       =  0.0001                      csrhgat       =  6.682e-06                   xjunsti       =  1.5783e-07
++ xjungat       =  0.0001                      phigbotd      =  1.16                        phigstid      =  1.16
++ phiggatd      =  1.16                        idsatrbotd    =  1e-12                       idsatrstid    =  1e-18
++ idsatrgatd    =  1e-18                       csrhbotd      =  100.0                       csrhstid      =  0.0001
++ csrhgatd      =  0.0001                      xjunstid      =  1e-07                       xjungatd      =  1e-07
++ ctatbot       =  100.0                       ctatsti       =  0.0001                      ctatgat       =  0.0001
++ mefftatbot    =  5.204                       mefftatsti    =  3.364                       mefftatgat    =  0.25
++ ctatbotd      =  100.0                       ctatstid      =  0.0001                      ctatgatd      =  0.0001
++ mefftatbotd   =  0.25                        mefftatstid   =  0.25                        mefftatgatd   =  0.25
++ cbbtbot       =  1e-12                       cbbtsti       =  1e-21                       cbbtgat       =  1e-18
++ fbbtrbot      =  1000000000.0                fbbtrsti      =  1000000000.0                fbbtrgat      =  1000000000.0
++ stfbbtbot     = -0.001                       stfbbtsti     = -0.001                       stfbbtgat     = -0.001
++ cbbtbotd      =  1e-12                       cbbtstid      =  1e-18                       cbbtgatd      =  1e-18
++ fbbtrbotd     =  1000000000.0                fbbtrstid     =  1000000000.0                fbbtrgatd     =  1000000000.0
++ stfbbtbotd    = -0.001                       stfbbtstid    = -0.001                       stfbbtgatd    = -0.001
++ vbrbot        =  10.0                        vbrsti        =  10.0                        vbrgat        =  10.0
++ pbrbot        =  4.0                         pbrsti        =  4.0                         pbrgat        =  4.0
++ vbrbotd       =  10.0                        vbrstid       =  10.0                        vbrgatd       =  10.0
++ pbrbotd       =  4.0                         pbrstid       =  4.0                         pbrgatd       =  4.0
++ vjunref       =  2.5                         fjunq         =  0.03                        vjunrefd      =  2.5
++ fjunqd        =  0.03                        rint          =  1.3025e-11
++ rvpoly        =  0.0                         dlsil         =  0.0
++ rsh           =  0.0                         rshd          =  0.0
++ cfrw          =  '2e-16 / ng'
 + SWSOA = 'SWSOA'
 + VGS_MAX = 1.6 VGD_MAX = 1.6 VGB_MAX = 1.6
 + VDS_MAX = 1.6 VDB_MAX = 1.6 VSB_MAX = 1.6
 
-                
-.model nmoscl_psp pspnqs103va                  type          =  +1
+.model nmoscl_psp_rf pspnqs103va               type          =  +1
 + tr            =  27.0                        dta           =  0.0
 + swgeo         =  1.0                         swigate       =  1.0                         swimpact      =  1.0
 + swgidl        =  1.0                         swjuncap      =  3.0                         swjunasym     =  0.0
@@ -468,10 +852,10 @@
 + rvpoly        =  0.0                         dlsil         =  0.0
 + rsh           =  0.0                         rshd          =  0.0
 + munqso        =  1.0
-+ swnqs         =  'rfmode * 5.0'                cfrw          =  '((1-rfmode)*2e-16 + rfmode * (1e-18 + pre_layout * (ng>0 ? 3.8525e-17 : 0)))/ng'
-+ rshg          =  'rfmode * 3.0'                rgo           =  'rfmode * 40.0'
-+ rbulko        =  'rfmode * 0.002 * ng/w'       rwello        =  'rfmode * 0.002 * ng/w'
-+ rjunso        =  'rfmode * 5000.0 * l/w'       rjundo        =  'rfmode * 5000.0 * l/w'
++ swnqs         =  'rfmode * 5.0'              cfrw          =  '((1-rfmode)*2e-16 + rfmode * (1e-18 + pre_layout * (ng>0 ? 3.8525e-17 : 0)))/ng'
++ rshg          =  'rfmode * 3.0'              rgo           =  'rfmode * 40.0'
++ rbulko        =  'rfmode * 0.002 * ng/w'     rwello        =  'rfmode * 0.002 * ng/w'
++ rjunso        =  'rfmode * 5000.0 * l/w'     rjundo        =  'rfmode * 5000.0 * l/w'
 + SWSOA = 'SWSOA'
 + VGS_MAX = 1.6 VGD_MAX = 1.6 VGB_MAX = 1.6
 + VDS_MAX = 1.6 VDB_MAX = 1.6 VSB_MAX = 1.6

--- a/ihp-sg13g2/libs.tech/verilog-a/psp103/PSP103_SPCalculation.include
+++ b/ihp-sg13g2/libs.tech/verilog-a/psp103/PSP103_SPCalculation.include
@@ -125,7 +125,7 @@
         xi2s         =  (8.0 * temp - 12.0 * xi0s) * temp * temp;
         if (x_s < `se05) begin
             delta_1s     =  exp(x_s);
-            Es           =  exp(-x_s);
+            Es           =  1.0 / delta_1s;
             delta_1s     =  delta_ns * delta_1s;
         end else if (x_s > (xn_s - `se05)) begin
             delta_1s     =  exp(x_s - xn_s);

--- a/ihp-sg13g2/libs.tech/verilog-a/psp103/psp103.va
+++ b/ihp-sg13g2/libs.tech/verilog-a/psp103/psp103.va
@@ -45,7 +45,11 @@
 //
 /////////////////////////////////////////////////////////////////////////////
 
+`ifdef __XYCE__
 module PSP103_VA(D, G, S, B);
+`else
+module PSP103VA(D, G, S, B);
+`endif
 
 `include "PSP103_module.include"
 

--- a/ihp-sg13g2/libs.tech/xschem/install.py
+++ b/ihp-sg13g2/libs.tech/xschem/install.py
@@ -70,6 +70,9 @@ if __name__ == "__main__":
     
     program_name = "openvaf"
     if is_program_installed(program_name):
+        command = "openvaf psp103.va --output " + destination_directory + "/psp103.osdi"    
+        print(f"{program_name} is installed and about to run the command '{command}' in a location: {source_directory} ")	
+        exec_app_in_directory(command, source_directory + "/psp103")
         command = "openvaf psp103_nqs.va --output " + destination_directory + "/psp103_nqs.osdi"    
         print(f"{program_name} is installed and about to run the command '{command}' in a location: {source_directory} ")	
         exec_app_in_directory(command, source_directory + "/psp103")


### PR DESCRIPTION
This PR is initiated by issue #743.
 
Actual all lv and hv mos simulations use by default the psp103_nqs model with switched off rf capabilities (rfmode=0). This is waste of resources and follows sometimes in convergence problems.

This PR allows the user to use the more suitable model psp103 for normal cmos designs in this 130nm process node. If more rf model features are required for rf circuits the user can switch to the psp103_nqs model by setting the device parameter rfmode=1 in the device symbol property box. There is no need to modify library entries.

Experiments with the 2k SRAM from issue #743 show runtime improvements of more than 50% with same results.
