### PR TITLE
libs.tech/librelane: use existing I/O sites, add site for corners

### DIFF
--- a/ihp-sg13g2/libs.ref/sg13g2_io/lef/sg13g2_io.lef
+++ b/ihp-sg13g2/libs.ref/sg13g2_io/lef/sg13g2_io.lef
@@ -27,13 +27,19 @@ SITE sg13g2_ioSite
     SIZE 1.00 BY 180.00 ;
 END sg13g2_ioSite
 
+SITE sg13g2_cornerSite
+    CLASS PAD ;
+    SYMMETRY R90 ;
+    SIZE 180.00 BY 180.00 ;
+END sg13g2_cornerSite
+
 MACRO sg13g2_Corner
     CLASS PAD SPACER ;
     ORIGIN 0.000 0.000 ;
     FOREIGN sg13g2_Corner 0.000 0.000 ;
     SIZE 180.000 BY 180.000 ;
     SYMMETRY X Y R90 ;
-    SITE sg13g2_ioSite ;
+    SITE sg13g2_cornerSite ;
   PIN iovdd
     DIRECTION INOUT ;
     USE POWER ;

--- a/ihp-sg13g2/libs.ref/sg13g2_io/lef/sg13g2_io_notracks.lef
+++ b/ihp-sg13g2/libs.ref/sg13g2_io/lef/sg13g2_io_notracks.lef
@@ -27,13 +27,19 @@ SITE sg13g2_ioSite
     SIZE 1.00 BY 180.00 ;
 END sg13g2_ioSite
 
+SITE sg13g2_cornerSite
+    CLASS PAD ;
+    SYMMETRY R90 ;
+    SIZE 180.00 BY 180.00 ;
+END sg13g2_cornerSite
+
 MACRO sg13g2_Corner
     CLASS PAD SPACER ;
     ORIGIN 0.000 0.000 ;
     FOREIGN sg13g2_Corner 0.000 0.000 ;
     SIZE 180.000 BY 180.000 ;
     SYMMETRY X Y R90 ;
-    SITE sg13g2_ioSite ;
+    SITE sg13g2_cornerSite ;
   PIN iovdd
     DIRECTION INOUT ;
     USE POWER ;

--- a/ihp-sg13g2/libs.tech/librelane/sg13g2_io/config.tcl
+++ b/ihp-sg13g2/libs.tech/librelane/sg13g2_io/config.tcl
@@ -1,14 +1,8 @@
 set current_folder [file dirname [file normalize [info script]]]
 
 # Pad IO sites
-set ::env(PAD_SITE_NAME) "IOLibSite"
-set ::env(PAD_CORNER_SITE_NAME) "IOLibCSite"
-
-# Pad fake IO sites information
-set ::env(PAD_FAKE_SITE_HEIGHT) "180"
-set ::env(PAD_FAKE_SITE_WIDTH) "1"
-set ::env(PAD_FAKE_CORNER_SITE_HEIGHT) "180"
-set ::env(PAD_FAKE_CORNER_SITE_WIDTH) "180"
+set ::env(PAD_SITE_NAME) "sg13g2_ioSite"
+set ::env(PAD_CORNER_SITE_NAME) "sg13g2_cornerSite"
 
 # Set IO pad information
 set ::env(PAD_CELLS) [dict create]


### PR DESCRIPTION
This PR updates the LibreLane config to use the existing I/O site as well as a corner site. This eliminates the need to create fake sites.

There does not currently exist a corner site in the IO LEF, thus this PR adds `sg13g2_cornerSite`. An issue is documented in c4m-flexio: https://gitlab.com/Chips4Makers/c4m-flexio/-/issues/9