### PR TITLE
revision and documentation of ngspice poly resistor library

### DIFF
--- a/ihp-sg13g2/libs.tech/ngspice/models/cornerRES.lib
+++ b/ihp-sg13g2/libs.tech/ngspice/models/cornerRES.lib
@@ -9,7 +9,7 @@
 *    https://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
-*distributed under the License is distributed on an "AS IS" BASIS,
+* distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
@@ -20,8 +20,18 @@
   .param rsh_rhigh = 1360
   .param rsh_rppd  = 260.0
   .param rsh_rsil  = 7.0
-  .param res_area  = 1.0
-  .param res_rpara = 1.0
+  .param drsh_rhigh = 0.0
+  .param drsh_rsil  = 0.0
+  .param drsh_rppd  = 0.0
+  .param dl_rhigh  = 0.0
+  .param dw_rhigh  = 0.0
+  .param dl_rsil   = 0.0
+  .param dw_rsil   = 0.0
+  .param dl_rppd   = 0.0
+  .param dw_rppd   = 0.0
+  .param dw_rsil_par  =  0.01e-6
+  .param dw_rppd_par  =  0.006e-6
+  .param dw_rhigh_par = -0.04e-6
 
 .include resistors_mod.lib
 .ENDL res_typ
@@ -31,31 +41,70 @@
   .param rsh_rhigh = 1360
   .param rsh_rppd  = 260.0
   .param rsh_rsil  = 7.0
-  .param res_area  = 1.0
-  .param res_rpara = 1.0
+  .param drsh_rhigh = 0.0
+  .param drsh_rsil  = 0.0
+  .param drsh_rppd  = 0.0
+  .param dl_rhigh  = 0.0
+  .param dw_rhigh  = 0.0
+  .param dl_rsil   = 0.0
+  .param dw_rsil   = 0.0
+  .param dl_rppd   = 0.0
+  .param dw_rppd   = 0.0
+  .param dw_rsil_par  =  0.01e-6
+  .param dw_rppd_par  =  0.006e-6
+  .param dw_rhigh_par = -0.04e-6
+  .param nsig_rsil_rsh=0  ; global number of standard deviations for rsh
+  .param nsig_rsil_w=0    ; global number of standard deviations for w
+  .param nsig_rsil_l=0    ; global number of standard deviations for l
+  .param nsig_rppd_rsh=0  ; global number of standard deviations for rsh
+  .param nsig_rppd_w=0    ; global number of standard deviations for w
+  .param nsig_rppd_l=0    ; global number of standard deviations for l
+  .param nsig_rhigh_rsh=0 ; global number of standard deviations for rsh
+  .param nsig_rhigh_w=0   ; global number of standard deviations for w
+  .param nsig_rhigh_l=0   ; global number of standard deviations for l
+  .param rsh_rsil_mm  = 1.7   ; local %um of 1 Sigma
+  .param rsh_rppd_mm  = 2.0   ; local %um of 1 Sigma
+  .param rsh_rhigh_mm = 5.0   ; local %um of 1 Sigma
+  .param dl_rsil_mm   = 0.006 ; local um of 1 Sigma
+  .param dw_rsil_mm   = 0.006 ; local um of 1 Sigma
+  .param dl_rppd_mm   = 0.006 ; local um of 1 Sigma
+  .param dw_rppd_mm   = 0.006 ; local um of 1 Sigma
+  .param dl_rhigh_mm  = 0.009 ; local um of 1 Sigma
+  .param dw_rhigh_mm  = 0.009 ; local um of 1 Sigma
 
 .include resistors_mod_mismatch.lib
 .ENDL res_typ_mismatch
 
 * Typical with statistical modeling
-.LIB res_typ_stat
-  .param rsh_rhigh_norm= 1360
-  .param rsh_rppd_norm= 260.0
-  .param rsh_rsil_norm= 7.0
-  .param res_area_norm= 1.0
-  .param res_rpara_norm= 1.0
+.LIB res_stat
+  .param rsh_rhigh = 1360
+  .param rsh_rppd  = 260.0
+  .param rsh_rsil  = 7.0
+  .param dw_rsil_par  =  0.01e-6
+  .param dw_rppd_par  =  0.006e-6
+  .param dw_rhigh_par = -0.04e-6
 
 .include resistors_stat.lib
 .include resistors_mod.lib
-.ENDL res_typ_stat
+.ENDL res_stat
 
 * Best Case
 .LIB res_bcs
   .param rsh_rhigh = 1020
   .param rsh_rppd  = 234.0
   .param rsh_rsil  = 6.02
-  .param res_area  = 1.0
-  .param res_rpara = 1.0
+  .param drsh_rhigh = 0.0
+  .param drsh_rsil  = 0.0
+  .param drsh_rppd  = 0.0
+  .param dl_rhigh  = 0.0
+  .param dw_rhigh  = 0.0
+  .param dl_rsil   = 0.0
+  .param dw_rsil   = 0.0
+  .param dl_rppd   = 0.0
+  .param dw_rppd   = 0.0
+  .param dw_rsil_par  = 0.04e-6
+  .param dw_rppd_par  = 0.036e-6
+  .param dw_rhigh_par = 0.0
 
 .include resistors_mod.lib
 .ENDL res_bcs
@@ -65,8 +114,36 @@
   .param rsh_rhigh = 1020
   .param rsh_rppd  = 234.0
   .param rsh_rsil  = 6.02
-  .param res_area  = 1.0
-  .param res_rpara = 1.0
+  .param drsh_rhigh = 0.0
+  .param drsh_rsil  = 0.0
+  .param drsh_rppd  = 0.0
+  .param dl_rhigh  = 0.0
+  .param dw_rhigh  = 0.0
+  .param dl_rsil   = 0.0
+  .param dw_rsil   = 0.0
+  .param dl_rppd   = 0.0
+  .param dw_rppd   = 0.0
+  .param dw_rsil_par  = 0.04e-6
+  .param dw_rppd_par  = 0.036e-6
+  .param dw_rhigh_par = 0.0
+  .param nsig_rsil_rsh=0  ; global number of standard deviations for rsh
+  .param nsig_rsil_w=0    ; global number of standard deviations for w
+  .param nsig_rsil_l=0    ; global number of standard deviations for l
+  .param nsig_rppd_rsh=0  ; global number of standard deviations for rsh
+  .param nsig_rppd_w=0    ; global number of standard deviations for w
+  .param nsig_rppd_l=0    ; global number of standard deviations for l
+  .param nsig_rhigh_rsh=0 ; global number of standard deviations for rsh
+  .param nsig_rhigh_w=0   ; global number of standard deviations for w
+  .param nsig_rhigh_l=0   ; global number of standard deviations for l
+  .param rsh_rsil_mm  = 1.7   ; local %um of 1 Sigma
+  .param rsh_rppd_mm  = 2.0   ; local %um of 1 Sigma
+  .param rsh_rhigh_mm = 5.0   ; local %um of 1 Sigma
+  .param dl_rsil_mm   = 0.006 ; local um of 1 Sigma
+  .param dw_rsil_mm   = 0.006 ; local um of 1 Sigma
+  .param dl_rppd_mm   = 0.006 ; local um of 1 Sigma
+  .param dw_rppd_mm   = 0.006 ; local um of 1 Sigma
+  .param dl_rhigh_mm  = 0.009 ; local um of 1 Sigma
+  .param dw_rhigh_mm  = 0.009 ; local um of 1 Sigma
 
 .include resistors_mod_mismatch.lib
 .ENDL res_bcs_mismatch
@@ -76,8 +153,18 @@
   .param rsh_rhigh = 1700
   .param rsh_rppd  = 286.0
   .param rsh_rsil  = 7.98
-  .param res_area  = 1.0
-  .param res_rpara = 1.0
+  .param drsh_rhigh = 0.0
+  .param drsh_rsil  = 0.0
+  .param drsh_rppd  = 0.0
+  .param dl_rhigh  = 0.0
+  .param dw_rhigh  = 0.0
+  .param dl_rsil   = 0.0
+  .param dw_rsil   = 0.0
+  .param dl_rppd   = 0.0
+  .param dw_rppd   = 0.0
+  .param dw_rsil_par  = -0.02e-6
+  .param dw_rppd_par  = -0.024e-6
+  .param dw_rhigh_par = -0.08e-6
 
 .include resistors_mod.lib
 .ENDL res_wcs
@@ -87,8 +174,68 @@
   .param rsh_rhigh = 1700
   .param rsh_rppd  = 286.0
   .param rsh_rsil  = 7.98
-  .param res_area  = 1.0
-  .param res_rpara = 1.0
+  .param drsh_rhigh = 0.0
+  .param drsh_rsil  = 0.0
+  .param drsh_rppd  = 0.0
+  .param dl_rhigh  = 0.0
+  .param dw_rhigh  = 0.0
+  .param dl_rsil   = 0.0
+  .param dw_rsil   = 0.0
+  .param dl_rppd   = 0.0
+  .param dw_rppd   = 0.0
+  .param dw_rsil_par  = -0.02e-6
+  .param dw_rppd_par  = -0.024e-6
+  .param dw_rhigh_par = -0.08e-6
+  .param nsig_rsil_rsh=0  ; global number of standard deviations for rsh
+  .param nsig_rsil_w=0    ; global number of standard deviations for w
+  .param nsig_rsil_l=0    ; global number of standard deviations for l
+  .param nsig_rppd_rsh=0  ; global number of standard deviations for rsh
+  .param nsig_rppd_w=0    ; global number of standard deviations for w
+  .param nsig_rppd_l=0    ; global number of standard deviations for l
+  .param nsig_rhigh_rsh=0 ; global number of standard deviations for rsh
+  .param nsig_rhigh_w=0   ; global number of standard deviations for w
+  .param nsig_rhigh_l=0   ; global number of standard deviations for l
+  .param rsh_rsil_mm  = 1.7   ; local %um of 1 Sigma
+  .param rsh_rppd_mm  = 2.0   ; local %um of 1 Sigma
+  .param rsh_rhigh_mm = 5.0   ; local %um of 1 Sigma
+  .param dl_rsil_mm   = 0.006 ; local um of 1 Sigma
+  .param dw_rsil_mm   = 0.006 ; local um of 1 Sigma
+  .param dl_rppd_mm   = 0.006 ; local um of 1 Sigma
+  .param dw_rppd_mm   = 0.006 ; local um of 1 Sigma
+  .param dl_rhigh_mm  = 0.009 ; local um of 1 Sigma
+  .param dw_rhigh_mm  = 0.009 ; local um of 1 Sigma
 
 .include resistors_mod_mismatch.lib
 .ENDL res_wcs_mismatch
+
+* Statistical with mismatch modeling
+.LIB res_stat_mismatch
+  .param rsh_rhigh = 1360
+  .param rsh_rppd  = 260.0
+  .param rsh_rsil  = 7.0
+  .param dw_rsil_par  =  0.01e-6
+  .param dw_rppd_par  =  0.006e-6
+  .param dw_rhigh_par = -0.04e-6
+  .param nsig_rsil_rsh='agauss(0, 1, 1)'  ; global number of standard deviations for rsh
+  .param nsig_rsil_w='agauss(0, 1, 1)'    ; global number of standard deviations for w
+  .param nsig_rsil_l='agauss(0, 1, 1)'    ; global number of standard deviations for l
+  .param nsig_rppd_rsh='agauss(0, 1, 1)'  ; global number of standard deviations for rsh
+  .param nsig_rppd_w='agauss(0, 1, 1)'    ; global number of standard deviations for w
+  .param nsig_rppd_l='agauss(0, 1, 1)'    ; global number of standard deviations for l
+  .param nsig_rhigh_rsh='agauss(0, 1, 1)' ; global number of standard deviations for rsh
+  .param nsig_rhigh_w='agauss(0, 1, 1)'   ; global number of standard deviations for w
+  .param nsig_rhigh_l='agauss(0, 1, 1)'   ; global number of standard deviations for l
+  .param rsh_rsil_mm  = 1.7   ; local %um of 1 Sigma
+  .param rsh_rppd_mm  = 2.0   ; local %um of 1 Sigma
+  .param rsh_rhigh_mm = 5.0   ; local %um of 1 Sigma
+  .param dl_rsil_mm   = 0.006 ; local um of 1 Sigma
+  .param dw_rsil_mm   = 0.006 ; local um of 1 Sigma
+  .param dl_rppd_mm   = 0.006 ; local um of 1 Sigma
+  .param dw_rppd_mm   = 0.006 ; local um of 1 Sigma
+  .param dl_rhigh_mm  = 0.009 ; local um of 1 Sigma
+  .param dw_rhigh_mm  = 0.009 ; local um of 1 Sigma
+
+.include resistors_stat.lib
+.include resistors_mod_mismatch.lib
+.ENDL res_stat_mismatch
+

--- a/ihp-sg13g2/libs.tech/ngspice/models/resistors_mod.lib
+++ b/ihp-sg13g2/libs.tech/ngspice/models/resistors_mod.lib
@@ -9,7 +9,7 @@
 *    https://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
-*distributed under the License is distributed on an "AS IS" BASIS,
+* distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
@@ -43,11 +43,11 @@ R1 1 2 R=r*res_rpara TC1=TC1 TC2=TC2
 .ends Rparasitic
 
 .subckt rsil 1 2 bn
-.param w=0.5e-6 l=0.5e-6 mm_ok=1 b=0 m=1 trise=0 sw_et=0
+.param w=0.5e-6 l=0.5e-6 mm_ok=0 b=0 m=1 trise=0 sw_et=0
 +postsim=0
 +kappa=1.85
 +ps=0.18e-6
-+weff=w+0.01e-6
++weff=w+dw_rsil_par
 +leff=(b+1)*l+(2/kappa*weff+ps)*b
 +rzspec=4.5e-6
 +lhead=0.86e-6
@@ -70,9 +70,6 @@ NR1 1 bn 2 dt rmod_rsil L=leff W=weff m=m
 +trise=trise
 +sw_et=sw_et
 +sw_mman=0
-+nsmm_rsh=1 ; number of standard deviations for rsh
-+nsmm_w=1   ; number of standard deviations for w
-+nsmm_l=1   ; number of standard deviations for l
 
 .model rmod_rsil r3_cmc
 +rsh=rsh_rsil
@@ -98,18 +95,21 @@ NR1 1 bn 2 dt rmod_rsil L=leff W=weff m=m
 +kfn=2.812e-12
 +afn=1.607
 +bfn=1.267
-+smm_rsh=1.2 ; relative standard deviation for rsh [%]
-+smm_w=0.01  ; absolute standard deviation for w [um]
-+smm_l=0.01  ; absolute standard deviation for l [um]
++nsig_rsh='agauss(0, 1, 1)' ; global number of standard deviations for rsh
++nsig_w='agauss(0, 1, 1)'   ; global number of standard deviations for w
++nsig_l='agauss(0, 1, 1)'   ; global number of standard deviations for l
++sig_rsh=drsh_rsil          ; global relative standard deviation for rsh [%]
++sig_w=dw_rsil              ; global absolute standard deviation for w [um]
++sig_l=dl_rsil              ; global absolute standard deviation for l [um]
 
 .ends rsil
 
 .subckt rhigh 1 2 bn
-.param w=0.5e-6 l=0.96e-6 mm_ok=1 b=0 trise=0 m=1 sw_et=0
+.param w=0.5e-6 l=0.96e-6 mm_ok=0 b=0 trise=0 m=1 sw_et=0
 +postsim=0
 +kappa=1.85
 +ps=0.18e-6
-+weff=w-0.04e-6
++weff=w+dw_rhigh_par
 +leff=(b+1)*l+(2/kappa*weff+ps)*b
 +lhead=0.86e-6
 +rzspec=80e-6
@@ -132,9 +132,6 @@ NR1 1 bn 2 dt rmod_rhigh L=leff W=weff m=m
 +trise=trise
 +sw_et=sw_et
 +sw_mman=0
-+nsmm_rsh=1 ; number of standard deviations for rsh
-+nsmm_w=1   ; number of standard deviations for w
-+nsmm_l=1   ; number of standard deviations for l
 
 .model rmod_rhigh r3_cmc
 +rsh=rsh_rhigh
@@ -160,17 +157,20 @@ NR1 1 bn 2 dt rmod_rhigh L=leff W=weff m=m
 +kfn=5.205e-10
 +afn=1.935
 +bfn=0.9086
-+smm_rsh=5  ; relative standard deviation for rsh [%]
-+smm_w=0.01 ; absolute standard deviation for w [um]
-+smm_l=0.01 ; absolute standard deviation for l [um]
++nsig_rsh='agauss(0, 1, 1)' ; global number of standard deviations for rsh
++nsig_w='agauss(0, 1, 1)'   ; global number of standard deviations for w
++nsig_l='agauss(0, 1, 1)'   ; global number of standard deviations for l
++sig_rsh=drsh_rhigh         ; global relative standard deviation for rsh [%]
++sig_w=dw_rhigh             ; global absolute standard deviation for w [um]
++sig_l=dl_rhigh             ; global absolute standard deviation for l [um]
 
 .ends rhigh
 
 .subckt rppd 1 2 bn
-.param w=0.5e-6 l=0.5e-6 mm_ok=1 b=0 ps=0.18e-6 trise=0 m=1 sw_et=0
+.param w=0.5e-6 l=0.5e-6 mm_ok=0 b=0 ps=0.18e-6 trise=0 m=1 sw_et=0
 +postsim=0
 +kappa=1.85
-+weff=w+0.006e-6
++weff=w+dw_rppd_par
 +leff=(b+1)*l+(2/kappa*weff+ps)*b
 +lhead=0.86e-6
 +rzspec=35e-6
@@ -192,9 +192,6 @@ NR1 1 bn 2 dt res_rppd L=leff W=weff m=m
 +trise=trise
 +sw_et=sw_et
 +sw_mman=0
-+nsmm_rsh=1 ; number of standard deviations for rsh
-+nsmm_w=1   ; number of standard deviations for w
-+nsmm_l=1   ; number of standard deviations for l
 
 .model res_rppd r3_cmc
 +rsh=rsh_rppd
@@ -219,8 +216,11 @@ NR1 1 bn 2 dt res_rppd L=leff W=weff m=m
 +kfn=4.601e-11
 +afn=1.886
 +bfn=0.9963
-+smm_rsh=1.5 ; relative standard deviation for rsh [%]
-+smm_w=0.01  ; absolute standard deviation for w [um]
-+smm_l=0.01  ; absolute standard deviation for l [um]
++nsig_rsh='agauss(0, 1, 1)' ; global number of standard deviations for rsh
++nsig_w='agauss(0, 1, 1)'   ; global number of standard deviations for w
++nsig_l='agauss(0, 1, 1)'   ; global number of standard deviations for l
++sig_rsh=drsh_rppd          ; global relative standard deviation for rsh [%]
++sig_w=dw_rppd              ; global absolute standard deviation for w [um]
++sig_l=dl_rppd              ; global absolute standard deviation for l [um]
 
 .ends rppd

--- a/ihp-sg13g2/libs.tech/ngspice/models/resistors_mod_mismatch.lib
+++ b/ihp-sg13g2/libs.tech/ngspice/models/resistors_mod_mismatch.lib
@@ -9,7 +9,7 @@
 *    https://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
-*distributed under the License is distributed on an "AS IS" BASIS,
+* distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
@@ -47,7 +47,7 @@ R1 1 2 R=r*res_rpara TC1=TC1 TC2=TC2
 +postsim=0
 +kappa=1.85
 +ps=0.18e-6
-+weff=w+0.01e-6
++weff=w+dw_rsil_par
 +leff=(b+1)*l+(2/kappa*weff+ps)*b
 +rzspec=4.5e-6
 +lhead=0.86e-6
@@ -70,9 +70,9 @@ NR1 1 bn 2 dt rmod_rsil L=leff W=weff m=m
 +trise=trise
 +sw_et=sw_et
 +sw_mman=1
-+nsmm_rsh='gauss(1, 1, (mm_ok != 1 ? 0 : 1))' ; number of standard deviations for rsh
-+nsmm_w='gauss(1, 1, (mm_ok != 1 ? 0 : 1))'   ; number of standard deviations for w
-+nsmm_l='gauss(1, 1, (mm_ok != 1 ? 0 : 1))'   ; number of standard deviations for l
++nsmm_rsh='agauss(0, 1, (mm_ok != 1 ? 0 : 1))' ; number of standard deviations for rsh
++nsmm_w='agauss(0, 1, (mm_ok != 1 ? 0 : 1))'   ; number of standard deviations for w
++nsmm_l='agauss(0, 1, (mm_ok != 1 ? 0 : 1))'   ; number of standard deviations for l
 
 .model rmod_rsil r3_cmc
 +rsh=rsh_rsil
@@ -98,9 +98,15 @@ NR1 1 bn 2 dt rmod_rsil L=leff W=weff m=m
 +kfn=2.812e-12
 +afn=1.607
 +bfn=1.267
-+smm_rsh=1.2 ; relative standard deviation for rsh [%]
-+smm_w=0.01  ; absolute standard deviation for w [um]
-+smm_l=0.01  ; absolute standard deviation for l [um]
++nsig_rsh=nsig_rsil_rsh ; global number of standard deviations for rsh
++nsig_w=nsig_rsil_w     ; global number of standard deviations for w
++nsig_l=nsig_rsil_l     ; global number of standard deviations for l
++sig_rsh=drsh_rsil      ; global relative standard deviation for rsh [%]
++sig_w=dw_rsil          ; global absolute standard deviation for w [um]
++sig_l=dl_rsil          ; global absolute standard deviation for l [um]
++smm_rsh=rsh_rsil_mm ; local relative standard deviation for rsh [%um]
++smm_w=dw_rsil_mm    ; local absolute standard deviation for w [um]
++smm_l=dl_rsil_mm    ; local absolute standard deviation for l [um]
 
 .ends rsil
 
@@ -109,7 +115,7 @@ NR1 1 bn 2 dt rmod_rsil L=leff W=weff m=m
 +postsim=0
 +kappa=1.85
 +ps=0.18e-6
-+weff=w-0.04e-6
++weff=w+dw_rhigh_par
 +leff=(b+1)*l+(2/kappa*weff+ps)*b
 +lhead=0.86e-6
 +rzspec=80e-6
@@ -132,9 +138,9 @@ NR1 1 bn 2 dt rmod_rhigh L=leff W=weff m=m
 +trise=trise
 +sw_et=sw_et
 +sw_mman=1
-+nsmm_rsh='gauss(1, 1, (mm_ok != 1 ? 0 : 1))' ; number of standard deviations for rsh
-+nsmm_w='gauss(1, 1, (mm_ok != 1 ? 0 : 1))'   ; number of standard deviations for w
-+nsmm_l='gauss(1, 1, (mm_ok != 1 ? 0 : 1))'   ; number of standard deviations for l
++nsmm_rsh='agauss(0, 1, (mm_ok != 1 ? 0 : 1))' ; number of standard deviations for rsh
++nsmm_w='agauss(0, 1, (mm_ok != 1 ? 0 : 1))'   ; number of standard deviations for w
++nsmm_l='agauss(0, 1, (mm_ok != 1 ? 0 : 1))'   ; number of standard deviations for l
 
 .model rmod_rhigh r3_cmc
 +rsh=rsh_rhigh
@@ -160,9 +166,15 @@ NR1 1 bn 2 dt rmod_rhigh L=leff W=weff m=m
 +kfn=5.205e-10
 +afn=1.935
 +bfn=0.9086
-+smm_rsh=5  ; relative standard deviation for rsh [%]
-+smm_w=0.01 ; absolute standard deviation for w [um]
-+smm_l=0.01 ; absolute standard deviation for l [um]
++nsig_rsh=nsig_rhigh_rsh ; global number of standard deviations for rsh
++nsig_w=nsig_rhigh_w     ; global number of standard deviations for w
++nsig_l=nsig_rhigh_l     ; global number of standard deviations for l
++sig_rsh=drsh_rhigh      ; global relative standard deviation for rsh [%]
++sig_w=dw_rhigh          ; global absolute standard deviation for w [um]
++sig_l=dl_rhigh          ; global absolute standard deviation for l [um]
++smm_rsh=rsh_rhigh_mm ; local relative standard deviation for rsh [%um]
++smm_w=dw_rhigh_mm    ; local absolute standard deviation for w [um]
++smm_l=dl_rhigh_mm    ; local absolute standard deviation for l [um]
 
 .ends rhigh
 
@@ -170,7 +182,7 @@ NR1 1 bn 2 dt rmod_rhigh L=leff W=weff m=m
 .param w=0.5e-6 l=0.5e-6 mm_ok=1 b=0 ps=0.18e-6 trise=0 m=1 sw_et=0
 +postsim=0
 +kappa=1.85
-+weff=w+0.006e-6
++weff=w+dw_rppd_par
 +leff=(b+1)*l+(2/kappa*weff+ps)*b
 +lhead=0.86e-6
 +rzspec=35e-6
@@ -192,9 +204,9 @@ NR1 1 bn 2 dt res_rppd L=leff W=weff m=m
 +trise=trise
 +sw_et=sw_et
 +sw_mman=1
-+nsmm_rsh='gauss(1, 1, (mm_ok != 1 ? 0 : 1))' ; number of standard deviations for rsh
-+nsmm_w='gauss(1, 1, (mm_ok != 1 ? 0 : 1))'   ; number of standard deviations for w
-+nsmm_l='gauss(1, 1, (mm_ok != 1 ? 0 : 1))'   ; number of standard deviations for l
++nsmm_rsh='agauss(0, 1, (mm_ok != 1 ? 0 : 1))' ; number of standard deviations for rsh
++nsmm_w='agauss(0, 1, (mm_ok != 1 ? 0 : 1))'   ; number of standard deviations for w
++nsmm_l='agauss(0, 1, (mm_ok != 1 ? 0 : 1))'   ; number of standard deviations for l
 
 .model res_rppd r3_cmc
 +rsh=rsh_rppd
@@ -219,8 +231,14 @@ NR1 1 bn 2 dt res_rppd L=leff W=weff m=m
 +kfn=4.601e-11
 +afn=1.886
 +bfn=0.9963
-+smm_rsh=1.5 ; relative standard deviation for rsh [%]
-+smm_w=0.01  ; absolute standard deviation for w [um]
-+smm_l=0.01  ; absolute standard deviation for l [um]
++nsig_rsh=nsig_rppd_rsh ; global number of standard deviations for rsh
++nsig_w=nsig_rppd_w     ; global number of standard deviations for w
++nsig_l=nsig_rppd_l     ; global number of standard deviations for l
++sig_rsh=drsh_rppd      ; global relative standard deviation for rsh [%]
++sig_w=dw_rppd          ; global absolute standard deviation for w [um]
++sig_l=dl_rppd          ; global absolute standard deviation for l [um]
++smm_rsh=rsh_rppd_mm ; local relative standard deviation for rsh [%um]
++smm_w=dw_rppd_mm    ; local absolute standard deviation for w [um]
++smm_l=dl_rppd_mm    ; local absolute standard deviation for l [um]
 
 .ends rppd

--- a/ihp-sg13g2/libs.tech/ngspice/models/resistors_stat.lib
+++ b/ihp-sg13g2/libs.tech/ngspice/models/resistors_stat.lib
@@ -9,7 +9,7 @@
 *    https://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
-*distributed under the License is distributed on an "AS IS" BASIS,
+* distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
@@ -18,17 +18,13 @@
 * NOTE:
 * values are one-sigma deviations (1/3 of min-max)
 
-.param num_sigmas=1
-
-* ngspice statistical parameters
-.param  mc_rsh_rhigh = 'gauss(rsh_rhigh_norm, 0.0833,  num_sigmas)'
-.param  mc_rsh_rsil  = 'gauss(rsh_rsil_norm, 0.0467,  num_sigmas)'
-.param  mc_rsh_rppd  = 'gauss(rsh_rppd_norm, 0.033,  num_sigmas)'
-.param  mc_res_area  = 'gauss(res_area_norm, 0.033,  num_sigmas)'
-.param  mc_res_rpara = 'gauss(res_rpara_norm, 0.067,  num_sigmas)'
-
-.param  rsh_rhigh = mc_rsh_rhigh
-.param  rsh_rsil  = mc_rsh_rsil
-.param  rsh_rppd  = mc_rsh_rppd
-.param  res_area  = mc_res_area
-.param  res_rpara = mc_res_rpara
+* ngspice global statistical parameters
+.param drsh_rsil  = 4.67 ; % of 1 Sigma
+.param drsh_rppd  = 3.3  ; % of 1 Sigma
+.param drsh_rhigh = 8.33 ; % of 1 Sigma
+.param dl_rsil   = 0.01  ; um of 1 Sigma
+.param dw_rsil   = 0.01  ; um of 1 Sigma
+.param dl_rppd   = 0.01  ; um of 1 Sigma
+.param dw_rppd   = 0.01  ; um of 1 Sigma
+.param dl_rhigh  = 0.015 ; um of 1 Sigma
+.param dw_rhigh  = 0.015 ; um of 1 Sigma


### PR DESCRIPTION
This PR contents an revised ngspice library for the poly resistors if ihp sg13g2 process.

The work based on the [process documentation](https://github.com/IHP-GmbH/IHP-Open-PDK/blob/dev/ihp-sg13g2/libs.doc/doc/SG13G2_os_process_spec.pdf) and the previous open pdk library.

1. Sheet resistance variations are taken over from former lib and assumed as 3 Sigma values - this is opposite to the values in documentation above - issue #843 .
2. Mismatch models are now concordant to the _Mismatch Coefficients_ of process specification.
3. Name change for statistical library entry: res_typ_stat -> res_stat
4. New is a library entry for Statistical + Mismatch simulations: res_stat_mismatch

Plausibility evaluation. 
The attached document show an overview of the variations for rsil, rppd and rhigh resistor with different sizes.

[res_new.pdf](https://github.com/user-attachments/files/25688756/res_new.pdf)

- The 1 Sigma deviation of 2000 Monte Carlo runs are similar to the fixed corner deviation. The slight differences stem from insufficient run count.
- In my opinion the local mismatch length dependency is too small compared to width dependency. Further investigations based on measurement data are recommendable.