### PR TITLE
Respect TMx.d Rules in Filler Script

### DIFF
--- a/ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_filler_Metal.lym
+++ b/ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_filler_Metal.lym
@@ -266,7 +266,7 @@
 	M1Fil_c.size(0.42, 0.42, "square_limit")
 	M1Fil_d = TRANS.dup
 	M1Fil_d.size(1.0, 1.0, "square_limit")
-	M1Fil = EdgeSeal.holes - (M1Fil_b | M1Fil_c | M1Fil_d | Metal1_nofill | Metal1_slit | TRANS | NoMetFiller)
+	M1Fil = EdgeSeal.holes - (M1Fil_b | M1Fil_c | M1Fil_d | Metal1_nofill | Metal1_slit | NoMetFiller)
 	M1Fil_left = M1Fil.fill_with_left(pattern_m1_m, hstep(width_m1_m + distance_m1_m), vstep(height_m1_m + distance_m1_m))
 	M1Fil_left.fill(pattern_m1_s, hstep(width_m1_s + distance_m1_s), vstep(height_m1_s + distance_m1_s))
 
@@ -277,7 +277,7 @@
 	M2Fil_c.size(0.42, 0.42, "square_limit")
 	M2Fil_d = TRANS.dup
 	M2Fil_d.size(1.0, 1.0, "square_limit")
-	M2Fil = EdgeSeal.holes - (M2Fil_b | M2Fil_c | M2Fil_d | Metal2_nofill | Metal2_slit | TRANS | NoMetFiller)
+	M2Fil = EdgeSeal.holes - (M2Fil_b | M2Fil_c | M2Fil_d | Metal2_nofill | Metal2_slit | NoMetFiller)
 	M2Fil_left = M2Fil.fill_with_left(pattern_m2_m, hstep(width_m2_m + distance_m2_m), vstep(height_m2_m + distance_m2_m))
 	M2Fil_left.fill(pattern_m2_s, hstep(width_m2_s + distance_m2_s), vstep(height_m2_s + distance_m2_s))
 
@@ -288,7 +288,7 @@
 	M3Fil_c.size(0.42, 0.42, "square_limit")
 	M3Fil_d = TRANS.dup
 	M3Fil_d.size(1.0, 1.0, "square_limit")
-	M3Fil = EdgeSeal.holes - (M3Fil_b | M3Fil_c | M3Fil_d | Metal3_nofill | Metal3_slit | TRANS | NoMetFiller)
+	M3Fil = EdgeSeal.holes - (M3Fil_b | M3Fil_c | M3Fil_d | Metal3_nofill | Metal3_slit | NoMetFiller)
 	M3Fil_left = M3Fil.fill_with_left(pattern_m3_m, hstep(width_m3_m + distance_m3_m), vstep(height_m3_m + distance_m3_m))
 	M3Fil_left.fill(pattern_m3_s, hstep(width_m3_s + distance_m3_s), vstep(height_m3_s + distance_m3_s))
 
@@ -299,7 +299,7 @@
 	M4Fil_c.size(0.42, 0.42, "square_limit")
 	M4Fil_d = TRANS.dup
 	M4Fil_d.size(1.0, 1.0, "square_limit")
-	M4Fil = EdgeSeal.holes - (M4Fil_b | M4Fil_c | M4Fil_d | Metal4_nofill | Metal4_slit | TRANS | NoMetFiller)
+	M4Fil = EdgeSeal.holes - (M4Fil_b | M4Fil_c | M4Fil_d | Metal4_nofill | Metal4_slit | NoMetFiller)
 	M4Fil_left = M4Fil.fill_with_left(pattern_m4_m, hstep(width_m4_m + distance_m4_m), vstep(height_m4_m + distance_m4_m))
 	M4Fil_left.fill(pattern_m4_s, hstep(width_m4_s + distance_m4_s), vstep(height_m4_s + distance_m4_s))
 
@@ -310,7 +310,7 @@
 	M5Fil_c.size(0.42, 0.42, "square_limit")
 	M5Fil_d = TRANS.dup
 	M5Fil_d.size(1.0, 1.0, "square_limit")
-	M5Fil = EdgeSeal.holes - (M5Fil_b | M5Fil_c | M5Fil_d | Metal5_nofill | Metal5_slit | TRANS | NoMetFiller)
+	M5Fil = EdgeSeal.holes - (M5Fil_b | M5Fil_c | M5Fil_d | Metal5_nofill | Metal5_slit | NoMetFiller)
 	M5Fil_left = M5Fil.fill_with_left(pattern_m5_m, hstep(width_m5_m + distance_m5_m), vstep(height_m5_m + distance_m5_m))
 	M5Fil_left.fill(pattern_m5_s, hstep(width_m5_s + distance_m5_s), vstep(height_m5_s + distance_m5_s))
 	</text>

--- a/ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_filler_TopMetal.lym
+++ b/ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_filler_TopMetal.lym
@@ -121,17 +121,21 @@
 	pattern_tm2 = fill_pattern("TM2_FILL_CELL").shape(134, 22, box(0.0, 0.0, width, height))
 	 
 	# Define noFill exclusion layer
+	TM1Fil_b = TopMetal1_filler.dup
+	TM1Fil_b.size(3.0, 3.0, "square_limit")
 	TM1Fil_c = TopMetal1.dup
 	TM1Fil_c.size(3.0, 3.0, "square_limit")
 	TM1Fil_d = TRANS.dup
 	TM1Fil_d.size(4.9, 4.9, "square_limit")
-	exclLayTM1 = TM1Fil_c | TM1Fil_d | TopMetal1_filler | TopMetal1_nofill | TopMetal1_slit | NoMetFiller
+	exclLayTM1 = TM1Fil_b | TM1Fil_c | TM1Fil_d | TopMetal1_nofill | TopMetal1_slit | NoMetFiller
 
+	TM2Fil_b = TopMetal2_filler.dup
+	TM2Fil_b.size(3.0, 3.0, "square_limit")
 	TM2Fil_c = TopMetal2.dup
 	TM2Fil_c.size(3.0, 3.0, "square_limit")
 	TM2Fil_d = TRANS.dup
 	TM2Fil_d.size(4.9, 4.9, "square_limit")
-	exclLayTM2 = TM2Fil_c | TM2Fil_d | TopMetal2_filler | TopMetal2_nofill | TopMetal2_slit | NoMetFiller
+	exclLayTM2 = TM2Fil_b | TM2Fil_c | TM2Fil_d | TopMetal2_nofill | TopMetal2_slit | NoMetFiller
 
 	# perform fill
 	(EdgeSeal.holes - exclLayTM1).fill(pattern_tm1, hstep(width + distance), vstep(height + distance))

--- a/ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_filler_TopMetal.lym
+++ b/ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_filler_TopMetal.lym
@@ -125,13 +125,13 @@
 	TM1Fil_c.size(3.0, 3.0, "square_limit")
 	TM1Fil_d = TRANS.dup
 	TM1Fil_d.size(4.9, 4.9, "square_limit")
-	exclLayTM1 = TM1Fil_c | TM1Fil_d | TopMetal1_filler | TopMetal1_nofill | TopMetal1_slit | TRANS | NoMetFiller
+	exclLayTM1 = TM1Fil_c | TM1Fil_d | TopMetal1_filler | TopMetal1_nofill | TopMetal1_slit | NoMetFiller
 
 	TM2Fil_c = TopMetal2.dup
 	TM2Fil_c.size(3.0, 3.0, "square_limit")
 	TM2Fil_d = TRANS.dup
 	TM2Fil_d.size(4.9, 4.9, "square_limit")
-	exclLayTM2 = TM2Fil_c | TM2Fil_d | TopMetal2_filler | TopMetal2_nofill | TopMetal2_slit | TRANS | NoMetFiller
+	exclLayTM2 = TM2Fil_c | TM2Fil_d | TopMetal2_filler | TopMetal2_nofill | TopMetal2_slit | NoMetFiller
 
 	# perform fill
 	(EdgeSeal.holes - exclLayTM1).fill(pattern_tm1, hstep(width + distance), vstep(height + distance))


### PR DESCRIPTION
Remove `TRANS` as exclusive layer since we already have the MxFil.d/TMxFil.d rules implemented. Additionally, add existing TopMetal fill with `3.0 um` space to respect the TMx.d rules. 
