### PR TITLE
Fixed a typo in the fill generation deck for magic

### DIFF
--- a/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-GDS.tech
+++ b/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-GDS.tech
@@ -881,7 +881,7 @@ style patternfill variants (),(tiled)
 	grow	580
 	or	ALLDIFF,DIFFFILL,DIFFBLOCK,difffill_coarse
 
- templayer      obstruct_poly_medium ALLDIFF,DIFFILL,PSD
+ templayer      obstruct_poly_medium ALLDIFF,DIFFFILL,PSD
 	or	difffill_coarse
 	grow	100
 	or	BIPOLARID


### PR DESCRIPTION
One misspelling of "DIFFILL" instead of "DIFFFILL", corrected.

Fixes #<issue_number_goes_here>

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR
