### PR TITLE
Update Xschem npn13G2 sym files

### DIFF
--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2.sym
@@ -16,7 +16,7 @@ v {xschem version=3.4.8RC file_version=1.3
 }
 G {}
 K {type=vertical_npn
-lvs_format="Q@name @pinlist @model le=900e-9 we=70.0n m=@Nx"
+lvs_format="Q@name @pinlist @model le=900e-9 we=70.0n Nx=@Nx"
 format="@spiceprefix@name @pinlist @model Nx=@Nx"
 template="name=Q1
 model=npn13G2
@@ -38,7 +38,7 @@ B 5 -22.5 -2.5 -17.5 2.5 {name=B dir=in sim_pinnumber=2}
 B 5 17.5 27.5 22.5 32.5 {name=E dir=inout sim_pinnumber=3}
 B 5 17.5 -2.5 22.5 2.5 {name=S dir=in sim_pinnumber=4}
 P 4 4 20 30 13.75 13.75 3.75 23.75 20 30 {fill=true}
-T {Nx=@Nx} 22.5 11.25 0 0 0.2 0.2 {layer=13}
+T {Nx=@Nx} 32.5 11.25 0 0 0.2 0.2 {layer=13}
 T {@model} 22.5 -15 0 0 0.2 0.2 {}
 T {S} 10 -5 0 0 0.2 0.2 {}
 T {@name} 22.5 -27.5 0 0 0.2 0.2 {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2.sym
@@ -16,12 +16,13 @@ v {xschem version=3.4.8RC file_version=1.3
 }
 G {}
 K {type=vertical_npn
-lvs_format="Q@name @pinlist @model le=900e-9 we=70.0n m=@Nx"
+lvs_format="Q@name @pinlist @model le=900e-9 we=70.0n m=@m Nx=@Nx"
 format="@spiceprefix@name @pinlist @model Nx=@Nx"
 template="name=Q1
 model=npn13G2
 spiceprefix=X
 Nx=1
+m=1
 "
 drc="hbt_drc @name @symname @model @Nx @El"
 }
@@ -38,7 +39,8 @@ B 5 -22.5 -2.5 -17.5 2.5 {name=B dir=in sim_pinnumber=2}
 B 5 17.5 27.5 22.5 32.5 {name=E dir=inout sim_pinnumber=3}
 B 5 17.5 -2.5 22.5 2.5 {name=S dir=in sim_pinnumber=4}
 P 4 4 20 30 13.75 13.75 3.75 23.75 20 30 {fill=true}
-T {Nx=@Nx} 22.5 11.25 0 0 0.2 0.2 {layer=13}
+T {Nx=@Nx} 32.5 11.25 0 0 0.2 0.2 {layer=13}
 T {@model} 22.5 -15 0 0 0.2 0.2 {}
 T {S} 10 -5 0 0 0.2 0.2 {}
 T {@name} 22.5 -27.5 0 0 0.2 0.2 {}
+T {m=@m} 32.5 21.25 0 0 0.2 0.2 {layer=13}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2.sym
@@ -16,7 +16,7 @@ v {xschem version=3.4.8RC file_version=1.3
 }
 G {}
 K {type=vertical_npn
-lvs_format="Q@name @pinlist @model le=900e-9 we=70.0n Nx=@Nx"
+lvs_format="Q@name @pinlist @model le=900e-9 we=70.0n m=@Nx"
 format="@spiceprefix@name @pinlist @model Nx=@Nx"
 template="name=Q1
 model=npn13G2
@@ -38,7 +38,7 @@ B 5 -22.5 -2.5 -17.5 2.5 {name=B dir=in sim_pinnumber=2}
 B 5 17.5 27.5 22.5 32.5 {name=E dir=inout sim_pinnumber=3}
 B 5 17.5 -2.5 22.5 2.5 {name=S dir=in sim_pinnumber=4}
 P 4 4 20 30 13.75 13.75 3.75 23.75 20 30 {fill=true}
-T {Nx=@Nx} 32.5 11.25 0 0 0.2 0.2 {layer=13}
+T {Nx=@Nx} 22.5 11.25 0 0 0.2 0.2 {layer=13}
 T {@model} 22.5 -15 0 0 0.2 0.2 {}
 T {S} 10 -5 0 0 0.2 0.2 {}
 T {@name} 22.5 -27.5 0 0 0.2 0.2 {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2.sym
@@ -16,13 +16,12 @@ v {xschem version=3.4.8RC file_version=1.3
 }
 G {}
 K {type=vertical_npn
-lvs_format="Q@name @pinlist @model le=900e-9 we=70.0n m=@m Nx=@Nx"
+lvs_format="Q@name @pinlist @model le=900e-9 we=70.0n m=@Nx"
 format="@spiceprefix@name @pinlist @model Nx=@Nx"
 template="name=Q1
 model=npn13G2
 spiceprefix=X
 Nx=1
-m=1
 "
 drc="hbt_drc @name @symname @model @Nx @El"
 }
@@ -39,8 +38,7 @@ B 5 -22.5 -2.5 -17.5 2.5 {name=B dir=in sim_pinnumber=2}
 B 5 17.5 27.5 22.5 32.5 {name=E dir=inout sim_pinnumber=3}
 B 5 17.5 -2.5 22.5 2.5 {name=S dir=in sim_pinnumber=4}
 P 4 4 20 30 13.75 13.75 3.75 23.75 20 30 {fill=true}
-T {Nx=@Nx} 32.5 11.25 0 0 0.2 0.2 {layer=13}
+T {Nx=@Nx} 22.5 11.25 0 0 0.2 0.2 {layer=13}
 T {@model} 22.5 -15 0 0 0.2 0.2 {}
 T {S} 10 -5 0 0 0.2 0.2 {}
 T {@name} 22.5 -27.5 0 0 0.2 0.2 {}
-T {m=@m} 32.5 21.25 0 0 0.2 0.2 {layer=13}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2_5t.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2_5t.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.8RC file_version=1.3
+v {xschem version=3.4.5 file_version=1.2
 * Copyright 2023 IHP PDK Authors
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +16,7 @@ v {xschem version=3.4.8RC file_version=1.3
 }
 G {}
 K {type=vertical_npn
-lvs_format="Q@name @pinlist @model le=900e-9 we=70.0n Nx=@Nx"
+lvs_format="Q@name @pinlist @model le=900e-9 we=70.0n m=@Nx"
 format="@spiceprefix@name @pinlist @model Nx=@Nx"
 template="name=Q1
 model=npn13G2_5t
@@ -27,7 +27,6 @@ drc="hbt_drc @name @symname @model @Nx @El"
 }
 V {}
 S {}
-F {}
 E {}
 L 4 0 -30 0 30 {}
 L 4 -20 0 0 0 {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2_5t.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2_5t.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.8RC file_version=1.3
+v {xschem version=3.4.5 file_version=1.2
 * Copyright 2023 IHP PDK Authors
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,19 +16,17 @@ v {xschem version=3.4.8RC file_version=1.3
 }
 G {}
 K {type=vertical_npn
-lvs_format="Q@name @pinlist @model le=900e-9 we=70.0n m=@m Nx=@Nx"
+lvs_format="Q@name @pinlist @model le=900e-9 we=70.0n m=@Nx"
 format="@spiceprefix@name @pinlist @model Nx=@Nx"
 template="name=Q1
 model=npn13G2_5t
 spiceprefix=X
 Nx=1
-m=1
 "
 drc="hbt_drc @name @symname @model @Nx @El"
 }
 V {}
 S {}
-F {}
 E {}
 L 4 0 -30 0 30 {}
 L 4 -20 0 0 0 {}
@@ -44,7 +42,6 @@ P 4 5 -40 -50 70 -50 70 50 -40 50 -40 -50 {}
 T {Nx=@Nx} 22.5 11.25 0 0 0.2 0.2 {layer=13}
 T {@model} 22.5 -15 0 0 0.2 0.2 {}
 T {@name} 22.5 -27.5 0 0 0.2 0.2 {}
-T {m=@m} 22.5 21.25 0 0 0.2 0.2 {layer=13}
 N -40 -0 -20 -0 {
 lab=#net1}
 N 20 -50 20 -30 {

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2_5t.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2_5t.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
+v {xschem version=3.4.8RC file_version=1.3
 * Copyright 2023 IHP PDK Authors
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,17 +16,19 @@ v {xschem version=3.4.5 file_version=1.2
 }
 G {}
 K {type=vertical_npn
-lvs_format="Q@name @pinlist @model le=900e-9 we=70.0n m=@Nx"
+lvs_format="Q@name @pinlist @model le=900e-9 we=70.0n m=@m Nx=@Nx"
 format="@spiceprefix@name @pinlist @model Nx=@Nx"
 template="name=Q1
 model=npn13G2_5t
 spiceprefix=X
 Nx=1
+m=1
 "
 drc="hbt_drc @name @symname @model @Nx @El"
 }
 V {}
 S {}
+F {}
 E {}
 L 4 0 -30 0 30 {}
 L 4 -20 0 0 0 {}
@@ -42,6 +44,7 @@ P 4 5 -40 -50 70 -50 70 50 -40 50 -40 -50 {}
 T {Nx=@Nx} 22.5 11.25 0 0 0.2 0.2 {layer=13}
 T {@model} 22.5 -15 0 0 0.2 0.2 {}
 T {@name} 22.5 -27.5 0 0 0.2 0.2 {}
+T {m=@m} 22.5 21.25 0 0 0.2 0.2 {layer=13}
 N -40 -0 -20 -0 {
 lab=#net1}
 N 20 -50 20 -30 {

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2_5t.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2_5t.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
+v {xschem version=3.4.8RC file_version=1.3
 * Copyright 2023 IHP PDK Authors
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +16,7 @@ v {xschem version=3.4.5 file_version=1.2
 }
 G {}
 K {type=vertical_npn
-lvs_format="Q@name @pinlist @model le=900e-9 we=70.0n m=@Nx"
+lvs_format="Q@name @pinlist @model le=900e-9 we=70.0n Nx=@Nx"
 format="@spiceprefix@name @pinlist @model Nx=@Nx"
 template="name=Q1
 model=npn13G2_5t
@@ -27,6 +27,7 @@ drc="hbt_drc @name @symname @model @Nx @El"
 }
 V {}
 S {}
+F {}
 E {}
 L 4 0 -30 0 30 {}
 L 4 -20 0 0 0 {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2l.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2l.sym
@@ -16,12 +16,13 @@ v {xschem version=3.4.8RC file_version=1.3
 }
 G {}
 K {type=vertical_npn
-lvs_format="tcleval(Q@name @pinlist @model le=[ev \{ @El * 1.0e-6 \} ] we=70.0n m=@Nx )"
+lvs_format="tcleval(Q@name @pinlist @model le=[ev \{ @El * 1.0e-6 \} ] we=70.0n m=@m Nx=@Nx )"
 format="@spiceprefix@name @pinlist @model Nx=@Nx El=@El"
 template="name=Q1
 model=npn13G2l
 spiceprefix=X
 Nx=1
+m=1
 El=1.0
 "
 drc="hbt_drc @name @symname @model @Nx @El"
@@ -39,8 +40,9 @@ B 5 -22.5 -2.5 -17.5 2.5 {name=B dir=in sim_pinnumber=2}
 B 5 17.5 27.5 22.5 32.5 {name=E dir=inout sim_pinnumber=3}
 B 5 17.5 -2.5 22.5 2.5 {name=S dir=in sim_pinnumber=4}
 P 4 4 20 30 13.75 13.75 3.75 23.75 20 30 {fill=true}
-T {Nx=@Nx} 32.5 1.25 0 0 0.2 0.2 {layer=13}
+T {Nx=@Nx} 32.5 11.25 0 0 0.2 0.2 {layer=13}
 T {@model} 22.5 -15 0 0 0.2 0.2 {}
 T {S} 10 -5 0 0 0.2 0.2 {}
 T {@name} 22.5 -27.5 0 0 0.2 0.2 {}
-T {El=@El} 32.5 11.25 0 0 0.2 0.2 {layer=13}
+T {El=@El} 32.5 31.25 0 0 0.2 0.2 {layer=13}
+T {m=@m} 32.5 21.25 0 0 0.2 0.2 {layer=13}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2l.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2l.sym
@@ -16,7 +16,7 @@ v {xschem version=3.4.8RC file_version=1.3
 }
 G {}
 K {type=vertical_npn
-lvs_format="tcleval(Q@name @pinlist @model le=[ev \{ @El * 1.0e-6 \} ] we=70.0n Nx=@Nx )"
+lvs_format="tcleval(Q@name @pinlist @model le=[ev \{ @El * 1.0e-6 \} ] we=70.0n m=@Nx )"
 format="@spiceprefix@name @pinlist @model Nx=@Nx El=@El"
 template="name=Q1
 model=npn13G2l
@@ -39,8 +39,8 @@ B 5 -22.5 -2.5 -17.5 2.5 {name=B dir=in sim_pinnumber=2}
 B 5 17.5 27.5 22.5 32.5 {name=E dir=inout sim_pinnumber=3}
 B 5 17.5 -2.5 22.5 2.5 {name=S dir=in sim_pinnumber=4}
 P 4 4 20 30 13.75 13.75 3.75 23.75 20 30 {fill=true}
-T {Nx=@Nx} 32.5 11.25 0 0 0.2 0.2 {layer=13}
+T {Nx=@Nx} 32.5 1.25 0 0 0.2 0.2 {layer=13}
 T {@model} 22.5 -15 0 0 0.2 0.2 {}
 T {S} 10 -5 0 0 0.2 0.2 {}
 T {@name} 22.5 -27.5 0 0 0.2 0.2 {}
-T {El=@El} 32.5 21.25 0 0 0.2 0.2 {layer=13}
+T {El=@El} 32.5 11.25 0 0 0.2 0.2 {layer=13}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2l.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2l.sym
@@ -16,7 +16,7 @@ v {xschem version=3.4.8RC file_version=1.3
 }
 G {}
 K {type=vertical_npn
-lvs_format="tcleval(Q@name @pinlist @model le=[ev \{ @El * 1.0e-6 \} ] we=70.0n m=@Nx )"
+lvs_format="tcleval(Q@name @pinlist @model le=[ev \{ @El * 1.0e-6 \} ] we=70.0n Nx=@Nx )"
 format="@spiceprefix@name @pinlist @model Nx=@Nx El=@El"
 template="name=Q1
 model=npn13G2l
@@ -39,8 +39,8 @@ B 5 -22.5 -2.5 -17.5 2.5 {name=B dir=in sim_pinnumber=2}
 B 5 17.5 27.5 22.5 32.5 {name=E dir=inout sim_pinnumber=3}
 B 5 17.5 -2.5 22.5 2.5 {name=S dir=in sim_pinnumber=4}
 P 4 4 20 30 13.75 13.75 3.75 23.75 20 30 {fill=true}
-T {Nx=@Nx} 32.5 1.25 0 0 0.2 0.2 {layer=13}
+T {Nx=@Nx} 32.5 11.25 0 0 0.2 0.2 {layer=13}
 T {@model} 22.5 -15 0 0 0.2 0.2 {}
 T {S} 10 -5 0 0 0.2 0.2 {}
 T {@name} 22.5 -27.5 0 0 0.2 0.2 {}
-T {El=@El} 32.5 11.25 0 0 0.2 0.2 {layer=13}
+T {El=@El} 32.5 21.25 0 0 0.2 0.2 {layer=13}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2l.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2l.sym
@@ -16,13 +16,12 @@ v {xschem version=3.4.8RC file_version=1.3
 }
 G {}
 K {type=vertical_npn
-lvs_format="tcleval(Q@name @pinlist @model le=[ev \{ @El * 1.0e-6 \} ] we=70.0n m=@m Nx=@Nx )"
+lvs_format="tcleval(Q@name @pinlist @model le=[ev \{ @El * 1.0e-6 \} ] we=70.0n m=@Nx )"
 format="@spiceprefix@name @pinlist @model Nx=@Nx El=@El"
 template="name=Q1
 model=npn13G2l
 spiceprefix=X
 Nx=1
-m=1
 El=1.0
 "
 drc="hbt_drc @name @symname @model @Nx @El"
@@ -40,9 +39,8 @@ B 5 -22.5 -2.5 -17.5 2.5 {name=B dir=in sim_pinnumber=2}
 B 5 17.5 27.5 22.5 32.5 {name=E dir=inout sim_pinnumber=3}
 B 5 17.5 -2.5 22.5 2.5 {name=S dir=in sim_pinnumber=4}
 P 4 4 20 30 13.75 13.75 3.75 23.75 20 30 {fill=true}
-T {Nx=@Nx} 32.5 11.25 0 0 0.2 0.2 {layer=13}
+T {Nx=@Nx} 32.5 1.25 0 0 0.2 0.2 {layer=13}
 T {@model} 22.5 -15 0 0 0.2 0.2 {}
 T {S} 10 -5 0 0 0.2 0.2 {}
 T {@name} 22.5 -27.5 0 0 0.2 0.2 {}
-T {El=@El} 32.5 31.25 0 0 0.2 0.2 {layer=13}
-T {m=@m} 32.5 21.25 0 0 0.2 0.2 {layer=13}
+T {El=@El} 32.5 11.25 0 0 0.2 0.2 {layer=13}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2l_5t.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2l_5t.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.8RC file_version=1.3
+v {xschem version=3.4.5 file_version=1.2
 * Copyright 2023 IHP PDK Authors
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,36 +16,34 @@ v {xschem version=3.4.8RC file_version=1.3
 }
 G {}
 K {type=vertical_npn
-lvs_format="tcleval(Q@name @pinlist @model le=[ev \{ @El * 1.0e-6 \} ] we=70.0n Nx=@Nx )"
+lvs_format="tcleval(Q@name @pinlist @model le=[ev \{ @El * 1.0e-6 \} ] we=70.0n m=@Nx )"
 format="@spiceprefix@name @pinlist @model Nx=@Nx El=@El"
 template="name=Q1
 model=npn13G2l_5t
 spiceprefix=X
-Nx=1
+Nx=1 
 El=2.5
 "
 drc="hbt_drc @name @symname @model @Nx @El"
 }
 V {}
 S {}
-F {}
 E {}
 L 4 0 -30 0 30 {}
 L 4 -20 0 0 0 {}
 L 4 0 10 8.75 18.75 {}
 L 4 0 -10 20 -30 {}
 B 5 17.5 -52.5 22.5 -47.5 {name=C dir=inout sim_pinnumber=1}
-B 5 -42.5 -2.5 -37.5 2.5 {name=B dir=in sim_pinnumber=2}
-B 5 17.5 47.5 22.5 52.5 {name=E dir=inout sim_pinnumber=3}
-B 5 47.5 47.5 52.5 52.5 {name=S dir=in sim_pinnumber=4}
-B 5 67.5 -2.5 72.5 2.5 {name=T dir=in sim_pinnumber=5}
+B 5 -42.5 -2.5 -37.5 2.5  {name=B dir=in sim_pinnumber=2}
+B 5 17.5 47.5 22.5 52.5   {name=E dir=inout sim_pinnumber=3}
+B 5 47.5 47.5 52.5 52.5   {name=S dir=in sim_pinnumber=4}
+B 5 67.5 -2.5 72.5 2.5    {name=T dir=in sim_pinnumber=5}
 P 4 4 20 30 13.75 13.75 3.75 23.75 20 30 {fill=true}
 P 4 5 -40 -50 70 -50 70 50 -40 50 -40 -50 {}
 T {Nx=@Nx} 22.5 11.25 0 0 0.2 0.2 {layer=13}
-T {El=@El} 22.5 30.25 0 0 0.2 0.2 {layer=13}
+T {El=@El} 22.5 20.25 0 0 0.2 0.2 {layer=13}
 T {@model} 22.5 -15 0 0 0.2 0.2 {}
 T {@name} 22.5 -27.5 0 0 0.2 0.2 {}
-T {m=@m} 22.5 21.25 0 0 0.2 0.2 {layer=13}
 N -40 -0 -20 -0 {
 lab=#net1}
 N 20 -50 20 -30 {

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2l_5t.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2l_5t.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
+v {xschem version=3.4.8RC file_version=1.3
 * Copyright 2023 IHP PDK Authors
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,34 +16,36 @@ v {xschem version=3.4.5 file_version=1.2
 }
 G {}
 K {type=vertical_npn
-lvs_format="tcleval(Q@name @pinlist @model le=[ev \{ @El * 1.0e-6 \} ] we=70.0n m=@Nx )"
+lvs_format="tcleval(Q@name @pinlist @model le=[ev \{ @El * 1.0e-6 \} ] we=70.0n Nx=@Nx )"
 format="@spiceprefix@name @pinlist @model Nx=@Nx El=@El"
 template="name=Q1
 model=npn13G2l_5t
 spiceprefix=X
-Nx=1 
+Nx=1
 El=2.5
 "
 drc="hbt_drc @name @symname @model @Nx @El"
 }
 V {}
 S {}
+F {}
 E {}
 L 4 0 -30 0 30 {}
 L 4 -20 0 0 0 {}
 L 4 0 10 8.75 18.75 {}
 L 4 0 -10 20 -30 {}
 B 5 17.5 -52.5 22.5 -47.5 {name=C dir=inout sim_pinnumber=1}
-B 5 -42.5 -2.5 -37.5 2.5  {name=B dir=in sim_pinnumber=2}
-B 5 17.5 47.5 22.5 52.5   {name=E dir=inout sim_pinnumber=3}
-B 5 47.5 47.5 52.5 52.5   {name=S dir=in sim_pinnumber=4}
-B 5 67.5 -2.5 72.5 2.5    {name=T dir=in sim_pinnumber=5}
+B 5 -42.5 -2.5 -37.5 2.5 {name=B dir=in sim_pinnumber=2}
+B 5 17.5 47.5 22.5 52.5 {name=E dir=inout sim_pinnumber=3}
+B 5 47.5 47.5 52.5 52.5 {name=S dir=in sim_pinnumber=4}
+B 5 67.5 -2.5 72.5 2.5 {name=T dir=in sim_pinnumber=5}
 P 4 4 20 30 13.75 13.75 3.75 23.75 20 30 {fill=true}
 P 4 5 -40 -50 70 -50 70 50 -40 50 -40 -50 {}
 T {Nx=@Nx} 22.5 11.25 0 0 0.2 0.2 {layer=13}
-T {El=@El} 22.5 20.25 0 0 0.2 0.2 {layer=13}
+T {El=@El} 22.5 30.25 0 0 0.2 0.2 {layer=13}
 T {@model} 22.5 -15 0 0 0.2 0.2 {}
 T {@name} 22.5 -27.5 0 0 0.2 0.2 {}
+T {m=@m} 22.5 21.25 0 0 0.2 0.2 {layer=13}
 N -40 -0 -20 -0 {
 lab=#net1}
 N 20 -50 20 -30 {

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2l_5t.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2l_5t.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.8RC file_version=1.3
+v {xschem version=3.4.5 file_version=1.2
 * Copyright 2023 IHP PDK Authors
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,37 +16,34 @@ v {xschem version=3.4.8RC file_version=1.3
 }
 G {}
 K {type=vertical_npn
-lvs_format="tcleval(Q@name @pinlist @model le=[ev \{ @El * 1.0e-6 \} ] we=70.0n m=@m Nx=@Nx )"
+lvs_format="tcleval(Q@name @pinlist @model le=[ev \{ @El * 1.0e-6 \} ] we=70.0n m=@Nx )"
 format="@spiceprefix@name @pinlist @model Nx=@Nx El=@El"
 template="name=Q1
 model=npn13G2l_5t
 spiceprefix=X
-Nx=1
-m=1
+Nx=1 
 El=2.5
 "
 drc="hbt_drc @name @symname @model @Nx @El"
 }
 V {}
 S {}
-F {}
 E {}
 L 4 0 -30 0 30 {}
 L 4 -20 0 0 0 {}
 L 4 0 10 8.75 18.75 {}
 L 4 0 -10 20 -30 {}
 B 5 17.5 -52.5 22.5 -47.5 {name=C dir=inout sim_pinnumber=1}
-B 5 -42.5 -2.5 -37.5 2.5 {name=B dir=in sim_pinnumber=2}
-B 5 17.5 47.5 22.5 52.5 {name=E dir=inout sim_pinnumber=3}
-B 5 47.5 47.5 52.5 52.5 {name=S dir=in sim_pinnumber=4}
-B 5 67.5 -2.5 72.5 2.5 {name=T dir=in sim_pinnumber=5}
+B 5 -42.5 -2.5 -37.5 2.5  {name=B dir=in sim_pinnumber=2}
+B 5 17.5 47.5 22.5 52.5   {name=E dir=inout sim_pinnumber=3}
+B 5 47.5 47.5 52.5 52.5   {name=S dir=in sim_pinnumber=4}
+B 5 67.5 -2.5 72.5 2.5    {name=T dir=in sim_pinnumber=5}
 P 4 4 20 30 13.75 13.75 3.75 23.75 20 30 {fill=true}
 P 4 5 -40 -50 70 -50 70 50 -40 50 -40 -50 {}
 T {Nx=@Nx} 22.5 11.25 0 0 0.2 0.2 {layer=13}
-T {El=@El} 22.5 30.25 0 0 0.2 0.2 {layer=13}
+T {El=@El} 22.5 20.25 0 0 0.2 0.2 {layer=13}
 T {@model} 22.5 -15 0 0 0.2 0.2 {}
 T {@name} 22.5 -27.5 0 0 0.2 0.2 {}
-T {m=@m} 22.5 21.25 0 0 0.2 0.2 {layer=13}
 N -40 -0 -20 -0 {
 lab=#net1}
 N 20 -50 20 -30 {

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2l_5t.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2l_5t.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
+v {xschem version=3.4.8RC file_version=1.3
 * Copyright 2023 IHP PDK Authors
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,28 +16,29 @@ v {xschem version=3.4.5 file_version=1.2
 }
 G {}
 K {type=vertical_npn
-lvs_format="tcleval(Q@name @pinlist @model le=[ev \{ @El * 1.0e-6 \} ] we=70.0n m=@Nx )"
+lvs_format="tcleval(Q@name @pinlist @model le=[ev \{ @El * 1.0e-6 \} ] we=70.0n Nx=@Nx )"
 format="@spiceprefix@name @pinlist @model Nx=@Nx El=@El"
 template="name=Q1
 model=npn13G2l_5t
 spiceprefix=X
-Nx=1 
+Nx=1
 El=2.5
 "
 drc="hbt_drc @name @symname @model @Nx @El"
 }
 V {}
 S {}
+F {}
 E {}
 L 4 0 -30 0 30 {}
 L 4 -20 0 0 0 {}
 L 4 0 10 8.75 18.75 {}
 L 4 0 -10 20 -30 {}
 B 5 17.5 -52.5 22.5 -47.5 {name=C dir=inout sim_pinnumber=1}
-B 5 -42.5 -2.5 -37.5 2.5  {name=B dir=in sim_pinnumber=2}
-B 5 17.5 47.5 22.5 52.5   {name=E dir=inout sim_pinnumber=3}
-B 5 47.5 47.5 52.5 52.5   {name=S dir=in sim_pinnumber=4}
-B 5 67.5 -2.5 72.5 2.5    {name=T dir=in sim_pinnumber=5}
+B 5 -42.5 -2.5 -37.5 2.5 {name=B dir=in sim_pinnumber=2}
+B 5 17.5 47.5 22.5 52.5 {name=E dir=inout sim_pinnumber=3}
+B 5 47.5 47.5 52.5 52.5 {name=S dir=in sim_pinnumber=4}
+B 5 67.5 -2.5 72.5 2.5 {name=T dir=in sim_pinnumber=5}
 P 4 4 20 30 13.75 13.75 3.75 23.75 20 30 {fill=true}
 P 4 5 -40 -50 70 -50 70 50 -40 50 -40 -50 {}
 T {Nx=@Nx} 22.5 11.25 0 0 0.2 0.2 {layer=13}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2l_5t.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2l_5t.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
+v {xschem version=3.4.8RC file_version=1.3
 * Copyright 2023 IHP PDK Authors
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,34 +16,37 @@ v {xschem version=3.4.5 file_version=1.2
 }
 G {}
 K {type=vertical_npn
-lvs_format="tcleval(Q@name @pinlist @model le=[ev \{ @El * 1.0e-6 \} ] we=70.0n m=@Nx )"
+lvs_format="tcleval(Q@name @pinlist @model le=[ev \{ @El * 1.0e-6 \} ] we=70.0n m=@m Nx=@Nx )"
 format="@spiceprefix@name @pinlist @model Nx=@Nx El=@El"
 template="name=Q1
 model=npn13G2l_5t
 spiceprefix=X
-Nx=1 
+Nx=1
+m=1
 El=2.5
 "
 drc="hbt_drc @name @symname @model @Nx @El"
 }
 V {}
 S {}
+F {}
 E {}
 L 4 0 -30 0 30 {}
 L 4 -20 0 0 0 {}
 L 4 0 10 8.75 18.75 {}
 L 4 0 -10 20 -30 {}
 B 5 17.5 -52.5 22.5 -47.5 {name=C dir=inout sim_pinnumber=1}
-B 5 -42.5 -2.5 -37.5 2.5  {name=B dir=in sim_pinnumber=2}
-B 5 17.5 47.5 22.5 52.5   {name=E dir=inout sim_pinnumber=3}
-B 5 47.5 47.5 52.5 52.5   {name=S dir=in sim_pinnumber=4}
-B 5 67.5 -2.5 72.5 2.5    {name=T dir=in sim_pinnumber=5}
+B 5 -42.5 -2.5 -37.5 2.5 {name=B dir=in sim_pinnumber=2}
+B 5 17.5 47.5 22.5 52.5 {name=E dir=inout sim_pinnumber=3}
+B 5 47.5 47.5 52.5 52.5 {name=S dir=in sim_pinnumber=4}
+B 5 67.5 -2.5 72.5 2.5 {name=T dir=in sim_pinnumber=5}
 P 4 4 20 30 13.75 13.75 3.75 23.75 20 30 {fill=true}
 P 4 5 -40 -50 70 -50 70 50 -40 50 -40 -50 {}
 T {Nx=@Nx} 22.5 11.25 0 0 0.2 0.2 {layer=13}
-T {El=@El} 22.5 20.25 0 0 0.2 0.2 {layer=13}
+T {El=@El} 22.5 30.25 0 0 0.2 0.2 {layer=13}
 T {@model} 22.5 -15 0 0 0.2 0.2 {}
 T {@name} 22.5 -27.5 0 0 0.2 0.2 {}
+T {m=@m} 22.5 21.25 0 0 0.2 0.2 {layer=13}
 N -40 -0 -20 -0 {
 lab=#net1}
 N 20 -50 20 -30 {

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2v.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2v.sym
@@ -16,7 +16,7 @@ v {xschem version=3.4.8RC file_version=1.3
 }
 G {}
 K {type=vertical_npn
-lvs_format="tcleval(Q@name @pinlist @model le=[ev \{ @El * 1.0e-6 \} ] we=120.0n Nx=@Nx )"
+lvs_format="tcleval(Q@name @pinlist @model le=[ev \{ @El * 1.0e-6 \} ] we=120.0n m=@Nx )"
 format="@spiceprefix@name @pinlist @model Nx=@Nx El=@El"
 template="name=Q1
 model=npn13G2v
@@ -39,8 +39,8 @@ B 5 -22.5 -2.5 -17.5 2.5 {name=B dir=in sim_pinnumber=2}
 B 5 17.5 27.5 22.5 32.5 {name=E dir=inout sim_pinnumber=3}
 B 5 17.5 -2.5 22.5 2.5 {name=S dir=in sim_pinnumber=4}
 P 4 4 20 30 13.75 13.75 3.75 23.75 20 30 {fill=true}
-T {Nx=@Nx} 32.5 11.25 0 0 0.2 0.2 {layer=13}
+T {Nx=@Nx} 22.5 1.25 0 0 0.2 0.2 {layer=13}
 T {@model} 22.5 -15 0 0 0.2 0.2 {}
 T {S} 10 -5 0 0 0.2 0.2 {}
 T {@name} 22.5 -27.5 0 0 0.2 0.2 {}
-T {El=@El} 32.5 21.25 0 0 0.2 0.2 {layer=13}
+T {El=@El} 22.5 11.25 0 0 0.2 0.2 {layer=13}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2v.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2v.sym
@@ -16,12 +16,13 @@ v {xschem version=3.4.8RC file_version=1.3
 }
 G {}
 K {type=vertical_npn
-lvs_format="tcleval(Q@name @pinlist @model le=[ev \{ @El * 1.0e-6 \} ] we=120.0n m=@Nx )"
+lvs_format="tcleval(Q@name @pinlist @model le=[ev \{ @El * 1.0e-6 \} ] we=120.0n m=@m Nx=@Nx )"
 format="@spiceprefix@name @pinlist @model Nx=@Nx El=@El"
 template="name=Q1
 model=npn13G2v
 spiceprefix=X
 Nx=1
+m=1
 El=1.0
 "
 drc="hbt_drc @name @symname @model @Nx @El"
@@ -39,8 +40,9 @@ B 5 -22.5 -2.5 -17.5 2.5 {name=B dir=in sim_pinnumber=2}
 B 5 17.5 27.5 22.5 32.5 {name=E dir=inout sim_pinnumber=3}
 B 5 17.5 -2.5 22.5 2.5 {name=S dir=in sim_pinnumber=4}
 P 4 4 20 30 13.75 13.75 3.75 23.75 20 30 {fill=true}
-T {Nx=@Nx} 22.5 1.25 0 0 0.2 0.2 {layer=13}
+T {Nx=@Nx} 32.5 11.25 0 0 0.2 0.2 {layer=13}
 T {@model} 22.5 -15 0 0 0.2 0.2 {}
 T {S} 10 -5 0 0 0.2 0.2 {}
 T {@name} 22.5 -27.5 0 0 0.2 0.2 {}
-T {El=@El} 22.5 11.25 0 0 0.2 0.2 {layer=13}
+T {El=@El} 32.5 31.25 0 0 0.2 0.2 {layer=13}
+T {m=@m} 32.5 21.25 0 0 0.2 0.2 {layer=13}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2v.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2v.sym
@@ -16,7 +16,7 @@ v {xschem version=3.4.8RC file_version=1.3
 }
 G {}
 K {type=vertical_npn
-lvs_format="tcleval(Q@name @pinlist @model le=[ev \{ @El * 1.0e-6 \} ] we=120.0n m=@Nx )"
+lvs_format="tcleval(Q@name @pinlist @model le=[ev \{ @El * 1.0e-6 \} ] we=120.0n Nx=@Nx )"
 format="@spiceprefix@name @pinlist @model Nx=@Nx El=@El"
 template="name=Q1
 model=npn13G2v
@@ -39,8 +39,8 @@ B 5 -22.5 -2.5 -17.5 2.5 {name=B dir=in sim_pinnumber=2}
 B 5 17.5 27.5 22.5 32.5 {name=E dir=inout sim_pinnumber=3}
 B 5 17.5 -2.5 22.5 2.5 {name=S dir=in sim_pinnumber=4}
 P 4 4 20 30 13.75 13.75 3.75 23.75 20 30 {fill=true}
-T {Nx=@Nx} 22.5 1.25 0 0 0.2 0.2 {layer=13}
+T {Nx=@Nx} 32.5 11.25 0 0 0.2 0.2 {layer=13}
 T {@model} 22.5 -15 0 0 0.2 0.2 {}
 T {S} 10 -5 0 0 0.2 0.2 {}
 T {@name} 22.5 -27.5 0 0 0.2 0.2 {}
-T {El=@El} 22.5 11.25 0 0 0.2 0.2 {layer=13}
+T {El=@El} 32.5 21.25 0 0 0.2 0.2 {layer=13}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2v.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2v.sym
@@ -16,13 +16,12 @@ v {xschem version=3.4.8RC file_version=1.3
 }
 G {}
 K {type=vertical_npn
-lvs_format="tcleval(Q@name @pinlist @model le=[ev \{ @El * 1.0e-6 \} ] we=120.0n m=@m Nx=@Nx )"
+lvs_format="tcleval(Q@name @pinlist @model le=[ev \{ @El * 1.0e-6 \} ] we=120.0n m=@Nx )"
 format="@spiceprefix@name @pinlist @model Nx=@Nx El=@El"
 template="name=Q1
 model=npn13G2v
 spiceprefix=X
 Nx=1
-m=1
 El=1.0
 "
 drc="hbt_drc @name @symname @model @Nx @El"
@@ -40,9 +39,8 @@ B 5 -22.5 -2.5 -17.5 2.5 {name=B dir=in sim_pinnumber=2}
 B 5 17.5 27.5 22.5 32.5 {name=E dir=inout sim_pinnumber=3}
 B 5 17.5 -2.5 22.5 2.5 {name=S dir=in sim_pinnumber=4}
 P 4 4 20 30 13.75 13.75 3.75 23.75 20 30 {fill=true}
-T {Nx=@Nx} 32.5 11.25 0 0 0.2 0.2 {layer=13}
+T {Nx=@Nx} 22.5 1.25 0 0 0.2 0.2 {layer=13}
 T {@model} 22.5 -15 0 0 0.2 0.2 {}
 T {S} 10 -5 0 0 0.2 0.2 {}
 T {@name} 22.5 -27.5 0 0 0.2 0.2 {}
-T {El=@El} 32.5 31.25 0 0 0.2 0.2 {layer=13}
-T {m=@m} 32.5 21.25 0 0 0.2 0.2 {layer=13}
+T {El=@El} 22.5 11.25 0 0 0.2 0.2 {layer=13}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2v_5t.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2v_5t.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.8RC file_version=1.3
+v {xschem version=3.4.5 file_version=1.2
 * Copyright 2023 IHP PDK Authors
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,19 +16,17 @@ v {xschem version=3.4.8RC file_version=1.3
 }
 G {}
 K {type=vertical_npn
-lvs_format="tcleval(Q@name @pinlist @model le=[ev \{ @El * 1.0e-6 \} ] we=120.0n m=@m Nx=@Nx )"
+lvs_format="tcleval(Q@name @pinlist @model le=[ev \{ @El * 1.0e-6 \} ] we=120.0n m=@Nx )"
 format="@spiceprefix@name @pinlist @model Nx=@Nx El=@El"
 template="name=Q1
 model=npn13G2v_5t
 spiceprefix=X
 Nx=1
-m=1
 El=1.0
 drc="hbt_drc @name @symname @model @Nx @El"
 }
 V {}
 S {}
-F {}
 E {}
 L 4 0 -30 0 30 {}
 L 4 -20 0 0 0 {}
@@ -42,10 +40,9 @@ B 5 67.5 -2.5 72.5 2.5 {name=T dir=in sim_pinnumber=5}
 P 4 4 20 30 13.75 13.75 3.75 23.75 20 30 {fill=true}
 P 4 5 -40 -50 70 -50 70 50 -40 50 -40 -50 {}
 T {Nx=@Nx} 22.5 11.25 0 0 0.2 0.2 {layer=13}
-T {El=@El} 22.5 30.25 0 0 0.2 0.2 {layer=13}
+T {El=@El} 22.5 20.25 0 0 0.2 0.2 {layer=13}
 T {@model} 22.5 -15 0 0 0.2 0.2 {}
 T {@name} 22.5 -27.5 0 0 0.2 0.2 {}
-T {m=@m} 22.5 21.25 0 0 0.2 0.2 {layer=13}
 N -40 -0 -20 -0 {
 lab=#net1}
 N 20 -50 20 -30 {

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2v_5t.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2v_5t.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
+v {xschem version=3.4.8RC file_version=1.3
 * Copyright 2023 IHP PDK Authors
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +16,7 @@ v {xschem version=3.4.5 file_version=1.2
 }
 G {}
 K {type=vertical_npn
-lvs_format="tcleval(Q@name @pinlist @model le=[ev \{ @El * 1.0e-6 \} ] we=120.0n m=@Nx )"
+lvs_format="tcleval(Q@name @pinlist @model le=[ev \{ @El * 1.0e-6 \} ] we=120.0n Nx=@Nx )"
 format="@spiceprefix@name @pinlist @model Nx=@Nx El=@El"
 template="name=Q1
 model=npn13G2v_5t
@@ -27,6 +27,7 @@ drc="hbt_drc @name @symname @model @Nx @El"
 }
 V {}
 S {}
+F {}
 E {}
 L 4 0 -30 0 30 {}
 L 4 -20 0 0 0 {}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2v_5t.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2v_5t.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
+v {xschem version=3.4.8RC file_version=1.3
 * Copyright 2023 IHP PDK Authors
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +16,7 @@ v {xschem version=3.4.5 file_version=1.2
 }
 G {}
 K {type=vertical_npn
-lvs_format="tcleval(Q@name @pinlist @model le=[ev \{ @El * 1.0e-6 \} ] we=120.0n m=@Nx )"
+lvs_format="tcleval(Q@name @pinlist @model le=[ev \{ @El * 1.0e-6 \} ] we=120.0n Nx=@Nx )"
 format="@spiceprefix@name @pinlist @model Nx=@Nx El=@El"
 template="name=Q1
 model=npn13G2v_5t
@@ -27,6 +27,7 @@ drc="hbt_drc @name @symname @model @Nx @El"
 }
 V {}
 S {}
+F {}
 E {}
 L 4 0 -30 0 30 {}
 L 4 -20 0 0 0 {}
@@ -40,9 +41,10 @@ B 5 67.5 -2.5 72.5 2.5 {name=T dir=in sim_pinnumber=5}
 P 4 4 20 30 13.75 13.75 3.75 23.75 20 30 {fill=true}
 P 4 5 -40 -50 70 -50 70 50 -40 50 -40 -50 {}
 T {Nx=@Nx} 22.5 11.25 0 0 0.2 0.2 {layer=13}
-T {El=@El} 22.5 20.25 0 0 0.2 0.2 {layer=13}
+T {El=@El} 22.5 30.25 0 0 0.2 0.2 {layer=13}
 T {@model} 22.5 -15 0 0 0.2 0.2 {}
 T {@name} 22.5 -27.5 0 0 0.2 0.2 {}
+T {m=@m} 22.5 21.25 0 0 0.2 0.2 {layer=13}
 N -40 -0 -20 -0 {
 lab=#net1}
 N 20 -50 20 -30 {

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2v_5t.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2v_5t.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
+v {xschem version=3.4.8RC file_version=1.3
 * Copyright 2023 IHP PDK Authors
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,17 +16,19 @@ v {xschem version=3.4.5 file_version=1.2
 }
 G {}
 K {type=vertical_npn
-lvs_format="tcleval(Q@name @pinlist @model le=[ev \{ @El * 1.0e-6 \} ] we=120.0n m=@Nx )"
+lvs_format="tcleval(Q@name @pinlist @model le=[ev \{ @El * 1.0e-6 \} ] we=120.0n m=@m Nx=@Nx )"
 format="@spiceprefix@name @pinlist @model Nx=@Nx El=@El"
 template="name=Q1
 model=npn13G2v_5t
 spiceprefix=X
 Nx=1
+m=1
 El=1.0
 drc="hbt_drc @name @symname @model @Nx @El"
 }
 V {}
 S {}
+F {}
 E {}
 L 4 0 -30 0 30 {}
 L 4 -20 0 0 0 {}
@@ -40,9 +42,10 @@ B 5 67.5 -2.5 72.5 2.5 {name=T dir=in sim_pinnumber=5}
 P 4 4 20 30 13.75 13.75 3.75 23.75 20 30 {fill=true}
 P 4 5 -40 -50 70 -50 70 50 -40 50 -40 -50 {}
 T {Nx=@Nx} 22.5 11.25 0 0 0.2 0.2 {layer=13}
-T {El=@El} 22.5 20.25 0 0 0.2 0.2 {layer=13}
+T {El=@El} 22.5 30.25 0 0 0.2 0.2 {layer=13}
 T {@model} 22.5 -15 0 0 0.2 0.2 {}
 T {@name} 22.5 -27.5 0 0 0.2 0.2 {}
+T {m=@m} 22.5 21.25 0 0 0.2 0.2 {layer=13}
 N -40 -0 -20 -0 {
 lab=#net1}
 N 20 -50 20 -30 {

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2v_5t.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2v_5t.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.8RC file_version=1.3
+v {xschem version=3.4.5 file_version=1.2
 * Copyright 2023 IHP PDK Authors
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +16,7 @@ v {xschem version=3.4.8RC file_version=1.3
 }
 G {}
 K {type=vertical_npn
-lvs_format="tcleval(Q@name @pinlist @model le=[ev \{ @El * 1.0e-6 \} ] we=120.0n Nx=@Nx )"
+lvs_format="tcleval(Q@name @pinlist @model le=[ev \{ @El * 1.0e-6 \} ] we=120.0n m=@Nx )"
 format="@spiceprefix@name @pinlist @model Nx=@Nx El=@El"
 template="name=Q1
 model=npn13G2v_5t
@@ -27,7 +27,6 @@ drc="hbt_drc @name @symname @model @Nx @El"
 }
 V {}
 S {}
-F {}
 E {}
 L 4 0 -30 0 30 {}
 L 4 -20 0 0 0 {}
@@ -41,10 +40,9 @@ B 5 67.5 -2.5 72.5 2.5 {name=T dir=in sim_pinnumber=5}
 P 4 4 20 30 13.75 13.75 3.75 23.75 20 30 {fill=true}
 P 4 5 -40 -50 70 -50 70 50 -40 50 -40 -50 {}
 T {Nx=@Nx} 22.5 11.25 0 0 0.2 0.2 {layer=13}
-T {El=@El} 22.5 30.25 0 0 0.2 0.2 {layer=13}
+T {El=@El} 22.5 20.25 0 0 0.2 0.2 {layer=13}
 T {@model} 22.5 -15 0 0 0.2 0.2 {}
 T {@name} 22.5 -27.5 0 0 0.2 0.2 {}
-T {m=@m} 22.5 21.25 0 0 0.2 0.2 {layer=13}
 N -40 -0 -20 -0 {
 lab=#net1}
 N 20 -50 20 -30 {


### PR DESCRIPTION
Fixes [Issues#896](https://github.com/IHP-GmbH/IHP-Open-PDK/issues/896)

### Summary

- It has been observed that KLayout LVS fails to match npn13G2 devices when the parameter Nx >1.
- Current CDL format for Xschem npn13G2 devices with Nx=2 is 
`QQ1 nc nb ne sub! npn13G2 le=900e-9 we=70.0n m=2`
which is not aligned with [KLayout LVS schematic syntax reference](https://github.com/mabrains/IHP-Open-PDK/tree/feature/lvs_updates-1/ihp-sg13g2/libs.tech/klayout/tech/lvs/testing#lvs-schematic-syntax-reference) format
`QQ1 nc nb ne sub! npn13G2 le=900e-9 we=70.0n m=1 Nx=2`
- Modify the `lvs_format` so that the SPICE netlist matches the extracted circuit.

### Changes

- lvs_format formula defined in sg13g2_pr/npn13G2*.sym files
`lvs_format="Q@name @pinlist @model le=900e-9 we=70.0n m=@Nx"`
　　→　`lvs_format="Q@name @pinlist @model le=900e-9 we=70.0n Nx=@Nx"`


- Refer to [Netlist Format Sheet Netlist-Format(PR#902)](https://docs.google.com/spreadsheets/d/1GEoOd517_JA-xxpHtrVB9OOGxybPtv_bV-c-KIgPGYg/edit?usp=drive_link) for details


### Verification

- Schematic & Layout for Testcase
<img width="1361" height="781" alt="image" src="https://github.com/user-attachments/assets/fccef570-1dc3-43aa-bf7f-0b37a8fafbd3" />


<img width="1498" height="843" alt="image" src="https://github.com/user-attachments/assets/c01ae2ab-33c6-4e58-800c-c03eb5377915" />

<img width="598" height="216" alt="image" src="https://github.com/user-attachments/assets/09c540b0-20f9-483c-83ea-22e7ae1178f2" />

- Testcase Result

<img width="1106" height="438" alt="image" src="https://github.com/user-attachments/assets/b754ac85-121b-425a-b733-7584f46cd6cf" />


- [x] Tests pass
- [-] Appropriate changes to README are included in PR
