### PR TITLE
Isolbox connectivity issues

### DIFF
--- a/ihp-sg13g2/libs.tech/klayout/tech/lvs/rule_decks/diode_connections.lvs
+++ b/ihp-sg13g2/libs.tech/klayout/tech/lvs/rule_decks/diode_connections.lvs
@@ -41,4 +41,5 @@ connect(schottcky_n_con, metal1_con)
 # isolbox diode
 connect(isolbox_s, pwell)
 connect(isolbox_i, nbulay_drw)
+connect(isolbox_i, cont_drw)
 connect(isolbox_bn, pwell_sub)


### PR DESCRIPTION
It addresses #875 issue. 
Connectivity between `isolbox_i` and `nbulay_drw` added.
