### PR TITLE
Xschem Symbol ev() precision

### DIFF
--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/ntap1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/ntap1.sym
@@ -16,9 +16,9 @@ v {xschem version=3.4.8RC file_version=1.3
 }
 G {}
 K {type=res
-lvs_format="tcleval(R@name @pinlist @model A=[ev \{ @w * @l \} ] P=[ev \{ 2 * ( @w + @l ) \} ] )"
+lvs_format="tcleval(R@name @pinlist @model A=[ev7 \{ @w * @l \} ] P=[ev7 \{ 2 * ( @w + @l ) \} ] )"
 *lvs_format="@name @pinlist @model w=@w l=@l"
-format="tcleval(@spiceprefix@name @pinlist @model R=[ev \{  1.0 / ( 1.0 / ( 9.8e-10 / ( @w * @l ) ) + 1.0 / ( 9.8e-4 / ( 2.0 * ( @w + @l ) ) ) )\}] w=@w l=@l )"
+format="tcleval(@spiceprefix@name @pinlist @model R=[ev7 \{  1.0 / ( 1.0 / ( 9.8e-10 / ( @w * @l ) ) + 1.0 / ( 9.8e-4 / ( 2.0 * ( @w + @l ) ) ) )\}] w=@w l=@l )"
 template="name=R1
 model=ntap1
 spiceprefix=X
@@ -47,6 +47,6 @@ B 5 -2.5 27.5 2.5 32.5 {name=M dir=inout propag=0}
 T {@model} 15 -16.25 0 0 0.2 0.2 {}
 T {w=@w} 15 -3.75 0 0 0.2 0.2 {layer=13}
 T {@name} 15 -28.75 0 0 0.2 0.2 {}
-T {tcleval( R=[ ev \{ 1.0 / ( 1.0 / ( 9.8e-10 / ( @w * @l ) ) + 1.0 / ( 9.8e-4 / ( 2.0 * ( @w + @l ) ) ) ) \} ] )} 20 20 0 0 0.2 0.2 {layer=13}
+T {tcleval( R=[ ev7 \{ 1.0 / ( 1.0 / ( 9.8e-10 / ( @w * @l ) ) + 1.0 / ( 9.8e-4 / ( 2.0 * ( @w + @l ) ) ) ) \} ] )} 20 20 0 0 0.2 0.2 {layer=13}
 T {} 15 20 0 0 0.2 0.2 {}
 T {l=@l} 15 6.25 0 0 0.2 0.2 {layer=13}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/pnpMPA.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/pnpMPA.sym
@@ -16,8 +16,8 @@ v {xschem version=3.4.8RC file_version=1.3
 }
 G {}
 K {type=pnp
-format="tcleval(@spiceprefix@name @pinlist @model a=[ev \{ @w * @l \}] p=[ev \{ ( @w + @l ) * 2 \}] m=[ev \{ @m \}] )"
-lvs_format="tcleval(Q@name @pinlist @model a=[ev \{ @w * @l \}] p=[ev \{ ( @w + @l ) * 2 \}] m=[ev \{ @m \}] )"
+format="tcleval(@spiceprefix@name @pinlist @model a=[ev7 \{ @w * @l \}] p=[ev7 \{ ( @w + @l ) * 2 \}] m=[ev \{ @m \}] )"
+lvs_format="tcleval(Q@name @pinlist @model a=[ev7 \{ @w * @l \}] p=[ev7 \{ ( @w + @l ) * 2 \}] m=[ev \{ @m \}] )"
 template="name=Q1
 model=pnpMPA
 spiceprefix=X

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/ptap1.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/ptap1.sym
@@ -16,9 +16,9 @@ v {xschem version=3.4.8RC file_version=1.3
 }
 G {}
 K {type=res
-lvs_format="tcleval(R@name @pinlist @model A=[ev \{ @w * @l \} ] P=[ev \{ 2 * ( @w + @l ) \} ] )"
+lvs_format="tcleval(R@name @pinlist @model A=[ev7 \{ @w * @l \} ] P=[ev7 \{ 2 * ( @w + @l ) \} ] )"
 *lvs_format="@name @pinlist @model w=@w l=@l"
-format="tcleval(@spiceprefix@name @pinlist @model R=[ev \{  1.0 / ( 1.0 / ( 9.8e-10 / ( @w * @l ) ) + 1.0 / ( 9.8e-4 / ( 2.0 * ( @w + @l ) ) ) )\}] w=@w l=@l )"
+format="tcleval(@spiceprefix@name @pinlist @model R=[ev7 \{  1.0 / ( 1.0 / ( 9.8e-10 / ( @w * @l ) ) + 1.0 / ( 9.8e-4 / ( 2.0 * ( @w + @l ) ) ) )\}] w=@w l=@l )"
 template="name=R1
 model=ptap1
 spiceprefix=X
@@ -47,6 +47,6 @@ B 5 -2.5 27.5 2.5 32.5 {name=M dir=inout propag=0 }
 T {@model} 15 -16.25 0 0 0.2 0.2 {}
 T {w=@w} 15 -3.75 0 0 0.2 0.2 {layer=13}
 T {@name} 15 -28.75 0 0 0.2 0.2 {}
-T {tcleval( R=[ ev \{ 1.0 / ( 1.0 / ( 9.8e-10 / ( @w * @l ) ) + 1.0 / ( 9.8e-4 / ( 2.0 * ( @w + @l ) ) ) ) \} ] )} 20 20 0 0 0.2 0.2 {layer=13}
+T {tcleval( R=[ ev7 \{ 1.0 / ( 1.0 / ( 9.8e-10 / ( @w * @l ) ) + 1.0 / ( 9.8e-4 / ( 2.0 * ( @w + @l ) ) ) ) \} ] )} 20 20 0 0 0.2 0.2 {layer=13}
 T {} 15 20 0 0 0.2 0.2 {}
 T {l=@l} 15 6.25 0 0 0.2 0.2 {layer=13}


### PR DESCRIPTION
Fixes #903 

Inspection: The following xschem symbol uses ev() function.
```
- ntap1  : corrected
- ptap1   : corrected
- pnpMPA.sym   : corrected

- cap_cmim   : only in symbol does not affect LVS
- cap_rfcmim  : only in symbol  does not affect LVS
- npn13G2v  : does not cause LVS fail
- npn13G2l   : does not cause LVS fail
- schottky_nbl1  : does not cause LVS fail
```

Before: 
<div>
<img width="473" height="215" alt="Screenshot 2026-03-25 141302" src="https://github.com/user-attachments/assets/2b4c275f-acf5-47e9-9756-411e3c261182" />
<img width="473" height="210" alt="Screenshot 2026-03-25 141503" src="https://github.com/user-attachments/assets/b57af34f-fe20-4718-b60f-08244a89bd42" />
</div>


After:
<img width="473" height="195" alt="Screenshot 2026-03-25 140139" src="https://github.com/user-attachments/assets/074b06fe-bb52-4134-8eea-817f872694da" />
<img width="473" height="195" alt="Screenshot 2026-03-25 141035" src="https://github.com/user-attachments/assets/32f6a064-ff31-437d-803b-304358cc2c77" />

- [x] Tests pass

