### PR TITLE
Modified the netgen LVS setup file so that MiM cap W and L permute.

### DIFF
--- a/ihp-sg13g2/libs.tech/netgen/ihp-sg13g2_setup.tcl
+++ b/ihp-sg13g2/libs.tech/netgen/ihp-sg13g2_setup.tcl
@@ -270,20 +270,24 @@ lappend devices cap_rfcmim
 
 foreach dev $devices {
     if {[lsearch $cells1 $dev] >= 0} {
+	property "-circuit1 $dev" derive area w l
+	property "-circuit1 $dev" derive perimeter w l
 	property "-circuit1 $dev" parallel enable
-	property "-circuit1 $dev" parallel {l critical}
-	property "-circuit1 $dev" parallel {w add}
-	property "-circuit1 $dev" tolerance {w 0.01} {l 0.01}
+	property "-circuit1 $dev" parallel {area add}
+	property "-circuit1 $dev" parallel {perimeter add}
+	property "-circuit1 $dev" tolerance {area 0.01} {perimeter 0.01}
 	# Ignore these properties
-	property "-circuit1 $dev" delete ic
+	property "-circuit1 $dev" delete ic w l
     }
     if {[lsearch $cells2 $dev] >= 0} {
+	property "-circuit2 $dev" derive area w l
+	property "-circuit2 $dev" derive perimeter w l
 	property "-circuit2 $dev" parallel enable
-	property "-circuit2 $dev" parallel {l critical}
-	property "-circuit2 $dev" parallel {w add}
-	property "-circuit2 $dev" tolerance {w 0.01} {l 0.01}
+	property "-circuit2 $dev" parallel {area add}
+	property "-circuit2 $dev" parallel {perimeter add}
+	property "-circuit2 $dev" tolerance {area 0.01} {perimeter 0.01}
 	# Ignore these properties
-	property "-circuit2 $dev" delete ic
+	property "-circuit2 $dev" delete ic w l
     }
 }
 


### PR DESCRIPTION
This PR corrects the netgen setup file, which previously compared MiM capacitors by W and L and specified L as the "critical" property. This prevented matching of non-square capacitors in different orientations, and prevented combining capacitors unless the length value matched.  This could result in LVS property mismatches on circuits which should be considered correctly matched.

Fixes #<issue_number_goes_here>

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR
