### PR TITLE
fix(klayout/drc/dialogs): remove enforced background color

### DIFF
--- a/ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_drc.lym
+++ b/ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_drc.lym
@@ -213,7 +213,7 @@ end
 @title_font.setPointSize(14)
 @title_font.setBold(true)
 @title_label.setFont(@title_font)
-@title_label.setStyleSheet("color: #2c3e50; margin-left: 10px;")
+@title_label.setStyleSheet("margin-left: 10px;")
 @header_layout.addWidget(@title_label)
 @header_layout.addStretch
 @main_layout.addLayout(@header_layout)
@@ -221,7 +221,7 @@ end
 # Log output area
 @log_output = RBA::QTextEdit.new
 @log_output.setReadOnly(true)
-@log_output.setStyleSheet("background-color: #f4f4f4; font-family: monospace;")
+@log_output.setStyleSheet("font-family: monospace;")
 @main_layout.addWidget(@log_output)
 
 # Close button

--- a/ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_drc_options.lym
+++ b/ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_drc_options.lym
@@ -232,7 +232,6 @@
     # style (can be adjusted)
     @dialog_options.setStyleSheet(
       "QDialog {\n" \
-      "  background-color: #f8f9fa;\n" \
       "  border-radius: 12px;\n" \
       "  padding: 12px;\n" \
       "}\n" \


### PR DESCRIPTION
##  What
In the case where one uses a darker Qt theme, enforcing white background color, while not enforcing text color causes the text and background color to potentially be the same color.

Avoid enforcing background color, and let the Qt theme handle it.
The other enforced colors are looking _OK_ with my current theme, so I'll leave the changes to a minimum.

## Examples

### DRC options

**Darker Theme**

| Before | After |
| --------|-------|
| <img width="100%" height="1424" alt="image" src="https://github.com/user-attachments/assets/2cb2b071-252f-4305-bbd8-c05cd3e3c209" /> |  <img width="100%" height="1424" alt="image" src="https://github.com/user-attachments/assets/bdd1b2a5-b5ed-450f-9140-aa638debf780" /> |



**White/No Theme**

| Before | After |
| --------|-------|
|<img width="100%" height="1425" alt="image" src="https://github.com/user-attachments/assets/b4f3b2b8-5d49-4c10-b268-b52d57b4f9dc" /> |  <img width="100%" height="1424" alt="image" src="https://github.com/user-attachments/assets/30c9320c-c695-4490-8102-b02a554c6cc5" /> |

### DRC output logs

**Darker theme**

| Before | After |
| --------|-------|
| <img width="100%" height="745" alt="image" src="https://github.com/user-attachments/assets/2fa1a160-b434-48b2-9cb1-f3345734258b" /> |  <img width="100%" height="744" alt="image" src="https://github.com/user-attachments/assets/1daae7bc-9085-4d74-b79f-23e2d72f9165" /> |

**White/No Theme**

| Before | After |
| --------|-------|
| <img width="100%" height="745" alt="image" src="https://github.com/user-attachments/assets/489a93a9-7d5b-4f1c-8e80-b5c2f8b87d79" /> |   <img width="100%" height="741" alt="image" src="https://github.com/user-attachments/assets/071a82ee-08f8-435f-a59c-989d0b6a21f4" /> | 

## Summary

For the default/no theme option, the only _functional_ change is that the title of the DRC output logs changes from a dark blue-grey (#2C3E50) to a straight dark color, however that impact is minimum I'd say.

Otherwise it should now work more consistently with the system-level Qt theme in terms of background color vs text-color


