### PR TITLE
pycell_test: fix crash introduced by #930

### DIFF
--- a/ihp-sg13g2/libs.tech/klayout/sg13g2_tests/pycell_test.py
+++ b/ihp-sg13g2/libs.tech/klayout/sg13g2_tests/pycell_test.py
@@ -26,6 +26,7 @@
 # KLAYOUT_PATH=$(pwd)/.. klayout ihp-pycells.gds -e
 
 layout = pya.Layout()
+layout.technology_name = "sg13g2"
 pcellNmos = layout.create_cell("nmos", "SG13_dev", { "l": 0.350e-6, "w": 6e-6, "ng": 3 })
 pcellPmos = layout.create_cell("pmos", "SG13_dev", { "l": 0.350e-6, "w": 6e-6, "ng": 3 })
 pcellCmim = layout.create_cell("cmim", "SG13_dev", {})


### PR DESCRIPTION
Fixes the regression reported by @ThomasZecha in https://github.com/IHP-GmbH/IHP-Open-PDK/pull/930#issuecomment-4275611014.

PR #930 added `self.technology = 'sg13g2'` to `PyCellLib`, which restricts the `SG13_dev` library to layouts that have that technology set. The test was creating a bare `pya.Layout()` with no technology, so `create_cell()` was returning `None` for several cells and crashing on the first `DCellInstArray()`

Fix is one line: set `layout.technology_name = "sg13g2"` right after creating the layout.

Tested with:
```bash
cd ihp-sg13g2/libs.tech/klayout/sg13g2_tests
KLAYOUT_PATH=$(pwd)/.. klayout -zz -r pycell_test.py
```

Note: there are two unrelated non-fatal errors still showing up (from #822, `numeric` module and a Tcl callback issue). They don't affect the GDS output.