### PR TITLE
Update dc_hv_nmos.sch

### DIFF
--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_hbt_13g2.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_hbt_13g2.sch
@@ -111,7 +111,7 @@ set sim(spice,1,cmd) \{ngspice  \\"$N\\" -a\}
 set sim(spice,default) 0
 
 # Create FET and BIP .save file
-mkdir -p $netlist_dir
+file mkdir $netlist_dir
 write_data [save_params] $netlist_dir/[file rootname [file tail [xschem get current_name]]].save
 
 # run netlist and simulation

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_hbt_13g2_5t.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_hbt_13g2_5t.sch
@@ -154,7 +154,7 @@ set sim(spice,1,cmd) \{ngspice  \\"$N\\" -a\}
 set sim(spice,default) 0
 
 # Create FET and BIP .save file
-mkdir -p $netlist_dir
+file mkdir $netlist_dir
 write_data [save_params] $netlist_dir/[file rootname [file tail [xschem get current_name]]].save
 
 # run netlist and simulation

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_hbt_13g2l_5t.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_hbt_13g2l_5t.sch
@@ -156,7 +156,7 @@ set sim(spice,1,cmd) \{ngspice  \\"$N\\" -a\}
 set sim(spice,default) 0
 
 # Create FET and BIP .save file
-mkdir -p $netlist_dir
+file mkdir $netlist_dir
 write_data [save_params] $netlist_dir/[file rootname [file tail [xschem get current_name]]].save
 
 # run netlist and simulation

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_hbt_13g2v_5t.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_hbt_13g2v_5t.sch
@@ -154,7 +154,7 @@ set sim(spice,1,cmd) \{ngspice  \\"$N\\" -a\}
 set sim(spice,default) 0
 
 # Create FET and BIP .save file
-mkdir -p $netlist_dir
+file mkdir $netlist_dir
 write_data [save_params] $netlist_dir/[file rootname [file tail [xschem get current_name]]].save
 
 # run netlist and simulation

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_hv_nmos.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_hv_nmos.sch
@@ -112,7 +112,7 @@ set sim(spice,1,cmd) \{ngspice  \\"$N\\" -a\}
 set sim(spice,default) 0
 
 # Create FET and BIP .save file
-mkdir -p $netlist_dir
+exec mkdir -p $netlist_dir
 write_data [save_params] $netlist_dir/[file rootname [file tail [xschem get current_name]]].save
 
 # run netlist and simulation

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_hv_nmos.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_hv_nmos.sch
@@ -112,7 +112,7 @@ set sim(spice,1,cmd) \{ngspice  \\"$N\\" -a\}
 set sim(spice,default) 0
 
 # Create FET and BIP .save file
-exec mkdir -p $netlist_dir
+file mkdir $netlist_dir
 write_data [save_params] $netlist_dir/[file rootname [file tail [xschem get current_name]]].save
 
 # run netlist and simulation

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_hv_pmos.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_hv_pmos.sch
@@ -115,7 +115,7 @@ set sim(spice,1,cmd) \{ngspice  \\"$N\\" -a\}
 set sim(spice,default) 0
 
 # Create FET and BIP .save file
-mkdir -p $netlist_dir
+file mkdir $netlist_dir
 write_data [save_params] $netlist_dir/[file rootname [file tail [xschem get current_name]]].save
 
 # run netlist and simulation

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_lv_nmos.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_lv_nmos.sch
@@ -112,7 +112,7 @@ set sim(spice,1,cmd) \{ngspice  \\"$N\\" -a\}
 set sim(spice,default) 0
 
 # Create FET and BIP .save file
-mkdir -p $netlist_dir
+file mkdir $netlist_dir
 write_data [save_params] $netlist_dir/[file rootname [file tail [xschem get current_name]]].save
 
 # run netlist and simulation

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_lv_pmos.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/dc_lv_pmos.sch
@@ -116,7 +116,7 @@ set sim(spice,1,cmd) \{ngspice  \\"$N\\" -a\}
 set sim(spice,default) 0
 
 # Create FET and BIP .save file
-mkdir -p $netlist_dir
+file mkdir $netlist_dir
 write_data [save_params] $netlist_dir/[file rootname [file tail [xschem get current_name]]].save
 
 # run netlist and simulation

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/inv_mc_tb.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/inv_mc_tb.sch
@@ -58,7 +58,7 @@ set sim(spice,1,cmd) \{ngspice  \\"$N\\" -a\}
 set sim(spice,default) 0
 
 # Create FET and BIP .save file
-mkdir -p $netlist_dir
+file mkdir $netlist_dir
 write_data [save_params] $netlist_dir/[file rootname [file tail [xschem get current_name]]].save
 
 # run netlist and simulation
@@ -215,7 +215,7 @@ set sim(spice,1,cmd) \{ngspice  \\"$N\\" -a\}
 set sim(spice,default) 0
 
 # Create FET and BIP .save file
-mkdir -p $netlist_dir
+file mkdir $netlist_dir
 write_data [save_params] $netlist_dir/[file rootname [file tail [xschem get current_name]]].save
 
 # run netlist and simulation

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/inv_sweep_tb.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/inv_sweep_tb.sch
@@ -67,7 +67,7 @@ set sim(spice,1,cmd) \{ngspice  \\"$N\\" -a\}
 set sim(spice,default) 0
 
 # Create FET and BIP .save file
-mkdir -p $netlist_dir
+file mkdir $netlist_dir
 write_data [save_params] $netlist_dir/[file rootname [file tail [xschem get current_name]]].save
 
 # run netlist and simulation
@@ -249,7 +249,7 @@ set sim(spice,1,cmd) \{ngspice  \\"$N\\" -a\}
 set sim(spice,default) 0
 
 # Create FET and BIP .save file
-mkdir -p $netlist_dir
+file mkdir $netlist_dir
 write_data [save_params] $netlist_dir/[file rootname [file tail [xschem get current_name]]].save
 
 # run netlist and simulation

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/iso_dc_hv_nmos.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/iso_dc_hv_nmos.sch
@@ -113,7 +113,7 @@ set sim(spice,1,cmd) \{ngspice  \\"$N\\" -a\}
 set sim(spice,default) 0
 
 # Create FET and BIP .save file
-mkdir -p $netlist_dir
+file mkdir $netlist_dir
 write_data [save_params] $netlist_dir/[file rootname [file tail [xschem get current_name]]].save
 
 # run netlist and simulation

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/iso_dc_lv_nmos.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/iso_dc_lv_nmos.sch
@@ -123,7 +123,7 @@ set sim(spice,1,cmd) \{ngspice  \\"$N\\" -a\}
 set sim(spice,default) 0
 
 # Create FET and BIP .save file
-mkdir -p $netlist_dir
+file mkdir $netlist_dir
 write_data [save_params] $netlist_dir/[file rootname [file tail [xschem get current_name]]].save
 
 # run netlist and simulation

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/isolbox_sweep_tb.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/isolbox_sweep_tb.sch
@@ -46,7 +46,7 @@ set sim(spice,1,cmd) \{ngspice  \\"$N\\" -a\}
 set sim(spice,default) 0
 
 # Create FET and BIP .save file
-mkdir -p $netlist_dir
+file mkdir $netlist_dir
 write_data [save_params] $netlist_dir/[file rootname [file tail [xschem get current_name]]].save
 
 # run netlist and simulation
@@ -113,7 +113,7 @@ set sim(spice,1,cmd) \{ngspice  \\"$N\\" -a\}
 set sim(spice,default) 0
 
 # Create FET and BIP .save file
-mkdir -p $netlist_dir
+file mkdir $netlist_dir
 write_data [save_params] $netlist_dir/[file rootname [file tail [xschem get current_name]]].save
 
 # run netlist and simulation

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests_xyce/dc_hbt_13g2.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests_xyce/dc_hbt_13g2.sch
@@ -149,7 +149,7 @@ set sim(spice,1,cmd) \{ngspice  \\"$N\\" -a\}
 set sim(spice,default) 0
 
 # Create FET and BIP .save file
-mkdir -p $netlist_dir
+file mkdir $netlist_dir
 write_data [save_params] $netlist_dir/[file rootname [file tail [xschem get current_name]]].save
 
 # run netlist and simulation

--- a/ihp-sg13g2/libs.tech/xschem/start_page.sch
+++ b/ihp-sg13g2/libs.tech/xschem/start_page.sch
@@ -95,7 +95,7 @@ set sim(spice,1,cmd) \{ngspice  \\"$N\\" -a\}
 set sim(spice,default) 0
 
 # Create FET and BIP .save file
-mkdir -p $netlist_dir
+file mkdir $netlist_dir
 write_data [save_params] $netlist_dir/[file rootname [file tail [xschem get current_name]]].save
 
 # run netlist and simulation

--- a/ihp-sg13g2/libs.tech/xschem/xschem-menu
+++ b/ihp-sg13g2/libs.tech/xschem/xschem-menu
@@ -297,7 +297,7 @@ proc menupdk {} {
 
     ## Create one entry
     $topwin.menubar.ihp add command -label {Create FET and BIP .save file} -command {
-      mkdir -p $netlist_dir
+      file mkdir $netlist_dir
       write_data [save_params] $netlist_dir/[file rootname [file tail [xschem get current_name]]].save
       textwindow $netlist_dir/[file rootname [file tail [xschem get current_name]]].save
     }


### PR DESCRIPTION
Missing exec gives an error. This happens for every testbench. Should update all of them.