### PR TITLE
Fix nofill layers missing spacing margin in metal fill scripts

### DIFF
--- a/ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_filler_ActGatP.lym
+++ b/ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_filler_ActGatP.lym
@@ -182,7 +182,9 @@
   PWell_block_cpy_in.size(-sep, -sep, "square_limit")
   AFil_i = PWell_block_cpy_out - PWell_block_cpy_in
 
-  exclLayAct = AFil_c | AFil_c1 | AFil_e | AFil_d | AFil_i | Activ_nofill
+  AFil_nf = Activ_nofill.dup
+  AFil_nf.size(0.42, 0.42, "square_limit")
+  exclLayAct = AFil_c | AFil_c1 | AFil_e | AFil_d | AFil_i | AFil_nf
 
   ##########################################################################
   # CREATE GatPoly FILLER
@@ -221,7 +223,9 @@
   NWell_gp_cpy2.size(-sep, -sep, "square_limit")
   GFil_e = NWell_gp_cpy - NWell_gp_cpy2
 
-  exclLayGatP = GFil_c | GFil_d | GFil_f | GFil_e | GatPoly_nofill
+  GFil_nf = GatPoly_nofill.dup
+  GFil_nf.size(1.1, 1.1, "square_limit")
+  exclLayGatP = GFil_c | GFil_d | GFil_f | GFil_e | GFil_nf
 
   ActoutGatP = exclLayGatP - exclLayAct
   GatPoutAct = exclLayAct - exclLayGatP

--- a/ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_filler_Metal.lym
+++ b/ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_filler_Metal.lym
@@ -266,7 +266,9 @@
 	M1Fil_c.size(0.42, 0.42, "square_limit")
 	M1Fil_d = TRANS.dup
 	M1Fil_d.size(1.0, 1.0, "square_limit")
-	M1Fil = EdgeSeal.holes - (M1Fil_b | M1Fil_c | M1Fil_d | Metal1_nofill | Metal1_slit | TRANS | NoMetFiller)
+	M1Fil_nf = Metal1_nofill.dup
+	M1Fil_nf.size(0.42, 0.42, "square_limit")
+	M1Fil = EdgeSeal.holes - (M1Fil_b | M1Fil_c | M1Fil_d | M1Fil_nf | Metal1_slit | TRANS | NoMetFiller)
 	M1Fil_left = M1Fil.fill_with_left(pattern_m1_m, hstep(width_m1_m + distance_m1_m), vstep(height_m1_m + distance_m1_m))
 	M1Fil_left.fill(pattern_m1_s, hstep(width_m1_s + distance_m1_s), vstep(height_m1_s + distance_m1_s))
 
@@ -277,7 +279,9 @@
 	M2Fil_c.size(0.42, 0.42, "square_limit")
 	M2Fil_d = TRANS.dup
 	M2Fil_d.size(1.0, 1.0, "square_limit")
-	M2Fil = EdgeSeal.holes - (M2Fil_b | M2Fil_c | M2Fil_d | Metal2_nofill | Metal2_slit | TRANS | NoMetFiller)
+	M2Fil_nf = Metal2_nofill.dup
+	M2Fil_nf.size(0.42, 0.42, "square_limit")
+	M2Fil = EdgeSeal.holes - (M2Fil_b | M2Fil_c | M2Fil_d | M2Fil_nf | Metal2_slit | TRANS | NoMetFiller)
 	M2Fil_left = M2Fil.fill_with_left(pattern_m2_m, hstep(width_m2_m + distance_m2_m), vstep(height_m2_m + distance_m2_m))
 	M2Fil_left.fill(pattern_m2_s, hstep(width_m2_s + distance_m2_s), vstep(height_m2_s + distance_m2_s))
 
@@ -288,7 +292,9 @@
 	M3Fil_c.size(0.42, 0.42, "square_limit")
 	M3Fil_d = TRANS.dup
 	M3Fil_d.size(1.0, 1.0, "square_limit")
-	M3Fil = EdgeSeal.holes - (M3Fil_b | M3Fil_c | M3Fil_d | Metal3_nofill | Metal3_slit | TRANS | NoMetFiller)
+	M3Fil_nf = Metal3_nofill.dup
+	M3Fil_nf.size(0.42, 0.42, "square_limit")
+	M3Fil = EdgeSeal.holes - (M3Fil_b | M3Fil_c | M3Fil_d | M3Fil_nf | Metal3_slit | TRANS | NoMetFiller)
 	M3Fil_left = M3Fil.fill_with_left(pattern_m3_m, hstep(width_m3_m + distance_m3_m), vstep(height_m3_m + distance_m3_m))
 	M3Fil_left.fill(pattern_m3_s, hstep(width_m3_s + distance_m3_s), vstep(height_m3_s + distance_m3_s))
 
@@ -299,7 +305,9 @@
 	M4Fil_c.size(0.42, 0.42, "square_limit")
 	M4Fil_d = TRANS.dup
 	M4Fil_d.size(1.0, 1.0, "square_limit")
-	M4Fil = EdgeSeal.holes - (M4Fil_b | M4Fil_c | M4Fil_d | Metal4_nofill | Metal4_slit | TRANS | NoMetFiller)
+	M4Fil_nf = Metal4_nofill.dup
+	M4Fil_nf.size(0.42, 0.42, "square_limit")
+	M4Fil = EdgeSeal.holes - (M4Fil_b | M4Fil_c | M4Fil_d | M4Fil_nf | Metal4_slit | TRANS | NoMetFiller)
 	M4Fil_left = M4Fil.fill_with_left(pattern_m4_m, hstep(width_m4_m + distance_m4_m), vstep(height_m4_m + distance_m4_m))
 	M4Fil_left.fill(pattern_m4_s, hstep(width_m4_s + distance_m4_s), vstep(height_m4_s + distance_m4_s))
 
@@ -310,7 +318,9 @@
 	M5Fil_c.size(0.42, 0.42, "square_limit")
 	M5Fil_d = TRANS.dup
 	M5Fil_d.size(1.0, 1.0, "square_limit")
-	M5Fil = EdgeSeal.holes - (M5Fil_b | M5Fil_c | M5Fil_d | Metal5_nofill | Metal5_slit | TRANS | NoMetFiller)
+	M5Fil_nf = Metal5_nofill.dup
+	M5Fil_nf.size(0.42, 0.42, "square_limit")
+	M5Fil = EdgeSeal.holes - (M5Fil_b | M5Fil_c | M5Fil_d | M5Fil_nf | Metal5_slit | TRANS | NoMetFiller)
 	M5Fil_left = M5Fil.fill_with_left(pattern_m5_m, hstep(width_m5_m + distance_m5_m), vstep(height_m5_m + distance_m5_m))
 	M5Fil_left.fill(pattern_m5_s, hstep(width_m5_s + distance_m5_s), vstep(height_m5_s + distance_m5_s))
 	</text>

--- a/ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_filler_TopMetal.lym
+++ b/ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_filler_TopMetal.lym
@@ -125,13 +125,17 @@
 	TM1Fil_c.size(3.0, 3.0, "square_limit")
 	TM1Fil_d = TRANS.dup
 	TM1Fil_d.size(4.9, 4.9, "square_limit")
-	exclLayTM1 = TM1Fil_c | TM1Fil_d | TopMetal1_filler | TopMetal1_nofill | TopMetal1_slit | TRANS | NoMetFiller
+	TM1Fil_nf = TopMetal1_nofill.dup
+	TM1Fil_nf.size(3.0, 3.0, "square_limit")
+	exclLayTM1 = TM1Fil_c | TM1Fil_d | TopMetal1_filler | TM1Fil_nf | TopMetal1_slit | TRANS | NoMetFiller
 
 	TM2Fil_c = TopMetal2.dup
 	TM2Fil_c.size(3.0, 3.0, "square_limit")
 	TM2Fil_d = TRANS.dup
 	TM2Fil_d.size(4.9, 4.9, "square_limit")
-	exclLayTM2 = TM2Fil_c | TM2Fil_d | TopMetal2_filler | TopMetal2_nofill | TopMetal2_slit | TRANS | NoMetFiller
+	TM2Fil_nf = TopMetal2_nofill.dup
+	TM2Fil_nf.size(3.0, 3.0, "square_limit")
+	exclLayTM2 = TM2Fil_c | TM2Fil_d | TopMetal2_filler | TM2Fil_nf | TopMetal2_slit | TRANS | NoMetFiller
 
 	# perform fill
 	(EdgeSeal.holes - exclLayTM1).fill(pattern_tm1, hstep(width + distance), vstep(height + distance))


### PR DESCRIPTION
## Summary

The metal fill scripts subtract `*_nofill` layers from the fill area without adding a spacing margin.
This causes fill to be placed at 0 um from the nofill boundary.

Magic maps nofill layers to metal obstruction types (`obsm*`) and enforces fill-to-obstruction spacing.
This results in MFil.c violations (0.42 um for M1-M5) and TMFil.c violations (3.0 um for TM1-TM2).

## Root cause

In `sg13g2_filler_Metal.lym`,
`Metal*_filler` and `Metal*` drawing both get a 0.42 um margin via `.size()`.
But `Metal*_nofill` is subtracted as-is,
without any margin.

Same pattern in `sg13g2_filler_TopMetal.lym` where the required margin is 3.0 um.

## Fix

Add `.size()` to each `*_nofill` layer before using it in the exclusion formula.
This matches the margin already applied to `Metal*_filler` and `Metal*` drawing layers.

- `sg13g2_filler_Metal.lym`: add 0.42 um margin to Metal1-5 nofill
- `sg13g2_filler_TopMetal.lym`: add 3.0 um margin to TopMetal1-2 nofill

## Reproduction

Design with a hard macro containing `Metal5_nofill` (67/23).
After fill,
28 `Met5_S_FILL_CELL` rectangles are placed at 0.2 um from the nofill boundary instead of the required 0.42 um.
Magic DRC reports 28 MFil.c violations.
Control run without the macro: 0 violations.