### PR TITLE
This quick fix removes a line from the magic startup script that is breaking LibreLane.

### DIFF
--- a/ihp-sg13g2/libs.tech/magic/ihp-sg13g2.magicrc
+++ b/ihp-sg13g2/libs.tech/magic/ihp-sg13g2.magicrc
@@ -54,8 +54,9 @@ source [file dirname [file normalize [info script]]]/ihp-sg13g2.tcl
 # load bind keys (optional)
 # source [file dirname [file normalize [info script]]]/ihp-sg13g2-BindKeys
 
-# set units to microns
-units microns
+# set units to microns (warning:  this may break scripts which have not been
+# updated to expect the new "units" command in magic)
+# units microns
 
 # set sg13g2 standard power, ground, and substrate names
 set VDD VDD


### PR DESCRIPTION
This quick fix removes a line from the magic startup script that inadvertently breaks at least one LibreLane script and which was not meant to be in the last pull request for magic support.

Fixes #868 

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR
