### PR TITLE
Fix for importing SPICE netlists into magic

### DIFF
--- a/ihp-sg13g2/libs.tech/magic/diodevdd_2kv.tcl
+++ b/ihp-sg13g2/libs.tech/magic/diodevdd_2kv.tcl
@@ -411,6 +411,11 @@ label diodevdd_2kv FreeSans 600 90 0 0 c comment
 select area label
 setlabel sticky true
 select clear
+property gencell diodevdd_2kv
+property library sg13g2
+if {[info var parameters] == "parameters"} {
+    property parameters $parameters
+}
 view
 units {*}$curunits
 tech revert

--- a/ihp-sg13g2/libs.tech/magic/diodevdd_2kv.tcl
+++ b/ihp-sg13g2/libs.tech/magic/diodevdd_2kv.tcl
@@ -391,25 +391,15 @@ paint metal2
 box values 1541 747 2188 1267
 paint metal2
 box values 1830 3798 1830 3798
-label VDD FreeSans 500 90 0 0 c comment
-select area label
-setlabel sticky true
+label VDD FreeSans 500 90 0 0 c -metal2
 box values -64 3707 -64 3707
-label PAD FreeSans 500 90 0 0 c comment
-select area label
-setlabel sticky true
+label PAD FreeSans 500 90 0 0 c -metal2
 box values 972 135 972 135
-label VSS FreeSans 200 0 0 0 c comment
-select area label
-setlabel sticky true
+label VSS FreeSans 200 0 0 0 c -metal1
 box values 1666 125 1666 125
-label sub! FreeSans 200 0 0 0 c comment
-select area label
-setlabel sticky true
+label sub! FreeSans 200 0 0 0 c -psd
 box values 1260 3686 1260 3686
-label diodevdd_2kv FreeSans 600 90 0 0 c comment
-select area label
-setlabel sticky true
+label diodevdd_2kv FreeSans 600 90 0 0 c -comment
 select clear
 property gencell diodevdd_2kv
 property library sg13g2

--- a/ihp-sg13g2/libs.tech/magic/diodevdd_4kv.tcl
+++ b/ihp-sg13g2/libs.tech/magic/diodevdd_4kv.tcl
@@ -563,25 +563,15 @@ paint metal2
 box values 2456 743 3101 1263
 paint metal2
 box values 1432 135 1432 135
-label VSS FreeSans 200 0 0 0 c comment
-select area label
-setlabel sticky true
+label VSS FreeSans 200 0 0 0 c -metal1
 box values -100 3703 -100 3703
-label PAD FreeSans 500 90 0 0 c comment
-select area label
-setlabel sticky true
+label PAD FreeSans 500 90 0 0 c -metal2
 box values 2737 3702 2737 3702
-label VDD FreeSans 500 90 0 0 c comment
-select area label
-setlabel sticky true
+label VDD FreeSans 500 90 0 0 c -metal2
 box values 132 310 132 310
-label sub! FreeSans 200 0 0 0 c comment
-select area label
-setlabel sticky true
+label sub! FreeSans 200 0 0 0 c -psd
 box values 2124 3650 2124 3650
-label diodevdd_4kv FreeSans 600 90 0 0 c comment
-select area label
-setlabel sticky true
+label diodevdd_4kv FreeSans 600 90 0 0 c -comment
 select clear
 property gencell diodevdd_4kv
 property library sg13g2

--- a/ihp-sg13g2/libs.tech/magic/diodevdd_4kv.tcl
+++ b/ihp-sg13g2/libs.tech/magic/diodevdd_4kv.tcl
@@ -583,6 +583,11 @@ label diodevdd_4kv FreeSans 600 90 0 0 c comment
 select area label
 setlabel sticky true
 select clear
+property gencell diodevdd_4kv
+property library sg13g2
+if {[info var parameters] == "parameters"} {
+    property parameters $parameters
+}
 view
 units {*}$curunits
 tech revert

--- a/ihp-sg13g2/libs.tech/magic/diodevss_2kv.tcl
+++ b/ihp-sg13g2/libs.tech/magic/diodevss_2kv.tcl
@@ -475,25 +475,15 @@ paint metal2
 box values 1549 745 2196 1265
 paint metal2
 box values -56 3705 -56 3705
-label PAD FreeSans 500 90 0 0 c comment
-select area label
-setlabel sticky true
+label PAD FreeSans 500 90 0 0 c -metal2
 box values 1836 3705 1836 3705
-label VSS FreeSans 500 90 0 0 c comment
-select area label
-setlabel sticky true
+label VSS FreeSans 500 90 0 0 c -metal1
 box values 972 7275 972 7275
-label VDD FreeSans 200 0 0 0 c comment
-select area label
-setlabel sticky true
+label VDD FreeSans 200 0 0 0 c -metal2
 box values 657 477 657 477
-label sub! FreeSans 200 0 0 0 c comment
-select area label
-setlabel sticky true
+label sub! FreeSans 200 0 0 0 c -psd
 box values 1260 3686 1260 3686
-label diodevss_2kv FreeSans 600 90 0 0 c comment
-select area label
-setlabel sticky true
+label diodevss_2kv FreeSans 600 90 0 0 c -comment
 select clear
 property gencell diodevss_2kv
 property library sg13g2

--- a/ihp-sg13g2/libs.tech/magic/diodevss_2kv.tcl
+++ b/ihp-sg13g2/libs.tech/magic/diodevss_2kv.tcl
@@ -495,7 +495,12 @@ label diodevss_2kv FreeSans 600 90 0 0 c comment
 select area label
 setlabel sticky true
 select clear
+property gencell diodevss_2kv
+property library sg13g2
+if {[info var parameters] == "parameters"} {
+    property parameters $parameters
+}
 view
-set units {*}$curunits
+units {*}$curunits
 tech revert
 resumeall

--- a/ihp-sg13g2/libs.tech/magic/diodevss_4kv.tcl
+++ b/ihp-sg13g2/libs.tech/magic/diodevss_4kv.tcl
@@ -591,6 +591,11 @@ label diodevss_4kv FreeSans 600 90 0 0 c comment
 select area label
 setlabel sticky true
 select clear
+property gencell diodevss_4kv
+property library sg13g2
+if {[info var parameters] == "parameters"} {
+    property parameters $parameters
+}
 view
 units {*}$curunits
 tech revert

--- a/ihp-sg13g2/libs.tech/magic/diodevss_4kv.tcl
+++ b/ihp-sg13g2/libs.tech/magic/diodevss_4kv.tcl
@@ -571,25 +571,15 @@ paint metal2
 box values 492 744 3092 745
 paint metal2
 box values 1432 7275 1432 7275
-label VDD FreeSans 200 0 0 0 c comment
-select area label
-setlabel sticky true
+label VDD FreeSans 200 0 0 0 c -metal2
 box values 2728 3705 2728 3705
-label VSS FreeSans 500 90 0 0 c comment
-select area label
-setlabel sticky true
+label VSS FreeSans 500 90 0 0 c -metal1
 box values -102 3688 -102 3688
-label PAD FreeSans 500 90 0 0 c comment
-select area label
-setlabel sticky true
+label PAD FreeSans 500 90 0 0 c -metal2
 box values 689 499 689 499
-label sub! FreeSans 200 0 0 0 c comment
-select area label
-setlabel sticky true
+label sub! FreeSans 200 0 0 0 c -psd
 box values 2124 3650 2124 3650
-label diodevss_4kv FreeSans 600 90 0 0 c comment
-select area label
-setlabel sticky true
+label diodevss_4kv FreeSans 600 90 0 0 c -comment
 select clear
 property gencell diodevss_4kv
 property library sg13g2

--- a/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-bjt.tcl
+++ b/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-bjt.tcl
@@ -251,10 +251,7 @@ proc sg13g2::npn13g2_base_generate {} {
     # Cell has a text label at the bottom;  force it to attach to "comment"
     box position 0 -2.3um
     box size 0 0
-    label npn13G2 c space
-    select area label
-    setlabel sticky 1
-    setlabel layer comment
+    label npn13G2 c +comment
     
     # Return to our regularly scheduled program
     load $curcell
@@ -613,13 +610,10 @@ proc sg13g2::npn13g2l_draw {parameters} {
 	port make
 
 	sg13g2::setbox $ebox
-	label E c m2
-	port make
 	# This port crosses vias, so make it sticky and make sure it
 	# is on metal 2.
-	select area label
-	setlabel sticky 1
-	setlabel layer m2
+	label E c +m2
+	port make
     }
 
     popbox
@@ -863,13 +857,10 @@ proc sg13g2::npn13g2v_draw {parameters} {
 
 	# Emitter
 	sg13g2::setbox $ebox
-	label E c m2
-	port make
 	# This port crosses vias, so make it sticky and make sure it
 	# is on metal 2.
-	select area label
-	setlabel sticky 1
-	setlabel layer m2
+	label E c +m2
+	port make
     }
 
     popbox

--- a/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-bjt.tcl
+++ b/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-bjt.tcl
@@ -66,13 +66,21 @@ proc sg13g2::bipolar_convert {parameters} {
     dict for {key value} $parameters {
 	switch -nocase $key {
 	    m {
-		 dict set pdkparams nx $value
+		dict set pdkparams nx $value
 	    }
 	    we {
-		 dict set pdkparams w $value
+		# Convert value to microns
+		set value [magic::spice2float $value]
+		set value [expr $value * 1e6]
+		set value [magic::3digitpastdecimal $value]
+		dict set pdkparams w $value
 	    }
 	    le {
-		 dict set pdkparams l $value
+		# Convert value to microns
+		set value [magic::spice2float $value]
+		set value [expr $value * 1e6]
+		set value [magic::3digitpastdecimal $value]
+		dict set pdkparams l $value
 	    }
 	    default {
 		# Allow unrecognized parameters to be passed unmodified

--- a/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-cap.tcl
+++ b/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-cap.tcl
@@ -93,7 +93,7 @@ proc sg13g2::cap_convert {parameters} {
 	    w {
 		# Length and width are converted to units of microns
 		set value [magic::spice2float $value]
-		# set value [expr $value * 1e6]
+		set value [expr $value * 1e6]
 		set value [magic::3digitpastdecimal $value]
 		dict set pdkparams [string tolower $key] $value
 	    }

--- a/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-cifin.tech
+++ b/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-cifin.tech
@@ -1302,42 +1302,36 @@ style  sg13g2 variants ()
  layer fillblock FILLBLOCK
  labels FILLBLOCK
 
-# Use the obstruction types for fill block on individual layers
- layer obsactive FILLOBSDIFF
- and-not DIFF
- labels FILLOBSDIFF
+# Use mask hints only for fill block on individual layers, so that
+# the fill blockage does not require additional planes or interfere
+# with mask layers on the same plane.
 
- layer obspoly FILLOBSPOLY
- and-not POLY
- labels FILLOBSPOLY
+ templayer diffblock DIFFBLOCK
+ mask-hints DIFFBLOCK
 
- layer obsm1 FILLOBSM1
- and-not MET1
- labels FILLOBSM1
+ templayer polyblock POLYBLOCK
+ mask-hints POLYBLOCK
 
- layer obsm2 FILLOBSM2
- and-not MET2
- labels FILLOBSM2
+ templayer met1block MET1BLOCK
+ mask-hints MET1BLOCK
 
- layer obsm3 FILLOBSM3
- and-not MET3
- labels FILLOBSM3
+ templayer met2block MET2BLOCK
+ mask-hints MET2BLOCK
 
- layer obsm4 FILLOBSM4
- and-not MET4
- labels FILLOBSM4
+ templayer met3block MET3BLOCK
+ mask-hints MET3BLOCK
 
- layer obsm5 FILLOBSM5
- and-not MET5
- labels FILLOBSM5
+ templayer met4block MET4BLOCK
+ mask-hints MET4BLOCK
 
- layer obsm6 FILLOBSM6
- and-not MET6
- labels FILLOBSM6
+ templayer met5block MET5BLOCK
+ mask-hints MET5BLOCK
 
- layer obsm7 FILLOBSM7
- and-not MET7
- labels FILLOBSM7
+ templayer met6block MET6BLOCK
+ mask-hints MET6BLOCK
+
+ templayer met7block MET7BLOCK
+ mask-hints MET7BLOCK
 
  # MOS Varactor
  layer var vararea
@@ -1487,15 +1481,15 @@ style  sg13g2 variants ()
 
  calma MIM 36 0
 
- calma FILLOBSDIFF  1  23
- calma FILLOBSPOLY  5  23
- calma FILLOBSM1   8  23
- calma FILLOBSM2  10 23
- calma FILLOBSM3  30 23
- calma FILLOBSM4  50 23
- calma FILLOBSM5  67 23
- calma FILLOBSM6  126 23
- calma FILLOBSM7  134 23
+ calma DIFFBLOCK  1  23
+ calma POLYBLOCK  5  23
+ calma MET1BLOCK  8  23
+ calma MET2BLOCK  10 23
+ calma MET3BLOCK  30 23
+ calma MET4BLOCK  50 23
+ calma MET5BLOCK  67 23
+ calma MET6BLOCK  126 23
+ calma MET7BLOCK  134 23
  calma FILLBLOCK  160 0
 
  calma DIFFFILL	  1  22

--- a/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-cifout.tech
+++ b/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-cifout.tech
@@ -925,30 +925,39 @@ style gdsii
 # which it is blocking fill.
 
  layer FILLOBSDIFF  obsactive,inductor
+	mask-hints DIFFBLOCK
 	calma	1 23
 
  layer FILLOBSPOLY  obspoly,inductor
+	mask-hints POLYBLOCK
 	calma	5 23
 
  layer FILLOBSM1 obsm1,inductor
+	mask-hints MET1BLOCK
  	calma 	8 23
 
  layer FILLOBSM2 obsm2,inductor
+	mask-hints MET2BLOCK
  	calma 	10  23
 
  layer FILLOBSM3 obsm3,inductor
+	mask-hints MET3BLOCK
  	calma 	30 23
 
  layer FILLOBSM4 obsm4,inductor
+	mask-hints MET4BLOCK
  	calma 	50 23
 
  layer FILLOBSM5 obsm5,inductor
+	mask-hints MET5BLOCK
 	calma	67 23
 
  layer FILLOBSM6 obsm6,inductor
+	mask-hints MET6BLOCK
 	calma	126 23
 
  layer FILLOBSM7 obsm7,inductor
+	mask-hints MET7BLOCK
 	calma	134 23
 
  layer FILLBLOCK fillblock

--- a/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-dio.tcl
+++ b/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-dio.tcl
@@ -48,18 +48,10 @@ proc sg13g2::diode_convert {parameters} {
     dict for {key value} $parameters {
 	switch -nocase $key {
 	    l -
-	    w -
-	    peri {
-		# Length, width, and perimeter are converted to units of microns
+	    w {
+		# Length and width are converted to units of microns
 		set value [magic::spice2float $value]
-		# set value [expr $value * 1e6]
-		set value [magic::3digitpastdecimal $value]
-		dict set pdkparams [string tolower $key] $value
-	    }
-	    area {
-		# area also converted to units of microns
-		set value [magic::spice2float $value]
-		# set value [expr $value * 1e12]
+		set value [expr $value * 1e6]
 		set value [magic::3digitpastdecimal $value]
 		dict set pdkparams [string tolower $key] $value
 	    }

--- a/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-extract.tech
+++ b/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-extract.tech
@@ -1177,7 +1177,7 @@ variants (),(hrhc),(lrhc),(hrlc),(lrlc)
  # Diodes
  device csubcircuit dpantenna *pdiode nwell w=w l=l
  device dsubcircuit dantenna *ndiode pwell,space/w w=w l=l
- device subcircuit schottky *schottky *hvnsd nwell error w=w l=l
+ device subcircuit schottky_nbl1 *schottky *hvnsd pwell,space/w error w=w l=l
 
  # Resistors (3-terminal devices)
 
@@ -1244,7 +1244,7 @@ variants (lvs)
  # Diodes
  device pdiode dpantenna *pdiode nwell w=w l=l a=a p=p
  device ndiode dantenna *ndiode pwell,space/w w=w l=l a=a p=p
- device pdiode schottky *schottky *hvnsd pwell error w=w l=l a=a p=p
+ device pdiode schottky_nbl1 *schottky *hvnsd pwell,space/w error w=w l=l a=a p=p
 
  # Resistors
  device resistor $[rmod_rsil] nres *poly nwell,pwell,space/w $SUB s=$SUB r=

--- a/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-extract.tech
+++ b/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-extract.tech
@@ -1177,7 +1177,7 @@ variants (),(hrhc),(lrhc),(hrlc),(lrlc)
  # Diodes
  device csubcircuit dpantenna *pdiode nwell w=w l=l
  device dsubcircuit dantenna *ndiode pwell,space/w w=w l=l
- device subcircuit schottky_nbl1 *schottky *hvnsd pwell,space/w error w=w l=l
+ device subcircuit schottky_nbl1 *schottky *hvnsd,*hvntap pwell,space/w error w=w l=l
 
  # Resistors (3-terminal devices)
 
@@ -1244,7 +1244,7 @@ variants (lvs)
  # Diodes
  device pdiode dpantenna *pdiode nwell w=w l=l a=a p=p
  device ndiode dantenna *ndiode pwell,space/w w=w l=l a=a p=p
- device pdiode schottky_nbl1 *schottky *hvnsd pwell,space/w error w=w l=l a=a p=p
+ device pdiode schottky_nbl1 *schottky *hvnsd,*hvntap pwell,space/w error w=w l=l a=a p=p
 
  # Resistors
  device resistor $[rmod_rsil] nres *poly nwell,pwell,space/w $SUB s=$SUB r=

--- a/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-fet.tcl
+++ b/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-fet.tcl
@@ -22,7 +22,7 @@
 #    w       = Gate width
 #    l       = Gate length
 #    m	     = Multiplier
-#    nf	     = Number of fingers
+#    ng	     = Number of fingers
 #    diffcov = Diffusion contact coverage
 #    polycov = Poly contact coverage
 #    topc    = Top gate contact
@@ -42,7 +42,7 @@
 #----------------------------------------------------------------
 
 proc sg13g2::sg13_lv_pmos_defaults {} {
-    return {w 0.6 l 0.13 m 1 nf 1 diffcov 100 polycov 100 \
+    return {w 0.6 l 0.13 m 1 ng 1 diffcov 100 polycov 100 \
 		guard 0 glc 1 grc 1 gtc 1 gbc 1 tbcov 100 rlcov 100 \
 		topc 1 botc 1 poverlap 0 doverlap 1 lmin 0.13 wmin 0.15 \
 		class mosfet compatible {sg13_lv_pmos sg13_hv_pmos} \
@@ -52,7 +52,7 @@ proc sg13g2::sg13_lv_pmos_defaults {} {
 }
 
 proc sg13g2::sg13_hv_pmos_defaults {} {
-    return {w 1.0 l 0.4 m 1 nf 1 diffcov 100 polycov 100 \
+    return {w 1.0 l 0.4 m 1 ng 1 diffcov 100 polycov 100 \
 		guard 0 glc 1 grc 1 gtc 1 gbc 1 tbcov 100 rlcov 100 \
 		topc 1 botc 1 poverlap 0 doverlap 1 lmin 0.4 wmin 0.15 \
 		class mosfet compatible {sg13_lv_pmos sg13_hv_pmos} \
@@ -67,7 +67,7 @@ proc sg13g2::sg13_hv_pmos_defaults {} {
 # while non-RF devices do not.
 
 proc sg13g2::sg13_lv_rfpmos_defaults {} {
-    return {w 0.6 l 0.13 m 1 nf 1 diffcov 100 polycov 100 \
+    return {w 0.6 l 0.13 m 1 ng 1 diffcov 100 polycov 100 \
 		glc 1 grc 1 gtc 1 gbc 1 tbcov 100 rlcov 100 \
 		poverlap 0 doverlap 1 lmin 0.13 wmin 0.15 \
 		class mosfet compatible {sg13_lv_rfpmos sg13_hv_rfpmos} \
@@ -77,7 +77,7 @@ proc sg13g2::sg13_lv_rfpmos_defaults {} {
 }
 
 proc sg13g2::sg13_hv_rfpmos_defaults {} {
-    return {w 1.0 l 0.4 m 1 nf 1 diffcov 100 polycov 100 \
+    return {w 1.0 l 0.4 m 1 ng 1 diffcov 100 polycov 100 \
 		glc 1 grc 1 gtc 1 gbc 1 tbcov 100 rlcov 100 \
 		poverlap 0 doverlap 1 lmin 0.4 wmin 0.15 \
 		class mosfet compatible {sg13_lv_rfpmos sg13_hv_rfpmos} \
@@ -92,7 +92,7 @@ proc sg13g2::sg13_hv_rfpmos_defaults {} {
 #----------------------------------------------------------------
 
 proc sg13g2::sg13_lv_nmos_defaults {} {
-    return {w 0.6 l 0.13 m 1 nf 1 diffcov 100 polycov 100 \
+    return {w 0.6 l 0.13 m 1 ng 1 diffcov 100 polycov 100 \
 		guard 0 glc 1 grc 1 gtc 1 gbc 1 tbcov 100 rlcov 100 \
 		topc 1 botc 1 poverlap 0 doverlap 1 lmin 0.13 wmin 0.15 \
 		class mosfet compatible {sg13_lv_nmos sg13_hv_nmos} \
@@ -102,7 +102,7 @@ proc sg13g2::sg13_lv_nmos_defaults {} {
 }
 
 proc sg13g2::sg13_hv_nmos_defaults {} {
-    return {w 1.0 l 0.45 m 1 nf 1 diffcov 100 polycov 100 \
+    return {w 1.0 l 0.45 m 1 ng 1 diffcov 100 polycov 100 \
 		guard 0 glc 1 grc 1 gtc 1 gbc 1 tbcov 100 rlcov 100 \
 		topc 1 botc 1 poverlap 0 doverlap 1 lmin 0.45 wmin 0.15 \
 		class mosfet compatible {sg13_lv_nmos sg13_hv_nmos} \
@@ -114,7 +114,7 @@ proc sg13g2::sg13_hv_nmos_defaults {} {
 # RF devices (see comments above for pmos)
 
 proc sg13g2::sg13_lv_rfnmos_defaults {} {
-    return {w 0.6 l 0.13 m 1 nf 1 diffcov 100 polycov 100 \
+    return {w 0.6 l 0.13 m 1 ng 1 diffcov 100 polycov 100 \
 		glc 1 grc 1 gtc 1 gbc 1 tbcov 100 rlcov 100 \
 		poverlap 0 doverlap 1 lmin 0.13 wmin 0.15 \
 		class mosfet compatible {sg13_lv_rfnmos sg13_hv_rfnmos} \
@@ -124,7 +124,7 @@ proc sg13g2::sg13_lv_rfnmos_defaults {} {
 }
 
 proc sg13g2::sg13_hv_rfnmos_defaults {} {
-    return {w 1.0 l 0.45 m 1 nf 1 diffcov 100 polycov 100 \
+    return {w 1.0 l 0.45 m 1 ng 1 diffcov 100 polycov 100 \
 		glc 1 grc 1 gtc 1 gbc 1 tbcov 100 rlcov 100 \
 		poverlap 0 doverlap 1 lmin 0.45 wmin 0.15 \
 		class mosfet compatible {sg13_lv_rfnmos sg13_hv_rfnmos} \
@@ -145,14 +145,14 @@ proc sg13g2::mos_convert {parameters} {
 	    w {
 		# Length and width are converted to units of microns
 		set value [magic::spice2float $value]
-		# set value [expr $value * 1e6]
+		set value [expr $value * 1e6]
 		set value [magic::3digitpastdecimal $value]
 		dict set pdkparams [string tolower $key] $value
 	    }
 	    m {
 		dict set pdkparams [string tolower $key] $value
 	    }
-	    nf {
+	    ng {
 		# Adjustment ot W will be handled below
 		dict set pdkparams [string tolower $key] $value
 	    }
@@ -163,16 +163,16 @@ proc sg13g2::mos_convert {parameters} {
 	}
     }
 
-    # Magic does not understand "nf" as a parameter, but expands to
-    # "nf" number of devices connected horizontally.  The "w" value
-    # must be divided down accordingly, as the "nf" parameter implies
-    # that the total width "w" is divided into "nf" fingers.
+    # Magic does not understand "ng" as a parameter, but expands to
+    # "ng" number of devices connected horizontally.  The "w" value
+    # must be divided down accordingly, as the "ng" parameter implies
+    # that the total width "w" is divided into "ng" fingers.
 
     catch {
 	set w [dict get $pdkparams w]
-	set nf [dict get $pdkparams nf]
-	if {$nf > 1} {
-	    dict set pdkparams w [expr $w / $nf]
+	set ng [dict get $pdkparams ng]
+	if {$ng > 1} {
+	    dict set pdkparams w [expr $w / $ng]
 	}
     }
 
@@ -218,13 +218,13 @@ proc sg13g2::sg13_lv_rfpmos_convert {parameters} {
 #----------------------------------------------------------------
 
 proc sg13g2::mos_dialog {device parameters} {
-    # Editable fields:      w, l, nf, m, diffcov, polycov
+    # Editable fields:      w, l, ng, m, diffcov, polycov
     # Checked fields:  topc, botc
     # For specific devices, gate type is a selection list
 
     magic::add_entry w "Width (um)" $parameters
     magic::add_entry l "Length (um)" $parameters
-    magic::add_entry nf "Fingers" $parameters
+    magic::add_entry ng "Fingers" $parameters
     magic::add_entry m "M" $parameters
 
     if {[dict exists $parameters compatible]} {
@@ -913,7 +913,7 @@ proc sg13g2::mos_draw {parameters} {
     # If number of fingers is 1 then conn_gates has no meaning and
     # should be set to zero, except for RF devices where the gate
     # should be wide.
-    if {($nf == 1) && ($is_rf == 0)} {
+    if {($ng == 1) && ($is_rf == 0)} {
 	set conn_gates 0
     }
 
@@ -1000,7 +1000,7 @@ proc sg13g2::mos_draw {parameters} {
     }
 
     # Determine core width and height
-    set corex [+ [* [- $nf 1] $dx] $fw]
+    set corex [+ [* [- $ng 1] $dx] $fw]
     set corey [+ [* [- $m 1] $dy] $fh]
     set corellx [/ [+ [- $corex $fw] $lw] 2.0]
     set corelly [/ [+ [- $corey $fh] $lh] 2.0]
@@ -1095,7 +1095,7 @@ proc sg13g2::mos_draw {parameters} {
     pushbox
     box move w ${corellx}um
     box move s ${corelly}um
-    for {set xp 0} {$xp < $nf} {incr xp} {
+    for {set xp 0} {$xp < $ng} {incr xp} {
 	dict set parameters evens $evens
 	set evens [- 1 $evens]
         pushbox
@@ -1113,7 +1113,7 @@ proc sg13g2::mos_draw {parameters} {
         for {set yp 0} {$yp < $m} {incr yp} {
 	    # Apply rules for source/drain/gate port labeling
 	    if {$doports && ($m == 1)} {
-		if {$nf == 1} {
+		if {$ng == 1} {
 		    dict set parameters drain D
 		    dict set parameters source S
 		    dict set parameters gate G
@@ -1123,7 +1123,7 @@ proc sg13g2::mos_draw {parameters} {
 		    } else {
 			dict set parameters drain D$xp
 		    }
-		    if {$doverlap  && ($evens == 0) && ($xp < $nf-1)} {
+		    if {$doverlap  && ($evens == 0) && ($xp < $ng-1)} {
 			dict set parameters source ""
 		    } else {
 			dict set parameters source S$xp
@@ -1135,7 +1135,7 @@ proc sg13g2::mos_draw {parameters} {
 		    }
 		}
 	    } elseif {$doports} {
-		if {$nf == 1} {
+		if {$ng == 1} {
 		    dict set parameters drain D$yp
 		    dict set parameters source S$yp
 		    if {($poverlap || $gate_ring) && ($yp == 0)} {
@@ -1151,7 +1151,7 @@ proc sg13g2::mos_draw {parameters} {
 		    } else {
 			dict set parameters drain D${xp}_$yp
 		    }
-		    if {$doverlap && ($evens == 0) && ($xp < $nf-1)} {
+		    if {$doverlap && ($evens == 0) && ($xp < $ng-1)} {
 			dict set parameters source ""
 		    } else {
 			dict set parameters source S${xp}_$yp
@@ -1373,10 +1373,10 @@ proc sg13g2::mos_check {device parameters} {
     set w [magic::spice2float $w] 
     set w [magic::3digitpastdecimal $w]
 
-    # nf, m must be integer
-    if {![string is int $nf]} {
-	puts stderr "NF must be an integer!"
-        dict set parameters nf 1
+    # ng, m must be integer
+    if {![string is int $ng]} {
+	puts stderr "NG must be an integer!"
+        dict set parameters ng 1
     }
     if {![string is int $m]} {
 	puts stderr "M must be an integer!"
@@ -1402,9 +1402,9 @@ proc sg13g2::mos_check {device parameters} {
 	puts stderr "Mos width must be >= $wmin um"
         dict set parameters w $wmin
     } 
-    if {$nf < 1} {
-	puts stderr "NF must be >= 1"
-        dict set parameters nf 1
+    if {$ng < 1} {
+	puts stderr "NG must be >= 1"
+        dict set parameters ng 1
     } 
     if {$m < 1} {
 	puts stderr "M must be >= 1"
@@ -1486,15 +1486,15 @@ proc sg13g2::mos_check {device parameters} {
     set clearance 1.0
 
     set origm $m
-    set orignf $nf
+    set origng $ng
     while true {
        set yext [expr ($w + $clearance) * $m + $clearance]
-       set xext [expr ($l + $clearance) * $nf + $clearance]
+       set xext [expr ($l + $clearance) * $ng + $clearance]
        if {[expr min($xext, $yext)] > 30.0} {
           if {$yext > 30.0 && $m > 1} {
 	     incr m -1
-	  } elseif {$xext > 30.0 && $nf > 1} {
-	     incr nf -1
+	  } elseif {$xext > 30.0 && $ng > 1} {
+	     incr ng -1
 	  } elseif {$yext > 30.0} {
 	     set w 29
 	     puts -nonewline stderr "Transistor width must be < 29 um"
@@ -1514,9 +1514,9 @@ proc sg13g2::mos_check {device parameters} {
        puts stderr "Warning: M may need to be reduced to prevent tap distance violation"
        # dict set parameters m $m
     }
-    if {$nf != $orignf} {
+    if {$ng != $origng} {
        puts stderr "Warning: Fingers may need to be reduced to prevent tap distance violation"
-       # dict set parameters nf $nf
+       # dict set parameters ng $ng
     }
 
     catch {set magic::minfo_val ""}

--- a/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-fet.tcl
+++ b/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-fet.tcl
@@ -137,7 +137,7 @@ proc sg13g2::sg13_hv_rfnmos_defaults {} {
 # mos: Conversion from SPICE netlist parameters to toolkit
 #----------------------------------------------------------------
 
-proc sg13g2::mos_convert {parameters} {
+proc sg13g2::mos_convert {device parameters} {
     set pdkparams [dict create]
     dict for {key value} $parameters {
 	switch -nocase $key {
@@ -155,6 +155,19 @@ proc sg13g2::mos_convert {parameters} {
 	    ng {
 		# Adjustment ot W will be handled below
 		dict set pdkparams [string tolower $key] $value
+	    }
+	    rfmode {
+		dict set pdkparams is_rf 1
+		dict set pdkparams guard 1
+		dict set pdkparams gate_ring 1
+
+		# Change the device name from, e.g., pmos to rfpmos
+		set devlist [split $device "_"]
+		set np [- [llength $devlist] 1]
+		set devroot [lindex $devlist $np]
+		set newdevlist [lreplace $devlist $np $np rf$devroot]
+		set newdev [join $newdevlist "_"]
+		dict set pdkparams gencell $newdev
 	    }
 	    default {
 		# Allow unrecognized parameters to be passed unmodified
@@ -182,35 +195,35 @@ proc sg13g2::mos_convert {parameters} {
 #----------------------------------------------------------------
 
 proc sg13g2::sg13_hv_nmos_convert {parameters} {
-    return [sg13g2::mos_convert $parameters]
+    return [sg13g2::mos_convert sg13_hv_nmos $parameters]
 }
 
 proc sg13g2::sg13_lv_nmos_convert {parameters} {
-    return [sg13g2::mos_convert $parameters]
+    return [sg13g2::mos_convert sg13_lv_nmos $parameters]
 }
 
 proc sg13g2::sg13_hv_pmos_convert {parameters} {
-    return [sg13g2::mos_convert $parameters]
+    return [sg13g2::mos_convert sg13_hv_pmos $parameters]
 }
 
 proc sg13g2::sg13_lv_pmos_convert {parameters} {
-    return [sg13g2::mos_convert $parameters]
+    return [sg13g2::mos_convert sg13_lv_pmos $parameters]
 }
 
 proc sg13g2::sg13_hv_rfnmos_convert {parameters} {
-    return [sg13g2::mos_convert $parameters]
+    return [sg13g2::mos_convert sg13_hv_rfnmos $parameters]
 }
 
 proc sg13g2::sg13_lv_rfnmos_convert {parameters} {
-    return [sg13g2::mos_convert $parameters]
+    return [sg13g2::mos_convert sg13_lv_rfnmos $parameters]
 }
 
 proc sg13g2::sg13_hv_rfpmos_convert {parameters} {
-    return [sg13g2::mos_convert $parameters]
+    return [sg13g2::mos_convert st13_hv_rfpmos $parameters]
 }
 
 proc sg13g2::sg13_lv_rfpmos_convert {parameters} {
-    return [sg13g2::mos_convert $parameters]
+    return [sg13g2::mos_convert sg13_lv_rfpmos $parameters]
 }
 
 #----------------------------------------------------------------
@@ -1196,6 +1209,12 @@ proc sg13g2::mos_draw {parameters} {
     }
     popbox
     popbox
+
+    if {$is_rf == 1} {
+	# Put a gate attribute label on the gate with the parameter to output
+	box size 0 0
+	label rfmode=1^ c $gate_type
+    }
 
     units {*}$curunits
     tech revert

--- a/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-fix.tcl
+++ b/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-fix.tcl
@@ -235,7 +235,7 @@ proc sg13g2::schottky_nbl1_dialog {parameters} {
 # Fixed devices:  Generate the devices
 #----------------------------------------------------------------
 
-proc sg13g2::diodevdd_2kv_generate {} {
+proc sg13g2::diodevdd_2kv_generate {parameters} {
     if {[cellname list exists diodevdd_2kv]} {return}
     suspendall
 
@@ -261,7 +261,7 @@ proc sg13g2::diodevdd_2kv_generate {} {
 #----------------------------------------------------------------
 #----------------------------------------------------------------
 
-proc sg13g2::diodevdd_4kv_generate {} {
+proc sg13g2::diodevdd_4kv_generate {parameters} {
     if {[cellname list exists diodevdd_4kv]} {return}
     suspendall
 
@@ -287,7 +287,7 @@ proc sg13g2::diodevdd_4kv_generate {} {
 #----------------------------------------------------------------
 #----------------------------------------------------------------
 
-proc sg13g2::diodevss_2kv_generate {} {
+proc sg13g2::diodevss_2kv_generate {parameters} {
     if {[cellname list exists diodevss_2kv]} {return}
     suspendall
 
@@ -313,7 +313,7 @@ proc sg13g2::diodevss_2kv_generate {} {
 #----------------------------------------------------------------
 #----------------------------------------------------------------
 
-proc sg13g2::diodevss_4kv_generate {} {
+proc sg13g2::diodevss_4kv_generate {parameters} {
     if {[cellname list exists diodevss_4kv]} {return}
     suspendall
 
@@ -339,7 +339,7 @@ proc sg13g2::diodevss_4kv_generate {} {
 #----------------------------------------------------------------
 #----------------------------------------------------------------
 
-proc sg13g2::nmoscl_2_generate {} {
+proc sg13g2::nmoscl_2_generate {parameters} {
     if {[cellname list exists nmoscl_2]} {return}
     suspendall
 
@@ -365,7 +365,7 @@ proc sg13g2::nmoscl_2_generate {} {
 #----------------------------------------------------------------
 #----------------------------------------------------------------
 
-proc sg13g2::nmoscl_4_generate {} {
+proc sg13g2::nmoscl_4_generate {parameters} {
     if {[cellname list exists nmoscl_4]} {return}
     suspendall
 
@@ -391,7 +391,7 @@ proc sg13g2::nmoscl_4_generate {} {
 #----------------------------------------------------------------
 #----------------------------------------------------------------
 
-proc sg13g2::scr1_generate {} {
+proc sg13g2::scr1_generate {parameters} {
     if {[cellname list exists scr1]} {return}
     suspendall
 
@@ -417,7 +417,7 @@ proc sg13g2::scr1_generate {} {
 #----------------------------------------------------------------
 #----------------------------------------------------------------
 
-proc sg13g2::schottky_nbl1_generate {} {
+proc sg13g2::schottky_nbl1_generate {parameters} {
     if {[cellname list exists schottky_nbl1]} {return}
     suspendall
 
@@ -479,42 +479,58 @@ proc sg13g2::fixed_draw {devname parameters} {
 #----------------------------------------------------------------
 
 proc sg13g2::diodevdd_2kv_draw {parameters} {
-    if {[cellname list exists diodevdd_2kv] == 0} {sg13g2::diodevdd_2kv_generate}
+    if {[cellname list exists diodevdd_2kv] == 0} {
+	sg13g2::diodevdd_2kv_generate $parameters
+    }
     return [sg13g2::fixed_draw diodevdd_2kv $parameters]
 }
 
 proc sg13g2::diodevdd_4kv_draw {parameters} {
-    if {[cellname list exists diodevdd_4kv] == 0} {sg13g2::diodevdd_4kv_generate}
+    if {[cellname list exists diodevdd_4kv] == 0} {
+	sg13g2::diodevdd_4kv_generate $parameters
+    }
     return [sg13g2::fixed_draw diodevdd_4kv $parameters]
 }
 
 proc sg13g2::diodevss_2kv_draw {parameters} {
-    if {[cellname list exists diodevss_2kv] == 0} {sg13g2::diodevss_2kv_generate}
+    if {[cellname list exists diodevss_2kv] == 0} {
+	sg13g2::diodevss_2kv_generate $parameters
+    }
     return [sg13g2::fixed_draw diodevss_2kv $parameters]
 }
 
 proc sg13g2::diodevss_4kv_draw {parameters} {
-    if {[cellname list exists diodevss_4kv] == 0} {sg13g2::diodevss_4kv_generate}
+    if {[cellname list exists diodevss_4kv] == 0} {
+	sg13g2::diodevss_4kv_generate $parameters
+    }
     return [sg13g2::fixed_draw diodevss_4kv $parameters]
 }
 
 proc sg13g2::nmoscl_2_draw {parameters} {
-    if {[cellname list exists nmoscl_2] == 0} {sg13g2::nmoscl_2_generate}
+    if {[cellname list exists nmoscl_2] == 0} {
+	sg13g2::nmoscl_2_generate $parameters
+    }
     return [sg13g2::fixed_draw nmoscl_2 $parameters]
 }
 
 proc sg13g2::nmoscl_4_draw {parameters} {
-    if {[cellname list exists nmoscl_4] == 0} {sg13g2::nmoscl_4_generate}
+    if {[cellname list exists nmoscl_4] == 0} {
+	sg13g2::nmoscl_4_generate $parameters
+    }
     return [sg13g2::fixed_draw nmoscl_4 $parameters]
 }
 
 proc sg13g2::scr1_draw {parameters} {
-    if {[cellname list exists scr1] == 0} {sg13g2::scr1_generate}
+    if {[cellname list exists scr1] == 0} {
+	sg13g2::scr1_generate $parameters
+    }
     return [sg13g2::fixed_draw scr1 $parameters]
 }
 
 proc sg13g2::schottky_nbl1_draw {parameters} {
-    if {[cellname list exists schottky_nbl1] == 0} {sg13g2::schottky_nbl1_generate}
+    if {[cellname list exists schottky_nbl1] == 0} {
+	sg13g2::schottky_nbl1_generate $parameters
+    }
     return [sg13g2::fixed_draw schottky_nbl1 $parameters]
 }
 

--- a/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-fix.tcl
+++ b/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-fix.tcl
@@ -89,7 +89,7 @@ proc sg13g2::scr1_defaults {} {
     xstep 16.8 ystep 31.2 class diode}
 }
 
-proc sg13g2::schottky_nbl1_defaults {} {
+proc sg13g2::schottky_defaults {} {
     return {nx 1 ny 1 deltax 0 deltay 0 nocell 1 \
     xstep 5.5 ystep 6.0 class diode}
 }
@@ -147,7 +147,7 @@ proc sg13g2::scr1_convert {parameters} {
     return [sg13g2::fixed_convert $parameters]
 }
 
-proc sg13g2::schottky_nbl1_convert {parameters} {
+proc sg13g2::schottky_convert {parameters} {
     return [sg13g2::fixed_convert $parameters]
 }
 
@@ -227,8 +227,8 @@ proc sg13g2::scr1_dialog {parameters} {
     sg13g2::fixed_dialog scr1 $parameters
 }
 
-proc sg13g2::schottky_nbl1_dialog {parameters} {
-    sg13g2::fixed_dialog schottky_nbl1 $parameters
+proc sg13g2::schottky_dialog {parameters} {
+    sg13g2::fixed_dialog schottky $parameters
 }
 
 #----------------------------------------------------------------
@@ -417,8 +417,8 @@ proc sg13g2::scr1_generate {parameters} {
 #----------------------------------------------------------------
 #----------------------------------------------------------------
 
-proc sg13g2::schottky_nbl1_generate {parameters} {
-    if {[cellname list exists schottky_nbl1]} {return}
+proc sg13g2::schottky_generate {parameters} {
+    if {[cellname list exists schottky_cell]} {return}
     suspendall
 
     # Save critical values before creating and editing a new cell 
@@ -427,10 +427,10 @@ proc sg13g2::schottky_nbl1_generate {parameters} {
     # Stop the tag method from messing with this procedure
     set ltag [tag load]
     tag load {}
-    load schottky_nbl1 -silent
+    load schottky -silent
     tech unlock *
 
-    source ${sg13g2::script_path}/schottky_nbl1.tcl
+    source ${sg13g2::script_path}/schottky.tcl
 
     # Return to our regularly scheduled program
     load $curcell
@@ -527,11 +527,11 @@ proc sg13g2::scr1_draw {parameters} {
     return [sg13g2::fixed_draw scr1 $parameters]
 }
 
-proc sg13g2::schottky_nbl1_draw {parameters} {
-    if {[cellname list exists schottky_nbl1] == 0} {
-	sg13g2::schottky_nbl1_generate $parameters
+proc sg13g2::schottky_draw {parameters} {
+    if {[cellname list exists schottky] == 0} {
+	sg13g2::schottky_generate $parameters
     }
-    return [sg13g2::fixed_draw schottky_nbl1 $parameters]
+    return [sg13g2::fixed_draw schottky $parameters]
 }
 
 #----------------------------------------------------------------
@@ -612,7 +612,7 @@ proc sg13g2::scr1_check {parameters} {
     return [sg13g2::fixed_check $parameters]
 }
 
-proc sg13g2::schottky_nbl1_check {parameters} {
+proc sg13g2::schottky_check {parameters} {
     return [sg13g2::fixed_check $parameters]
 }
 

--- a/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-pad.tcl
+++ b/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-pad.tcl
@@ -29,6 +29,9 @@ proc sg13g2::bondpad_convert {parameters} {
     dict for {key value} $parameters {
 	switch -nocase $key {
 	    size {
+		set value [magic::spice2float $value]
+		set value [expr $value * 1e6]
+		set value [magic::3digitpastdecimal $value]
 		dict set pdkparams width $value
 		dict set pdkparams height $value
 	    }

--- a/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-res.tcl
+++ b/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-res.tcl
@@ -213,7 +213,7 @@ proc sg13g2::res_convert {parameters} {
 	    w {
 		# Length and width are converted to units of microns
 		set value [magic::spice2float $value]
-		# set value [expr $value * 1e6]
+		set value [expr $value * 1e6]
 		set value [magic::3digitpastdecimal $value]
 		dict set pdkparams [string tolower $key] $value
 	    }

--- a/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-var.tcl
+++ b/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-var.tcl
@@ -54,7 +54,7 @@ proc sg13g2::var_convert {parameters} {
 	    w {
 		# Length and width are converted to units of microns
 		set value [magic::spice2float $value]
-		# set value [expr $value * 1e6]
+		set value [expr $value * 1e6]
 		set value [magic::3digitpastdecimal $value]
 		dict set pdkparams [string tolower $key] $value
 	    }

--- a/ihp-sg13g2/libs.tech/magic/ihp-sg13g2.tcl
+++ b/ihp-sg13g2/libs.tech/magic/ihp-sg13g2.tcl
@@ -187,7 +187,7 @@ proc sg13g2::addtechmenu {framename} {
    magic::add_toolkit_command $layoutframe "p-diode" \
 	    "magic::gencell sg13g2::dpantenna" pdk1
    magic::add_toolkit_command $layoutframe "schottky" \
-	    "magic::gencell sg13g2::schottky_nbl1" pdk1
+	    "magic::gencell sg13g2::schottky" pdk1
    magic::add_toolkit_separator	$layoutframe pdk1
 
    magic::add_toolkit_command $layoutframe "NPN" \

--- a/ihp-sg13g2/libs.tech/magic/ihp-sg13g2.tech
+++ b/ihp-sg13g2/libs.tech/magic/ihp-sg13g2.tech
@@ -604,6 +604,8 @@ connect
   *ptap,*hvptap	*ndiff,*hvndiff
   npn,pbc	npn,pbc
   pbc,*m1	pbc,*m1
+  schottky,sdic	schottky,sdic
+  sdic,*m1	sdic,*m1
   *m1,m1fill,iprobe,diffprobe	*m1,m1fill,iprobe,diffprobe
   *m2,m2fill	*m2,m2fill
   *m3,m3fill	*m3,m3fill

--- a/ihp-sg13g2/libs.tech/magic/nmoscl_2.tcl
+++ b/ihp-sg13g2/libs.tech/magic/nmoscl_2.tcl
@@ -1127,23 +1127,15 @@ paint metal3
 box values -42 -604 6556 -24
 paint metal3
 box values 318 3852 318 3852
-label VDD FreeSans 200 0 0 0 c comment
-select area label
-setlabel sticky true
+label VDD FreeSans 200 0 0 0 c -metal2
 box values 290 3402 290 3402
-label sub! FreeSans 200 0 0 0 c comment
-select area label
-setlabel sticky true
+label sub! FreeSans 200 0 0 0 c -metal1
 box values 362 -249 362 -249
-label VSS FreeSans 200 0 0 0 c comment
-select area label
-setlabel sticky true
+label VSS FreeSans 200 0 0 0 c -metal2
 box values 3451 1676 3451 1676
-label nmoscl_2 FreeSans 1000 0 0 0 c comment
-select area label
-setlabel sticky true
+label nmoscl_2 FreeSans 1000 0 0 0 c -comment
 box values 290 3402 290 3402
-label sub! FreeSans 200 0 0 0 c dnwell
+label sub! FreeSans 200 0 0 0 c -dnwell
 select clear
 property gencell nmoscl_2
 property library sg13g2

--- a/ihp-sg13g2/libs.tech/magic/nmoscl_2.tcl
+++ b/ihp-sg13g2/libs.tech/magic/nmoscl_2.tcl
@@ -1145,6 +1145,11 @@ setlabel sticky true
 box values 290 3402 290 3402
 label sub! FreeSans 200 0 0 0 c dnwell
 select clear
+property gencell nmoscl_2
+property library sg13g2
+if {[info var parameters] == "parameters"} {
+    property parameters $parameters
+}
 view
 units {*}$curunits
 tech revert

--- a/ihp-sg13g2/libs.tech/magic/nmoscl_4.tcl
+++ b/ihp-sg13g2/libs.tech/magic/nmoscl_4.tcl
@@ -2023,23 +2023,15 @@ paint metal3
 box values -42 -604 12940 -24
 paint metal3
 box values 192 3822 192 3822
-label VDD FreeSans 200 0 0 0 c comment
-select area label
-setlabel sticky true
+label VDD FreeSans 200 0 0 0 c -metal2
 box values 290 3402 290 3402
-label sub! FreeSans 200 0 0 0 c comment
-select area label
-setlabel sticky true
+label sub! FreeSans 200 0 0 0 c -metal1
 box values 259 -150 259 -150
-label VSS FreeSans 200 0 0 0 c comment
-select area label
-setlabel sticky true
+label VSS FreeSans 200 0 0 0 c -metal2
 box values 5826 1640 5826 1640
-label nmoscl_4 FreeSans 1000 0 0 0 c comment
-select area label
-setlabel sticky true
+label nmoscl_4 FreeSans 1000 0 0 0 c -comment
 box values 290 3402 290 3402
-label sub! FreeSans 200 0 0 0 c dnwell
+label sub! FreeSans 200 0 0 0 c -dnwell
 select clear
 property gencell nmoscl_4
 property library sg13g2

--- a/ihp-sg13g2/libs.tech/magic/nmoscl_4.tcl
+++ b/ihp-sg13g2/libs.tech/magic/nmoscl_4.tcl
@@ -2041,6 +2041,11 @@ setlabel sticky true
 box values 290 3402 290 3402
 label sub! FreeSans 200 0 0 0 c dnwell
 select clear
+property gencell nmoscl_4
+property library sg13g2
+if {[info var parameters] == "parameters"} {
+    property parameters $parameters
+}
 view
 units {*}$curunits
 tech revert

--- a/ihp-sg13g2/libs.tech/magic/schottky.tcl
+++ b/ihp-sg13g2/libs.tech/magic/schottky.tcl
@@ -16,13 +16,13 @@
 #
 ########################################################################
 
-# Command script for generating cell schottky_nbl1
+# Command script for generating cell "schottky" for device schottky_nbl1
 
 suspendall
 tech unlock *
 set curunits [units]
 units internal
-load schottky_nbl1 -silent
+load schottky -silent
 box values 0 0 0 0
 box values -110 -84 350 464
 paint dnwell
@@ -181,30 +181,20 @@ paint metal2
 box values -116 -363 356 -139
 paint metal2
 box values 3 -118 3 -118
-label schottky_nbl1 FreeSans 70 0 0 0 c comment
-select area label
-setlabel sticky true
+label schottky_nbl1 FreeSans 70 0 0 0 c -comment
 box values 120 -251 120 -251
-label PLUS FreeSans 140 0 0 0 c metal2
-select area label
-setlabel sticky true
+label PLUS FreeSans 140 0 0 0 c -metal2
 box values 670 154 670 154
-label TIE FreeSans 37 0 0 0 c hvpsubdiffcont
-select area label
-setlabel sticky true
+label TIE FreeSans 37 0 0 0 c -hvpsubdiffcont
 box values -430 154 -430 154
-label TIE FreeSans 37 0 0 0 c hvpsubdiffcont
-select area label
-setlabel sticky true
+label TIE FreeSans 37 0 0 0 c -hvpsubdiffcont
 box values 120 565 120 565
-label MINUS FreeSans 131 0 0 0 c metal1
-select area label
-setlabel sticky true
+label MINUS FreeSans 131 0 0 0 c -metal1
 # Note: Use mask hint for pblock to avoid DRC errors.
 # PWELLBLK will be generated automatically.
 property MASKHINTS_PWELLBLK -326 -368 566 -130 -326 -130 -160 510 400 -130 566 510 -326 510 566 670
 select clear
-property gencell schottky_nbl1
+property gencell schottky
 property library sg13g2
 if {[info var parameters] == "parameters"} {
     property parameters $parameters

--- a/ihp-sg13g2/libs.tech/magic/schottky_nbl1.tcl
+++ b/ihp-sg13g2/libs.tech/magic/schottky_nbl1.tcl
@@ -204,6 +204,11 @@ setlabel sticky true
 # PWELLBLK will be generated automatically.
 property MASKHINTS_PWELLBLK -326 -368 566 -130 -326 -130 -160 510 400 -130 566 510 -326 510 566 670
 select clear
+property gencell schottky_nbl1
+property library sg13g2
+if {[info var parameters] == "parameters"} {
+    property parameters $parameters
+}
 view
 units {*}$curunits
 tech revert

--- a/ihp-sg13g2/libs.tech/magic/scr1.tcl
+++ b/ihp-sg13g2/libs.tech/magic/scr1.tcl
@@ -267,6 +267,11 @@ label scr1 FreeSans 500 0 0 0 ne space
 select area label
 setlabel sticky true
 select clear
+property gencell scr1
+property library sg13g2
+if {[info var parameters] == "parameters"} {
+    property parameters $parameters
+}
 view
 units {*}$curunits
 tech revert

--- a/ihp-sg13g2/libs.tech/magic/scr1.tcl
+++ b/ihp-sg13g2/libs.tech/magic/scr1.tcl
@@ -255,17 +255,11 @@ paint metal3
 box values 540 38 1532 57
 paint metal3
 box values 1036 534 1036 534
-label B FreeSans 1000 0 0 0 c space
-select area label
-setlabel sticky true
+label B FreeSans 1000 0 0 0 c -metal2
 box values -1036 4466 -1036 4466
-label A FreeSans 1000 0 0 0 c space
-select area label
-setlabel sticky true
+label A FreeSans 1000 0 0 0 c -metal2
 box values -1470 -418 -1470 -418
-label scr1 FreeSans 500 0 0 0 ne space
-select area label
-setlabel sticky true
+label scr1 FreeSans 500 0 0 0 ne -comment
 select clear
 property gencell scr1
 property library sg13g2


### PR DESCRIPTION
The "*_convert" routines used by the device generator toolkit in magic were not converting units of the devices in a SPICE netlist (SI units) to the units used by the device generator (microns).  In addition, "nf" was being used for device fingers in a FET while the models use "ng".  Both issues are fixed by this commit.

Fixes #<issue_number_goes_here>

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR
