### PR TITLE
[LVS] Improve hierarchical (deep-mode) extraction of taps

### DIFF
--- a/ihp-sg13g2/libs.tech/klayout/tech/lvs/rule_decks/tap_derivations.lvs
+++ b/ihp-sg13g2/libs.tech/klayout/tech/lvs/rule_decks/tap_derivations.lvs
@@ -33,10 +33,19 @@ taps_exclude = gatpoly.join(nsd_drw).join(trans_drw)
 ntap1_exc = pwell.join(psd_drw).join(taps_exclude)
 
 ntap1_tie = nactiv.and(ntap1_mk).not(ntap1_exc)
-ntap1_well = ntap1_mk.covering(ntap1_tie)
+# NOTE: the initial "nwell_drw.and(...)" does not change the layer
+# logically, but does a re-hierarchisation of the layer in deep mode
+# This is important to support cheats for cell-local extraction of 
+# guard rings through "cheats" (see tap_extraction.lvs).
+ntap1_well = nwell_drw.and(ntap1_mk.covering(ntap1_tie))
 
 # === ptap1 ===
 ptap1_exc = nwell_drw.join(taps_exclude)
 
 ptap1_tie = pactiv.and(ptap1_mk).not(ptap1_exc)
-ptap1_sub = ptap1_mk.covering(ptap1_tie)
+# NOTE: the initial "substrate_drw.and(...)" does not change the layer
+# logically, but does a re-hierarchisation of the layer in deep mode
+# This is important to support cheats for cell-local extraction of 
+# guard rings through "cheats" (see tap_extraction.lvs).
+ptap1_sub = substrate_drw.and(ptap1_mk.covering(ptap1_tie))
+

--- a/ihp-sg13g2/libs.tech/klayout/tech/lvs/rule_decks/tap_extraction.lvs
+++ b/ihp-sg13g2/libs.tech/klayout/tech/lvs/rule_decks/tap_extraction.lvs
@@ -31,11 +31,16 @@ logger.info('Extracting ntap1 device')
 #   - N => ntap1_well (nwell body)
 # This preserves PDK terminal order in the written netlist as "TIE WELL".
 # See: https://www.klayout.de/doc/manual/lvs_device_extractors.html#h2-117
-extract_devices(diode('ntap1', CustomTap), { 'P' => ntap1_tie, 'N' => ntap1_well })
+cheat("*") {
+  extract_devices(diode('ntap1', CustomTap), { 'P' => ntap1_tie, 'N' => ntap1_well })
+}
 
 # ptap1
 logger.info('Extracting ptap1 device')
 # ptap1 follows the same P/N region mapping rule:
 #   - P => ptap1_tie (tie contact)
 #   - N => ptap1_sub (substrate/body region)
-extract_devices(diode('ptap1', CustomTap), { 'P' => ptap1_tie, 'N' => ptap1_sub })
+cheat("*") {
+  extract_devices(diode('ptap1', CustomTap), { 'P' => ptap1_tie, 'N' => ptap1_sub })
+}
+


### PR DESCRIPTION
This is originated by @klayoutmatthias and did help us a lot (@simi1505) during our tapeout.

The problem was that
- Assume e.g. we have 2 guard rings in the schematic
- In the Layout, we overlap these two guard rings (east / west side)
- Then KLayout extracts a smaller area than given in the schematic
- This results in a LVS mismatch

During our discussions with @klayoutmatthias, he explained that there is an important concept called *cheats* (might sound phony but that is misleading) that should be employed by the LVS script to allow proper extraction (at least for `deep` mode).

This is tapeout phase verified by @simi1505.