### PR TITLE
Fix Python scripts tech association

### DIFF
--- a/ihp-sg13g2/libs.tech/klayout/python/import_netlist/import_netlist.py
+++ b/ihp-sg13g2/libs.tech/klayout/python/import_netlist/import_netlist.py
@@ -83,7 +83,7 @@ def create_pcell_instance(pcell_name='CIRCLE', lib_name='Basic', params={}, pos=
         print(f' - {key}: {value}')
 
     # Get PCell Library
-    lib = pya.Library.library_by_name(lib_name)
+    lib = pya.Library.library_by_name(lib_name, 'sg13g2')
 
     if not lib:
         print(f'Error: Library not found {lib_name}')

--- a/ihp-sg13g2/libs.tech/klayout/tech/scripts/bondpad.py
+++ b/ihp-sg13g2/libs.tech/klayout/tech/scripts/bondpad.py
@@ -29,7 +29,7 @@ def generate_bondpad(diameter: float, shape: str, output: str):
     layout = klayout.db.Layout(True)
     layout.dbu = 0.001
 
-    lib = pya.Library.library_by_name(LIB)
+    lib = pya.Library.library_by_name(LIB, 'sg13g2')
     pcell_decl = lib.layout().pcell_declaration(PCELL)
 
     cell_name = pathlib.Path(output).resolve().name.split('.')[0]

--- a/ihp-sg13g2/libs.tech/klayout/tech/scripts/sealring.py
+++ b/ihp-sg13g2/libs.tech/klayout/tech/scripts/sealring.py
@@ -37,7 +37,7 @@ def generate_sealring(width: float, heigth: float, input: str | None, output: st
     if input:
         layout.read(input)
 
-    lib = pya.Library.library_by_name(LIB)
+    lib = pya.Library.library_by_name(LIB, 'sg13g2')
     if lib is None:
         raise RuntimeError(
             "Could not find the 'SG13_dev' PCell library in the current KLayout environment.\n"


### PR DESCRIPTION
This PR fixes `bondpad.py`, `sealring.py`, and `import_netlist.py` by adding `'sg13g2'` to the `library_by_name` function. This fix is needed since COMMIT #929.

This probably also needs to be fixed in the `ihp-sg13cmos5l` PDK.