### PR TITLE
Update dc_hv_nmos.sch

### DIFF
--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_hv_nmos.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_hv_nmos.sch
@@ -112,7 +112,7 @@ set sim(spice,1,cmd) \{ngspice  \\"$N\\" -a\}
 set sim(spice,default) 0
 
 # Create FET and BIP .save file
-mkdir -p $netlist_dir
+exec mkdir -p $netlist_dir
 write_data [save_params] $netlist_dir/[file rootname [file tail [xschem get current_name]]].save
 
 # run netlist and simulation


### PR DESCRIPTION
Missing exec results in fail. This happens for every testbench. Should update all of them.
