### PR TITLE
[KLayout PyCell Tests] Fix failing test case by assigning technology to Layout object

### DIFF
--- a/ihp-sg13g2/libs.tech/klayout/sg13g2_tests/pycell_test.py
+++ b/ihp-sg13g2/libs.tech/klayout/sg13g2_tests/pycell_test.py
@@ -26,6 +26,7 @@
 # KLAYOUT_PATH=$(pwd)/.. klayout ihp-pycells.gds -e
 
 layout = pya.Layout()
+layout.technology_name = 'sg13g2'
 pcellNmos = layout.create_cell("nmos", "SG13_dev", { "l": 0.350e-6, "w": 6e-6, "ng": 3 })
 pcellPmos = layout.create_cell("pmos", "SG13_dev", { "l": 0.350e-6, "w": 6e-6, "ng": 3 })
 pcellCmim = layout.create_cell("cmim", "SG13_dev", {})


### PR DESCRIPTION
Fixes issue: https://github.com/IHP-GmbH/IHP-Open-PDK/pull/930#issuecomment-4275611014

Now that we've registered the library with the proper technology association,
we also have to do this for the Layout created in the test case.