### PR TITLE
libs.tech/klayout: improve defaults in scripts

### DIFF
--- a/ihp-sg13g2/libs.tech/klayout/tech/drc/ihp-sg13g2.drc
+++ b/ihp-sg13g2/libs.tech/klayout/tech/drc/ihp-sg13g2.drc
@@ -41,6 +41,9 @@ file_logger.formatter = formatter
 stdout_logger = Logger.new($stdout)
 stdout_logger.formatter = formatter
 
+# Don't buffer stdout
+$stdout.sync = true
+
 # MultiLogger class to broadcast to multiple loggers
 class MultiLogger
   def initialize(*targets)
@@ -116,12 +119,13 @@ def setup_run_mode(run_mode)
   end
 end
 
-# threads
+# Threads
 $threads = ($threads || Etc.nprocessors).to_i
 threads($threads)
-logger.info("KLayout will use #{$threads} thread(s) in tiled mode.")
+logger.info("KLayout will use #{$threads} thread(s) in tiling mode.")
 
 # Run mode
+$run_mode = $run_mode || 'deep'
 setup_run_mode($run_mode)
 logger.info("#{$run_mode} mode is enabled.")
 
@@ -171,8 +175,8 @@ logger.info("CONNECTIVITY_RULES enabled: #{CONNECTIVITY_RULES}.")
 # Method to get DRC values from JSON files
 def get_drc_values(logger)
   script_dir = File.expand_path(File.dirname(__FILE__))
-  $drc_json_default = $drc_json_default || File.join(script_dir, 'rule_decks/sg13g2_tech_default.json')
-  $drc_json = $drc_json || File.join(script_dir, '../../python/sg13g2_pycell_lib/sg13g2_tech_mod.json')
+  $drc_json_default = $drc_json_default || File.expand_path(File.join(script_dir, 'rule_decks/sg13g2_tech_default.json'))
+  $drc_json = $drc_json || File.expand_path(File.join(script_dir, '../../python/sg13g2_pycell_lib/sg13g2_tech_mod.json'))
 
   tech_rules = {}
   if $drc_json && $drc_json != $drc_json_default

--- a/ihp-sg13g2/libs.tech/klayout/tech/drc/rule_decks/antenna.drc
+++ b/ihp-sg13g2/libs.tech/klayout/tech/drc/rule_decks/antenna.drc
@@ -23,6 +23,7 @@ require 'time'
 require 'logger'
 require 'json'
 require 'pathname'
+require 'etc'
 
 exec_start_time = Time.now
 
@@ -39,6 +40,9 @@ file_logger.formatter = formatter
 # Create stdout logger
 stdout_logger = Logger.new($stdout)
 stdout_logger.formatter = formatter
+
+# Don't buffer stdout
+$stdout.sync = true
 
 # MultiLogger class to broadcast to multiple loggers
 class MultiLogger
@@ -109,11 +113,13 @@ def setup_run_mode(run_mode)
   end
 end
 
-# threads
-threads($thr.to_i)
-logger.info("Klayout will use #{$thr} thread(s)")
+# Threads
+$threads = ($threads || Etc.nprocessors).to_i
+threads($threads)
+logger.info("KLayout will use #{$threads} thread(s) in tiling mode.")
 
 # Run mode
+$run_mode = $run_mode || 'deep'
 setup_run_mode($run_mode)
 logger.info("#{$run_mode} mode is enabled for antenna table.")
 
@@ -253,6 +259,10 @@ logger.info("Total no. of polygons in the design is #{polygons_count}")
 
 # Method to get DRC values from JSON files
 def get_drc_values(logger)
+  script_dir = File.expand_path(File.dirname(__FILE__))
+  $drc_json_default = $drc_json_default || File.expand_path(File.join(script_dir, 'sg13g2_tech_default.json'))
+  $drc_json = $drc_json || File.expand_path(File.join(script_dir, '../../../python/sg13g2_pycell_lib/sg13g2_tech_mod.json'))
+
   tech_rules = {}
   if $drc_json && $drc_json != $drc_json_default
     begin
@@ -262,6 +272,7 @@ def get_drc_values(logger)
       logger.info("Loaded TECH DRC rules values from #{$drc_json}")
     rescue StandardError => e
       logger.error("Error reading TECH DRC rules from #{$drc_json}: #{e.message}")
+      raise "Error reading TECH DRC rules from #{$drc_json}: #{e.message}"
     end
   end
 
@@ -272,7 +283,7 @@ def get_drc_values(logger)
     logger.info("Loaded default DRC rules values from #{$drc_json_default}")
   rescue StandardError => e
     logger.error("Error reading default DRC rules from #{$drc_json_default}: #{e.message}")
-    return {}
+    raise "Error reading default DRC rules from #{$drc_json_default}: #{e.message}"
   end
 
   merged_rules = tech_rules.merge(default_rules)

--- a/ihp-sg13g2/libs.tech/klayout/tech/drc/rule_decks/density.drc
+++ b/ihp-sg13g2/libs.tech/klayout/tech/drc/rule_decks/density.drc
@@ -23,6 +23,7 @@ require 'time'
 require 'logger'
 require 'json'
 require 'pathname'
+require 'etc'
 
 exec_start_time = Time.now
 
@@ -39,6 +40,9 @@ file_logger.formatter = formatter
 # Create stdout logger
 stdout_logger = Logger.new($stdout)
 stdout_logger.formatter = formatter
+
+# Don't buffer stdout
+$stdout.sync = true
 
 # MultiLogger class to broadcast to multiple loggers
 class MultiLogger
@@ -99,11 +103,13 @@ def bool_check?(obj)
   obj.to_s.downcase == 'true'
 end
 
-# threads
-threads($thr.to_i)
-logger.info("Klayout will use #{$thr} thread(s)")
+# Threads
+$threads = ($threads || Etc.nprocessors).to_i
+threads($threads)
+logger.info("KLayout will use #{$threads} thread(s) in tiling mode.")
 
 # Enable deep mode for reading layers and processing general derivations
+$run_mode = 'deep'
 deep
 logger.info('Deep mode enabled: reading layers and preparing general derivations.')
 
@@ -237,6 +243,10 @@ logger.info("lbe_drw has #{count} polygons")
 
 # Method to get DRC values from JSON files
 def get_drc_values(logger)
+  script_dir = File.expand_path(File.dirname(__FILE__))
+  $drc_json_default = $drc_json_default || File.expand_path(File.join(script_dir, 'sg13g2_tech_default.json'))
+  $drc_json = $drc_json || File.expand_path(File.join(script_dir, '../../../python/sg13g2_pycell_lib/sg13g2_tech_mod.json'))
+
   tech_rules = {}
   if $drc_json && $drc_json != $drc_json_default
     begin
@@ -246,6 +256,7 @@ def get_drc_values(logger)
       logger.info("Loaded TECH DRC rules values from #{$drc_json}")
     rescue StandardError => e
       logger.error("Error reading TECH DRC rules from #{$drc_json}: #{e.message}")
+      raise "Error reading TECH DRC rules from #{$drc_json}: #{e.message}"
     end
   end
 
@@ -256,7 +267,7 @@ def get_drc_values(logger)
     logger.info("Loaded default DRC rules values from #{$drc_json_default}")
   rescue StandardError => e
     logger.error("Error reading default DRC rules from #{$drc_json_default}: #{e.message}")
-    return {}
+    raise "Error reading default DRC rules from #{$drc_json_default}: #{e.message}"
   end
 
   merged_rules = tech_rules.merge(default_rules)

--- a/ihp-sg13g2/libs.tech/librelane/config.tcl
+++ b/ihp-sg13g2/libs.tech/librelane/config.tcl
@@ -54,21 +54,14 @@ set ::env(KLAYOUT_DEF_LAYER_MAP) "$::env(PDK_ROOT)/$::env(PDK)/libs.tech/klayout
 
 set ::env(KLAYOUT_DRC_RUNSET) "$::env(PDK_ROOT)/$::env(PDK)/libs.tech/klayout/tech/drc/ihp-sg13g2.drc"
 set ::env(KLAYOUT_DRC_OPTIONS) [dict create]
-dict set ::env(KLAYOUT_DRC_OPTIONS) feol true
-dict set ::env(KLAYOUT_DRC_OPTIONS) beol true
-dict set ::env(KLAYOUT_DRC_OPTIONS) pin true
-dict set ::env(KLAYOUT_DRC_OPTIONS) forbidden true
-dict set ::env(KLAYOUT_DRC_OPTIONS) run_mode deep
 dict set ::env(KLAYOUT_DRC_OPTIONS) no_recommended true
-dict set ::env(KLAYOUT_DRC_OPTIONS) drc_json_default "$::env(PDK_ROOT)/$::env(PDK)/libs.tech/klayout/tech/drc/rule_decks/sg13g2_tech_default.json"
+dict set ::env(KLAYOUT_DRC_OPTIONS) run_mode deep
 
 set ::env(KLAYOUT_DENSITY_RUNSET) "$::env(PDK_ROOT)/$::env(PDK)/libs.tech/klayout/tech/drc/rule_decks/density.drc"
 set ::env(KLAYOUT_DENSITY_OPTIONS) [dict create]
-dict set ::env(KLAYOUT_DENSITY_OPTIONS) drc_json_default "$::env(PDK_ROOT)/$::env(PDK)/libs.tech/klayout/tech/drc/rule_decks/sg13g2_tech_default.json"
 
 set ::env(KLAYOUT_ANTENNA_RUNSET) "$::env(PDK_ROOT)/$::env(PDK)/libs.tech/klayout/tech/drc/rule_decks/antenna.drc"
 set ::env(KLAYOUT_ANTENNA_OPTIONS) [dict create]
-dict set ::env(KLAYOUT_ANTENNA_OPTIONS) drc_json_default "$::env(PDK_ROOT)/$::env(PDK)/libs.tech/klayout/tech/drc/rule_decks/sg13g2_tech_default.json"
 
 set ::env(KLAYOUT_FILLER_SCRIPT) "$::env(PDK_ROOT)/$::env(PDK)/libs.tech/klayout/tech/scripts/filler.py"
 


### PR DESCRIPTION
This PR improves the defaults in the KLayout scripts.

- Improved defaults:
  - Now, `antenna.drc` and `density.drc` also set the default drc json files. This was already the case for `ihp-sg13g2.drc`.
  - `$threads` is set to the maximum number of CPU threads in all scripts if not specified explicitly.
  - `$run_mode` is set by default to 'deep'. While the DRC function `deep` was already called when no run mode was specified, `$run_mode` was left undefined. Thus, `$run_mode == 'deep' ? ps : ps.merged` would resort to merging the polygons in deep mode, which destroys the performance.

- Expand the file paths when loading the drc json files to improve readability.

- Do not buffer stdout: If one of the KLayout scripts gets stuck early on, it can happen that LibreLane shows no output, providing no hint as to what's the issue. This change ensures that the output is written to stdout.

Note that most of these issues do not arise if the arguments are explicitly set. However, these changes are useful for direct debugging.