### PR TITLE
Corrects the MiM cap layers for parasitic extraction.

### DIFF
--- a/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-drc.tech
+++ b/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-drc.tech
@@ -608,34 +608,34 @@ variants *
 # METAL5 -
 #--------------------------------------------------
 
- width allm5,*mimcap,sealv5 200 "Metal5 width < %d (M5.a)"
- spacing allm5,*mimcap,sealv5  allm5,*mimcap,obsm5,sealv5 210 touching_ok \
+ width allm5,sealv5 200 "Metal5 width < %d (M5.a)"
+ spacing allm5,sealv5  allm5,*obsm5,sealv5 210 touching_ok \
 	"Metal5 spacing < %d (M5.b)"
- area allm5,*mimcap,obsm5 144000 200 "Metal5 minimum area < %a (M5.d)"
+ area allm5,obsm5 144000 200 "Metal5 minimum area < %a (M5.d)"
 
- angles allm5,*mimcap 45 "Only 45 and 90 degree angles permitted on metal5 (Grid Rules)"
+ angles allm5 45 "Only 45 and 90 degree angles permitted on metal5 (Grid Rules)"
 
- width *m5,*mimcap,rm5 240 angles "Metal5 drawn at 45 degrees width < %d (M5.g)"
+ width *m5,rm5 240 angles "Metal5 drawn at 45 degrees width < %d (M5.g)"
 
  # NOTE: M5.i is probably not implementable in magic (would require "spacing ... angles"
  # implementation similar to "width ... angles").
 
  variants (fast),(full)
- widespacing allm5,*mimcap,sealv5 395 1005 allm5,*mimcap,*obsm5 240 touching_ok \
+ widespacing allm5,sealv5 395 1005 allm5,*obsm5 240 touching_ok \
 	"Metal5 > 0.39um with runlength > 1.0um spacing to unrelated m5 < %d (M5.e)"
- widespacing *obsm5 395 1005 allm5,*mimcap 240 touching_ok \
+ widespacing *obsm5 395 1005 allm5 240 touching_ok \
 	"Metal5 > 0.39um with runlength > 1.0um spacing to unrelated m5 < %d (M5.e)"
 
- widespacing allm5,*mimcap,sealv5 10005 10005 allm5,*mimcap,*obsm5 600 touching_ok \
+ widespacing allm5,sealv5 10005 10005 allm5,*obsm5 600 touching_ok \
 	"Metal5 > 10.0um with runlength > 10.0um spacing to unrelated m5 < %d (M5.f)"
- widespacing *obsm5 10005 10005 allm5,*mimcap 600 touching_ok \
+ widespacing *obsm5 10005 10005 allm5 600 touching_ok \
 	"Metal5 > 10.0um with runlength > 10.0um spacing to unrelated m5 < %d (M5.f)"
  variants *
 
  width m5fill 1000 "Metal5 fill width < %d (MFil.a1)"
  maxwidth m5fill 5000 both "Metal5 fill width > %d (MFil.a2)"
  spacing m5fill m5fill 420 touching_ok "Metal5 fill spacing < %d (MFil.b)"
- spacing m5fill allm5,*mimcap,obsm5 420 touching_illegal \
+ spacing m5fill allm5,obsm5 420 touching_illegal \
 	"Metal5 fill spacing to Metal5 < %d (MFil.c)"
  spacing m5fill  npn,pnp 1000 touching_illegal \
 	"Metal5 fill spacing to bipolar transistor < %d (MFil.d)"

--- a/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-extract.tech
+++ b/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-extract.tech
@@ -39,10 +39,11 @@ extract
  planeorder metal3      6
  planeorder metal4      7
  planeorder metal5      8
- planeorder metal6      9
- planeorder metal7     10
- planeorder passiv     11
- planeorder comment    12
+ planeorder cap1        9
+ planeorder metal6     10
+ planeorder metal7     11
+ planeorder passiv     12
+ planeorder comment    13
 
  # Antenna check parameters
  # Note that checks w/diode diffusion are not modeled
@@ -82,7 +83,7 @@ variants (),(lvs)
  resist (allm2)/metal2            88
  resist (allm3)/metal3            88
  resist (allm4)/metal4            88
- resist (allm5,*mimcap)/metal5    88
+ resist (allm5)/metal5    	  88
  resist (allm6)/metal6            18
  resist (allm7)/metal7            11
 
@@ -108,7 +109,7 @@ variants (hrhc),(hrlc)
  resist (allm2)/metal2           103
  resist (allm3)/metal3           103
  resist (allm4)/metal4           103
- resist (allm5,*mimcap)/metal5   103
+ resist (allm5)/metal5   	 103
  resist (allm6)/metal6            21
  # actually 14.5, but must be integer
  resist (allm7)/metal7            15
@@ -135,7 +136,7 @@ variants (lrhc),(lrlc)
  resist (allm2)/metal2            73
  resist (allm3)/metal3            73
  resist (allm4)/metal4            73
- resist (allm5,*mimcap)/metal5    73
+ resist (allm5)/metal5    	  73
  resist (allm6)/metal6            15
  # actually 7.5, but must be integer
  resist (allm7)/metal7             7
@@ -342,50 +343,50 @@ variants ()
  defaultsideoverlap allm3 metal3 allm4 metal4 40.019
 
 # metal5
- defaultsidewall    allm5,*mimcap metal5 53.129 0.021
- defaultareacap     allm5,*mimcap metal5 7.136
- defaultperimeter   allm5,*mimcap metal5 27.527
+ defaultsidewall    allm5 metal5 53.129 0.021
+ defaultareacap     allm5 metal5 7.136
+ defaultperimeter   allm5 metal5 27.527
 
 # metal5->subs
- defaultoverlap     allm5,*mimcap metal5 pwell well  7.136
- defaultsideoverlap allm5,*mimcap metal5 pwell well  27.527
+ defaultoverlap     allm5 metal5 pwell well  7.136
+ defaultsideoverlap allm5 metal5 pwell well  27.527
 
 # metal5->nwell
- defaultoverlap     allm5,*mimcap metal5 nwell well  7.136
- defaultsideoverlap allm5,*mimcap metal5 nwell well  27.527
+ defaultoverlap     allm5 metal5 nwell well  7.136
+ defaultsideoverlap allm5 metal5 nwell well  27.527
 
 # metal5->diff
- defaultoverlap     allm5,*mimcap metal5 alldifflvnonfet active  7.766
- defaultsideoverlap allm5,*mimcap metal5 alldifflvnonfet active  28.227
+ defaultoverlap     allm5 metal5 alldifflvnonfet active  7.766
+ defaultsideoverlap allm5 metal5 alldifflvnonfet active  28.227
 
 # metal5->hvdiff
- defaultoverlap     allm5,*mimcap metal5 alldiffhvnonfet active  7.758
- defaultsideoverlap allm5,*mimcap metal5 alldiffhvnonfet active  28.221
+ defaultoverlap     allm5 metal5 alldiffhvnonfet active  7.758
+ defaultsideoverlap allm5 metal5 alldiffhvnonfet active  28.221
 
 # metal5->gatpoly
- defaultoverlap     allm5,*mimcap metal5 allpoly active 8.046
- defaultsideoverlap allm5,*mimcap metal5 allpoly active 28.414
+ defaultoverlap     allm5 metal5 allpoly active 8.046
+ defaultsideoverlap allm5 metal5 allpoly active 28.414
  defaultsideoverlap allpoly active allm5,*mimcap metal5 4.178
 
 # metal5->metal1
- defaultoverlap     allm5,*mimcap metal5 allm1 metal1 10.000
- defaultsideoverlap allm5,*mimcap metal5 allm1 metal1 29.935
+ defaultoverlap     allm5 metal5 allm1 metal1 10.000
+ defaultsideoverlap allm5 metal5 allm1 metal1 29.935
  defaultsideoverlap allm1 metal1 allm5,*mimcap metal5 9.725
 
 # metal5->metal2
- defaultoverlap     allm5,*mimcap metal5 allm2 metal2 13.962
- defaultsideoverlap allm5,*mimcap metal5 allm2 metal2 32.116
+ defaultoverlap     allm5 metal5 allm2 metal2 13.962
+ defaultsideoverlap allm5 metal5 allm2 metal2 32.116
  defaultsideoverlap allm2 metal2 allm5,*mimcap metal5 16.534
 
 # metal5->metal3
- defaultoverlap     allm5,*mimcap metal5 allm3 metal3 23.122
- defaultsideoverlap allm5,*mimcap metal5 allm3 metal3 36.971
- defaultsideoverlap allm3 metal3 allm5,*mimcap metal5 24.785
+ defaultoverlap     allm5 metal5 allm3 metal3 23.122
+ defaultsideoverlap allm5 metal5 allm3 metal3 36.971
+ defaultsideoverlap allm3 metal3 allm5 metal5 24.785
 
 # metal5->metal4
- defaultoverlap     allm5,*mimcap metal5 allm4 metal4 67.225
- defaultsideoverlap allm5,*mimcap metal5 allm4 metal4 49.517
- defaultsideoverlap allm4 metal4 allm5,*mimcap metal5 41.956
+ defaultoverlap     allm5 metal5 allm4 metal4 67.225
+ defaultsideoverlap allm5 metal5 allm4 metal4 49.517
+ defaultsideoverlap allm4 metal4 allm5 metal5 41.956
 
 # topmetal1
  defaultsidewall    allm6 metal6 162.172 0.343
@@ -435,7 +436,7 @@ variants ()
 
 # topmetal1->metal5
  defaultoverlap     allm6 metal6 allm5 metal5 42.708
- defaultsideoverlap allm6 metal6 allm5 metal5 65.859
+ defaultsideoverlap allm6,mimcc/m6 metal6 allm5 metal5 65.859
  defaultsideoverlap allm5 metal5 allm6 metal6 36.377
 
 # topmetal2
@@ -1117,7 +1118,7 @@ variants (hrlc),(lrlc)
 
 #---------------------------------------------------------
 
-variants *
+variants (lvs)
 
  # Area coefficient of the MiM cap for estimation of values for CDL
  # netlist output.
@@ -1163,8 +1164,8 @@ variants (),(hrhc),(lrhc),(hrlc),(lrlc)
  device msubcircuit pnpMPA pnp *pdiff pwell,space/w a1=a p1=p
 
  # Capacitors
- device csubcircuit cap_cmim *mimcap *m5 w=w l=l
- device csubcircuit cap_rfcmim *mimcap *m5 +pblock w=w l=l
+ device csubcircuit cap_cmim *mimcap m5 w=w l=l
+ device csubcircuit cap_rfcmim *mimcap m5 +pblock w=w l=l
  # Varactor:  Note that the SVaractor is a complex device incorporating
  # multiple varactor fingers.  This will normally be handled from a
  # generated cell using a "device" property.  In case varactor structures
@@ -1237,8 +1238,8 @@ variants (lvs)
  device bjt pnpMPA pnp *pdiff pwell,space/w a1=a p1=p
 
  # Capacitors
- device capacitor cap_cmim *mimcap *m5 c=c
- device capacitor cap_rfcmim *mimcap *m5 +pblock c=c
+ device capacitor cap_cmim *mimcap m5 c=c
+ device capacitor cap_rfcmim *mimcap m5 +pblock c=c
 
  # Diodes
  device pdiode dpantenna *pdiode nwell w=w l=l a=a p=p

--- a/ihp-sg13g2/libs.tech/magic/ihp-sg13g2.tech
+++ b/ihp-sg13g2/libs.tech/magic/ihp-sg13g2.tech
@@ -90,6 +90,7 @@ planes
   metal3,m3
   metal4,m4
   metal5,m5
+  cap1,c1
   metal6,m6
   metal7,m7
   passiv,p
@@ -226,8 +227,9 @@ types
  -metal5 m5fill
  -metal5 sealvia5,sealv5
 
-  metal5 mimcap,mim,capm
-  metal5 mimcapcontact,mimcapc,mimcc,capmc
+# MiM cap
+  cap1 mimcap,mim,capm
+  cap1 mimcapcontact,mimcapc,mimcc,capmc
 
 # Metal 6
   metal6 metal6,m6,met6
@@ -541,10 +543,6 @@ compose
 
   decompose hvnfetesd poly hvndiff
   decompose hvpfetesd poly hvpdiff
-
-  # Prevent m5 from erasing mimcap
-  paint	 mimcap	 m5	mimcap
-  paint	 mimcc	 m5	mimcc
 
   paint  ndc     nwell  pdc
   paint  nfet    nwell  pfet


### PR DESCRIPTION
Corrects the MiM cap layers for parasitic extraction. Previously the MiM cap layer was placed on metal5, but since the MiM cap layer is considered to be the MiM cap top plate and therefore connected to the metal layer above it, this arrangement was causing all parasitic capacitance to the bottom plate under the MiM cap layer to be added to the node of the top plate instead, which then ended up as an underestimate of parasitics to the bottom plate and an overesitmate of the parasitics to the top plate.  The solution is to create a separate plane for the MiM cap layer, not to put it on metal5.  This simplifies a number of DRC and extraction rules, which no longer need to include the mimcap layer as part of metal5.

This solves issue #803 "Extraction(cmim): bottom plate (Metal5) doesn't act as a parasitic shield for top plate".

Also:  Corrected the lines in the extraction section which allow the LVS extraction to compute a value for MiM caps, which were supposed to *only* be used for LVS extraction.  The lines of code were under "variants *" when they should have been under "variants (lvs)".

This solves issue #802 "Extraction(cmim): double capacitance count for top-plate capacitor".

Signed-off-by: R. Timothy Edwards <tim@opencircuitdesign.com>

Fixes #<issue_number_goes_here>

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR
