### PR TITLE
Fix magic fill generation (2nd pass)

### DIFF
--- a/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-GDS.tech
+++ b/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-GDS.tech
@@ -827,12 +827,23 @@ style patternfill variants (),(tiled)
 	and-not	well_shrink
 
 #------------------------------------------------------------------------
+# A similar guard band is needed around PWELLBLK, at 1.5um distance
+# Rule AFil.i
+#------------------------------------------------------------------------
+
+ templayer	pwblk_shrink PWELLBLK
+	shrink  1500
+
+ templayer	pwblk_guardband PWELLBLK
+	grow	1500
+	and-not	pwblk_shrink
+
+#------------------------------------------------------------------------
 # Diffusion filler keep-out areas
 # Spacing to diffusion:  0.42um (AFil.c1)
 # Spacing to poly and contact: 1.10um (AFil.c)
 # Space to NPN bipolar: 1um (AFil.e)
 #
-# To do:  Ensure spacing to pwell-block (Afil.i)
 # Note: Fill patterns inside pwell-block are not automatically
 # generated but can be manually drawn.
 #------------------------------------------------------------------------
@@ -844,14 +855,16 @@ style patternfill variants (),(tiled)
 	or	ALLDIFF,DIFFFILL,DIFFBLOCK
 
  templayer      obstruct_poly ALLDIFF,DIFFFILL
-	grow	100
-	or	BIPOLARID
-	grow	580
-	or	ALLPOLY,POLYFILL,POLYBLOCK
+	or	ALLPOLY,POLYBLOCK
+	or	BIPOLARID,SBLK,NSDBLOCK,PSD
+	grow	300
+	or	POLYFILL
+	grow	380
 
- templayer	obstruct_diffpoly obstruct_diff,obstruct_poly
+ templayer	obstruct_diffpoly obstruct_poly,obstruct_diff
 	grow	420
 	or	well_guardband
+	or	pwblk_guardband
 
 #---------------------------------------------------
 # DIFF and POLY fill
@@ -881,16 +894,18 @@ style patternfill variants (),(tiled)
 	grow	580
 	or	ALLDIFF,DIFFFILL,DIFFBLOCK,difffill_coarse
 
- templayer      obstruct_poly_medium ALLDIFF,DIFFILL,PSD
+ templayer      obstruct_poly_medium ALLDIFF,DIFFILL
 	or	difffill_coarse
-	grow	100
-	or	BIPOLARID
-	grow	580
-	or	ALLPOLY,POLYFILL,POLYBLOCK,polyfill_coarse
+	or	ALLPOLY,POLYBLOCK
+	or	BIPOLARID,SBLK,NSDBLOCK,PSD
+	grow	300
+	or	POLYFILL,polyfill_coarse
+	grow	380
 
  templayer      obstruct_diffpoly_medium obstruct_diff_medium,obstruct_poly_medium
 	grow	420
 	or	well_guardband
+	or	pwblk_guardband
 
  templayer	diffpolyfill_medium topbox
         slots   0 2400 1200 0 2400 1200 750 0
@@ -913,17 +928,18 @@ style patternfill variants (),(tiled)
 	or	ALLDIFF,DIFFFILL,DIFFBLOCK
 	or	difffill_coarse,difffill_medium
 
- templayer      obstruct_poly_fine ALLDIFF,DIFFFILL,PSD
+ templayer      obstruct_poly_fine ALLDIFF,DIFFFILL
 	or	difffill_coarse,difffill_medium
-	grow	100
-	or	BIPOLARID
-	grow	580
-	or	ALLPOLY,POLYFILL,POLYBLOCK
-	or	polyfill_coarse,polyfill_medium
+	or	ALLPOLY,POLYBLOCK
+	or	BIPOLARID,SBLK,NSDBLOCK,PSD
+	grow	300
+	or	POLYFILL,polyfill_coarse,polyfill_medium
+	grow	380
 
  templayer      obstruct_diffpoly_fine obstruct_diff_fine,obstruct_poly_fine
 	grow	420
 	or	well_guardband
+	or	pwblk_guardband
 
  templayer	diffpolyfill_fine topbox
         slots   0 1400 1200 0 1100 1200 360 0

--- a/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-GDS.tech
+++ b/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-GDS.tech
@@ -894,7 +894,7 @@ style patternfill variants (),(tiled)
 	grow	580
 	or	ALLDIFF,DIFFFILL,DIFFBLOCK,difffill_coarse
 
- templayer      obstruct_poly_medium ALLDIFF,DIFFILL
+ templayer      obstruct_poly_medium ALLDIFF,DIFFFILL
 	or	difffill_coarse
 	or	ALLPOLY,POLYBLOCK
 	or	BIPOLARID,SBLK,NSDBLOCK,PSD


### PR DESCRIPTION
This PR fixes a few remaining issues in the fill generation deck for magic (see issue #880).
Mainly, the distance rules for poly fill had been set to be the same as the distance rules for diffusion fill, when there are several key differences.  Those differences have been incorporated into this pull request, along with the implementation of a keep-out guard band around pwell-block layer edges, which had previously been flagged as "to do". 

Fixes #<issue_number_goes_here>

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR
