### PR TITLE
Fix DRC JSON precedence so user overrides take effect

### DIFF
--- a/ihp-sg13g2/libs.tech/klayout/tech/drc/ihp-sg13g2.drc
+++ b/ihp-sg13g2/libs.tech/klayout/tech/drc/ihp-sg13g2.drc
@@ -206,7 +206,8 @@ def get_drc_values(logger)
     raise "Error reading default DRC rules from #{$drc_json_default}: #{e.message}"
   end
 
-  merged_rules = tech_rules.merge(default_rules)
+  # Defaults are the baseline; process-specific TECH values must override them when provided.
+  merged_rules = default_rules.merge(tech_rules)
 
   # Report any fallback rules used
   missing_keys = default_rules.keys - tech_rules.keys

--- a/ihp-sg13g2/libs.tech/klayout/tech/drc/rule_decks/antenna.drc
+++ b/ihp-sg13g2/libs.tech/klayout/tech/drc/rule_decks/antenna.drc
@@ -296,7 +296,8 @@ def get_drc_values(logger)
     raise "Error reading default DRC rules from #{$drc_json_default}: #{e.message}"
   end
 
-  merged_rules = tech_rules.merge(default_rules)
+  # Defaults are the baseline; process-specific TECH values must override them when provided.
+  merged_rules = default_rules.merge(tech_rules)
 
   # Report any fallback rules used
   missing_keys = default_rules.keys - tech_rules.keys


### PR DESCRIPTION
Swap rule merging order in the main and antenna KLayout runsets to use defaults as baseline and let TECH/user --drc_json values override overlapping keys. This aligns behavior with density.drc and ensures custom rule JSON files actually modify enforced DRC thresholds.


