### PR TITLE
fix(KLayout/DRC options): explicitly unmanage `QSpacerItem` to avoid use-after-free segfault

### DIFF
--- a/ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_drc_options.lym
+++ b/ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_drc_options.lym
@@ -179,6 +179,9 @@
 
     ## --- Basic Settings Tab ---
     @spacer = RBA::QSpacerItem.new(0, 5)
+    # Transfer ownership to C++ to prevent Ruby GC from freeing the spacer item.
+    # See: https://github.com/KLayout/klayout/issues/2273 for more information
+    @spacer._unmanage
     @basic_tab = RBA::QWidget.new
     @basic_layout_setup = RBA::QFormLayout.new(@basic_tab)
     @basic_layout_setup.setSpacing(15)


### PR DESCRIPTION
Currently there is an issue with a potential use-after-free bug triggered in the Ruby-Qt bindings.
Explicitly call `unmanage` on the object to transfer the lifetime to C++ to avoid a potential segfault.

Fixes: #815 