### PR TITLE
ihp-sg13g2: libs.ref: sg13g2_io: lib: Add dont_use

### DIFF
--- a/ihp-sg13g2/libs.ref/sg13g2_io/lib/sg13g2_io_fast_1p32V_3p6V_m40C.lib
+++ b/ihp-sg13g2/libs.ref/sg13g2_io/lib/sg13g2_io_fast_1p32V_3p6V_m40C.lib
@@ -300,6 +300,8 @@ library (sg13g2_io_fast_1p32V_3p6V_m40C) {
  cell (sg13g2_IOPadIn) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "input";
     pad_drivers : 1;
     bond_pads : 1;
@@ -490,6 +492,8 @@ library (sg13g2_io_fast_1p32V_3p6V_m40C) {
  cell (sg13g2_IOPadInOut16mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "inout";
     pad_drivers : 1;
     bond_pads : 1;
@@ -1184,6 +1188,8 @@ library (sg13g2_io_fast_1p32V_3p6V_m40C) {
  cell (sg13g2_IOPadInOut30mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "inout";
     pad_drivers : 1;
     bond_pads : 1;
@@ -1878,6 +1884,8 @@ library (sg13g2_io_fast_1p32V_3p6V_m40C) {
  cell (sg13g2_IOPadInOut4mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "inout";
     pad_drivers : 1;
     bond_pads : 1;
@@ -2572,6 +2580,8 @@ library (sg13g2_io_fast_1p32V_3p6V_m40C) {
  cell (sg13g2_IOPadOut16mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "inout";
     pad_drivers : 1;
     bond_pads : 1;
@@ -2763,6 +2773,8 @@ library (sg13g2_io_fast_1p32V_3p6V_m40C) {
  cell (sg13g2_IOPadOut30mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "inout";
     pad_drivers : 1;
     bond_pads : 1;
@@ -2954,6 +2966,8 @@ library (sg13g2_io_fast_1p32V_3p6V_m40C) {
  cell (sg13g2_IOPadOut4mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "inout";
     pad_drivers : 1;
     bond_pads : 1;
@@ -3145,6 +3159,8 @@ library (sg13g2_io_fast_1p32V_3p6V_m40C) {
  cell (sg13g2_IOPadTriOut16mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "tri_out";
     pad_drivers : 1;
     bond_pads : 1;
@@ -3611,6 +3627,8 @@ library (sg13g2_io_fast_1p32V_3p6V_m40C) {
  cell (sg13g2_IOPadTriOut30mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "tri_out";
     pad_drivers : 1;
     bond_pads : 1;
@@ -4077,6 +4095,8 @@ library (sg13g2_io_fast_1p32V_3p6V_m40C) {
  cell (sg13g2_IOPadTriOut4mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "tri_out";
     pad_drivers : 1;
     bond_pads : 1;

--- a/ihp-sg13g2/libs.ref/sg13g2_io/lib/sg13g2_io_fast_1p65V_3p6V_m40C.lib
+++ b/ihp-sg13g2/libs.ref/sg13g2_io/lib/sg13g2_io_fast_1p65V_3p6V_m40C.lib
@@ -300,6 +300,8 @@ library (sg13g2_io_fast_1p65V_3p6V_m40C) {
  cell (sg13g2_IOPadIn) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "input";
     pad_drivers : 1;
     bond_pads : 1;
@@ -490,6 +492,8 @@ library (sg13g2_io_fast_1p65V_3p6V_m40C) {
  cell (sg13g2_IOPadInOut16mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "inout";
     pad_drivers : 1;
     bond_pads : 1;
@@ -1184,6 +1188,8 @@ library (sg13g2_io_fast_1p65V_3p6V_m40C) {
  cell (sg13g2_IOPadInOut30mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "inout";
     pad_drivers : 1;
     bond_pads : 1;
@@ -1878,6 +1884,8 @@ library (sg13g2_io_fast_1p65V_3p6V_m40C) {
  cell (sg13g2_IOPadInOut4mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "inout";
     pad_drivers : 1;
     bond_pads : 1;
@@ -2572,6 +2580,8 @@ library (sg13g2_io_fast_1p65V_3p6V_m40C) {
  cell (sg13g2_IOPadOut16mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "inout";
     pad_drivers : 1;
     bond_pads : 1;
@@ -2763,6 +2773,8 @@ library (sg13g2_io_fast_1p65V_3p6V_m40C) {
  cell (sg13g2_IOPadOut30mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "inout";
     pad_drivers : 1;
     bond_pads : 1;
@@ -2954,6 +2966,8 @@ library (sg13g2_io_fast_1p65V_3p6V_m40C) {
  cell (sg13g2_IOPadOut4mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "inout";
     pad_drivers : 1;
     bond_pads : 1;
@@ -3145,6 +3159,8 @@ library (sg13g2_io_fast_1p65V_3p6V_m40C) {
  cell (sg13g2_IOPadTriOut16mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "tri_out";
     pad_drivers : 1;
     bond_pads : 1;
@@ -3611,6 +3627,8 @@ library (sg13g2_io_fast_1p65V_3p6V_m40C) {
  cell (sg13g2_IOPadTriOut30mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "tri_out";
     pad_drivers : 1;
     bond_pads : 1;
@@ -4077,6 +4095,8 @@ library (sg13g2_io_fast_1p65V_3p6V_m40C) {
  cell (sg13g2_IOPadTriOut4mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "tri_out";
     pad_drivers : 1;
     bond_pads : 1;

--- a/ihp-sg13g2/libs.ref/sg13g2_io/lib/sg13g2_io_slow_1p08V_3p0V_125C.lib
+++ b/ihp-sg13g2/libs.ref/sg13g2_io/lib/sg13g2_io_slow_1p08V_3p0V_125C.lib
@@ -300,6 +300,8 @@ library (sg13g2_io_slow_1p08V_3p0V_125C) {
  cell (sg13g2_IOPadIn) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "input";
     pad_drivers : 1;
     bond_pads : 1;
@@ -490,6 +492,8 @@ library (sg13g2_io_slow_1p08V_3p0V_125C) {
  cell (sg13g2_IOPadInOut16mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "inout";
     pad_drivers : 1;
     bond_pads : 1;
@@ -1184,6 +1188,8 @@ library (sg13g2_io_slow_1p08V_3p0V_125C) {
  cell (sg13g2_IOPadInOut30mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "inout";
     pad_drivers : 1;
     bond_pads : 1;
@@ -1878,6 +1884,8 @@ library (sg13g2_io_slow_1p08V_3p0V_125C) {
  cell (sg13g2_IOPadInOut4mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "inout";
     pad_drivers : 1;
     bond_pads : 1;
@@ -2572,6 +2580,8 @@ library (sg13g2_io_slow_1p08V_3p0V_125C) {
  cell (sg13g2_IOPadOut16mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "inout";
     pad_drivers : 1;
     bond_pads : 1;
@@ -2763,6 +2773,8 @@ library (sg13g2_io_slow_1p08V_3p0V_125C) {
  cell (sg13g2_IOPadOut30mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "inout";
     pad_drivers : 1;
     bond_pads : 1;
@@ -2954,6 +2966,8 @@ library (sg13g2_io_slow_1p08V_3p0V_125C) {
  cell (sg13g2_IOPadOut4mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "inout";
     pad_drivers : 1;
     bond_pads : 1;
@@ -3145,6 +3159,8 @@ library (sg13g2_io_slow_1p08V_3p0V_125C) {
  cell (sg13g2_IOPadTriOut16mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "tri_out";
     pad_drivers : 1;
     bond_pads : 1;
@@ -3611,6 +3627,8 @@ library (sg13g2_io_slow_1p08V_3p0V_125C) {
  cell (sg13g2_IOPadTriOut30mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "tri_out";
     pad_drivers : 1;
     bond_pads : 1;
@@ -4077,6 +4095,8 @@ library (sg13g2_io_slow_1p08V_3p0V_125C) {
  cell (sg13g2_IOPadTriOut4mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "tri_out";
     pad_drivers : 1;
     bond_pads : 1;

--- a/ihp-sg13g2/libs.ref/sg13g2_io/lib/sg13g2_io_slow_1p35V_3p0V_125C.lib
+++ b/ihp-sg13g2/libs.ref/sg13g2_io/lib/sg13g2_io_slow_1p35V_3p0V_125C.lib
@@ -300,6 +300,8 @@ library (sg13g2_io_slow_1p35V_3p0V_125C) {
  cell (sg13g2_IOPadIn) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "input";
     pad_drivers : 1;
     bond_pads : 1;
@@ -490,6 +492,8 @@ library (sg13g2_io_slow_1p35V_3p0V_125C) {
  cell (sg13g2_IOPadInOut16mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "inout";
     pad_drivers : 1;
     bond_pads : 1;
@@ -1184,6 +1188,8 @@ library (sg13g2_io_slow_1p35V_3p0V_125C) {
  cell (sg13g2_IOPadInOut30mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "inout";
     pad_drivers : 1;
     bond_pads : 1;
@@ -1878,6 +1884,8 @@ library (sg13g2_io_slow_1p35V_3p0V_125C) {
  cell (sg13g2_IOPadInOut4mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "inout";
     pad_drivers : 1;
     bond_pads : 1;
@@ -2572,6 +2580,8 @@ library (sg13g2_io_slow_1p35V_3p0V_125C) {
  cell (sg13g2_IOPadOut16mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "inout";
     pad_drivers : 1;
     bond_pads : 1;
@@ -2763,6 +2773,8 @@ library (sg13g2_io_slow_1p35V_3p0V_125C) {
  cell (sg13g2_IOPadOut30mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "inout";
     pad_drivers : 1;
     bond_pads : 1;
@@ -2954,6 +2966,8 @@ library (sg13g2_io_slow_1p35V_3p0V_125C) {
  cell (sg13g2_IOPadOut4mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "inout";
     pad_drivers : 1;
     bond_pads : 1;
@@ -3145,6 +3159,8 @@ library (sg13g2_io_slow_1p35V_3p0V_125C) {
  cell (sg13g2_IOPadTriOut16mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "tri_out";
     pad_drivers : 1;
     bond_pads : 1;
@@ -3611,6 +3627,8 @@ library (sg13g2_io_slow_1p35V_3p0V_125C) {
  cell (sg13g2_IOPadTriOut30mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "tri_out";
     pad_drivers : 1;
     bond_pads : 1;
@@ -4077,6 +4095,8 @@ library (sg13g2_io_slow_1p35V_3p0V_125C) {
  cell (sg13g2_IOPadTriOut4mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "tri_out";
     pad_drivers : 1;
     bond_pads : 1;

--- a/ihp-sg13g2/libs.ref/sg13g2_io/lib/sg13g2_io_typ_1p2V_3p3V_25C.lib
+++ b/ihp-sg13g2/libs.ref/sg13g2_io/lib/sg13g2_io_typ_1p2V_3p3V_25C.lib
@@ -300,6 +300,8 @@ library (sg13g2_io_typ_1p2V_3p3V_25C) {
  cell (sg13g2_IOPadIn) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "input";
     pad_drivers : 1;
     bond_pads : 1;
@@ -490,6 +492,8 @@ library (sg13g2_io_typ_1p2V_3p3V_25C) {
  cell (sg13g2_IOPadInOut16mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "inout";
     pad_drivers : 1;
     bond_pads : 1;
@@ -1184,6 +1188,8 @@ library (sg13g2_io_typ_1p2V_3p3V_25C) {
  cell (sg13g2_IOPadInOut30mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "inout";
     pad_drivers : 1;
     bond_pads : 1;
@@ -1878,6 +1884,8 @@ library (sg13g2_io_typ_1p2V_3p3V_25C) {
  cell (sg13g2_IOPadInOut4mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "inout";
     pad_drivers : 1;
     bond_pads : 1;
@@ -2572,6 +2580,8 @@ library (sg13g2_io_typ_1p2V_3p3V_25C) {
  cell (sg13g2_IOPadOut16mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "inout";
     pad_drivers : 1;
     bond_pads : 1;
@@ -2763,6 +2773,8 @@ library (sg13g2_io_typ_1p2V_3p3V_25C) {
  cell (sg13g2_IOPadOut30mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "inout";
     pad_drivers : 1;
     bond_pads : 1;
@@ -2954,6 +2966,8 @@ library (sg13g2_io_typ_1p2V_3p3V_25C) {
  cell (sg13g2_IOPadOut4mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "inout";
     pad_drivers : 1;
     bond_pads : 1;
@@ -3145,6 +3159,8 @@ library (sg13g2_io_typ_1p2V_3p3V_25C) {
  cell (sg13g2_IOPadTriOut16mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "tri_out";
     pad_drivers : 1;
     bond_pads : 1;
@@ -3611,6 +3627,8 @@ library (sg13g2_io_typ_1p2V_3p3V_25C) {
  cell (sg13g2_IOPadTriOut30mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "tri_out";
     pad_drivers : 1;
     bond_pads : 1;
@@ -4077,6 +4095,8 @@ library (sg13g2_io_typ_1p2V_3p3V_25C) {
  cell (sg13g2_IOPadTriOut4mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "tri_out";
     pad_drivers : 1;
     bond_pads : 1;

--- a/ihp-sg13g2/libs.ref/sg13g2_io/lib/sg13g2_io_typ_1p5V_3p3V_25C.lib
+++ b/ihp-sg13g2/libs.ref/sg13g2_io/lib/sg13g2_io_typ_1p5V_3p3V_25C.lib
@@ -300,6 +300,8 @@ library (sg13g2_io_typ_1p5V_3p3V_25C) {
  cell (sg13g2_IOPadIn) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "input";
     pad_drivers : 1;
     bond_pads : 1;
@@ -490,6 +492,8 @@ library (sg13g2_io_typ_1p5V_3p3V_25C) {
  cell (sg13g2_IOPadInOut16mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "inout";
     pad_drivers : 1;
     bond_pads : 1;
@@ -1184,6 +1188,8 @@ library (sg13g2_io_typ_1p5V_3p3V_25C) {
  cell (sg13g2_IOPadInOut30mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "inout";
     pad_drivers : 1;
     bond_pads : 1;
@@ -1878,6 +1884,8 @@ library (sg13g2_io_typ_1p5V_3p3V_25C) {
  cell (sg13g2_IOPadInOut4mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "inout";
     pad_drivers : 1;
     bond_pads : 1;
@@ -2572,6 +2580,8 @@ library (sg13g2_io_typ_1p5V_3p3V_25C) {
  cell (sg13g2_IOPadOut16mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "inout";
     pad_drivers : 1;
     bond_pads : 1;
@@ -2763,6 +2773,8 @@ library (sg13g2_io_typ_1p5V_3p3V_25C) {
  cell (sg13g2_IOPadOut30mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "inout";
     pad_drivers : 1;
     bond_pads : 1;
@@ -2954,6 +2966,8 @@ library (sg13g2_io_typ_1p5V_3p3V_25C) {
  cell (sg13g2_IOPadOut4mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "inout";
     pad_drivers : 1;
     bond_pads : 1;
@@ -3145,6 +3159,8 @@ library (sg13g2_io_typ_1p5V_3p3V_25C) {
  cell (sg13g2_IOPadTriOut16mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "tri_out";
     pad_drivers : 1;
     bond_pads : 1;
@@ -3611,6 +3627,8 @@ library (sg13g2_io_typ_1p5V_3p3V_25C) {
  cell (sg13g2_IOPadTriOut30mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "tri_out";
     pad_drivers : 1;
     bond_pads : 1;
@@ -4077,6 +4095,8 @@ library (sg13g2_io_typ_1p5V_3p3V_25C) {
  cell (sg13g2_IOPadTriOut4mA) {
     pad_cell : true;
     area : 14400;
+    dont_touch : true;
+    dont_use : true;
     cell_footprint : "tri_out";
     pad_drivers : 1;
     bond_pads : 1;


### PR DESCRIPTION
OpenROAD / Yoysy started to use the IO cells as standard cell when synthesizing a design. Add the dont_touch and dont_use properties to all IO cells in each lib file to prevent having them in the core area.
