### PR TITLE
Fix to the magic tech file extraction for RF MiM caps.

### DIFF
--- a/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-extract.tech
+++ b/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-extract.tech
@@ -1164,7 +1164,7 @@ variants (),(hrhc),(lrhc),(hrlc),(lrlc)
 
  # Capacitors
  device csubcircuit cap_cmim *mimcap *m5 w=w l=l
- device csubcircuit cap_rfcmim *mimcap *m5 w=w l=l +pblock
+ device csubcircuit cap_rfcmim *mimcap *m5 +pblock w=w l=l
  # Varactor:  Note that the SVaractor is a complex device incorporating
  # multiple varactor fingers.  This will normally be handled from a
  # generated cell using a "device" property.  In case varactor structures
@@ -1238,7 +1238,7 @@ variants (lvs)
 
  # Capacitors
  device capacitor cap_cmim *mimcap *m5 c=c
- device capacitor cap_rfcmim *mimcap *m5 c=c +pblock
+ device capacitor cap_rfcmim *mimcap *m5 +pblock c=c
 
  # Diodes
  device pdiode dpantenna *pdiode nwell w=w l=l a=a p=p


### PR DESCRIPTION
This patch swaps the order of two arguments to the "device capacitor" and "device csubcircuit" devices in the magic tech file ihp-sg13g2-extract.tech.  The identifier layer which determines the device must appear before any parameters, not after.

Fixes #791

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR
