### PR TITLE
LVS deck switch for disabling A/P comparison of taps

### DIFF
--- a/ihp-sg13g2/libs.tech/klayout/tech/lvs/run_lvs.py
+++ b/ihp-sg13g2/libs.tech/klayout/tech/lvs/run_lvs.py
@@ -483,6 +483,7 @@ def generate_klayout_switches(
         "run_mode": run_mode,
         "no_net_names": "true" if args.no_net_names else "false",
         "spice_comments": "true" if args.spice_comments else "false",
+        "tap_ap_compare": "true" if args.tap_ap_compare else "false",
         "net_only": "true" if effective_net_only else "false",
         "top_lvl_pins": "true" if args.top_lvl_pins else "false",
         "no_simplify": "true" if args.no_simplify else "false",
@@ -736,7 +737,7 @@ if __name__ == "__main__":
     run_lvs.py [--layout=<layout_path>]
                [--netlist=<netlist_path>] [--layout_netlist=<layout_netlist_path>] [--run_dir=<run_dir_path>]
                [--topcell=<topcell_name>] [--run_mode=<run_mode>]
-               [--no_net_names] [--spice_comments] [--net_only] [--no_simplify]
+               [--no_net_names] [--spice_comments] [--tap_ap_compare] [--net_only] [--no_simplify]
                [--no_series_res] [--no_parallel_res] [--combine_devices] [--top_lvl_pins]
                [--purge] [--purge_nets] [--ignore_top_ports_mismatch]
                [--implicit_nets=<nets>]
@@ -783,6 +784,11 @@ if __name__ == "__main__":
     )
     parser.add_argument("--no_net_names", action="store_true", help="Omit net names in extracted netlist.")
     parser.add_argument("--spice_comments", action="store_true", help="Include comments in extracted netlist.")
+    parser.add_argument(
+        "--tap_ap_compare",
+        action="store_true",
+        help="Enable A/P parameter comparison for tap devices (ntap1/ptap1). [default: disabled]",
+    )
     parser.add_argument("--net_only", action="store_true", help="Generate extracted netlist only (skip comparison).")
     parser.add_argument("--no_simplify", action="store_true", help="Disable simplify on layout/schematic netlists.")
     parser.add_argument("--no_series_res", action="store_true", help="Disable resistor series simplification.")

--- a/ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_lvs.lym
+++ b/ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_lvs.lym
@@ -53,6 +53,7 @@ DEFAULT_OPTIONS = {
   'run_dir' => '',
   'no_net_names' => false,
   'spice_comments' => false,
+  'tap_ap_compare' => false,
   'net_only' => false,
   'no_simplify' => false,
   'no_series_res' => false,
@@ -181,6 +182,7 @@ cmd_opts &lt;&lt; "--layout_netlist=#{Shellwords.escape(layout_netlist_path)}" u
 %w[
   no_net_names
   spice_comments
+  tap_ap_compare
   net_only
   no_simplify
   no_series_res

--- a/ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_lvs_options.lym
+++ b/ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_lvs_options.lym
@@ -49,6 +49,7 @@ module SG13G2LVSOptions
     'run_dir' => '',
     'no_net_names' => false,
     'spice_comments' => false,
+    'tap_ap_compare' => false,
     'net_only' => false,
     'no_simplify' => false,
     'no_series_res' => false,
@@ -255,6 +256,11 @@ module SG13G2LVSOptions
       options['spice_comments'],
       'Emit detailed comments in extracted netlist.'
     )
+    @widgets[:tap_ap_compare] = create_check_box(
+      'Compare Tap A/P',
+      options['tap_ap_compare'],
+      'Compare A and P parameters for ntap1/ptap1 tap devices. Disabled by default.'
+    )
     @widgets[:no_series_res] = create_check_box(
       'Disable Series Res Merge',
       options['no_series_res'],
@@ -349,6 +355,7 @@ module SG13G2LVSOptions
       'Case-sensitive implicit net patterns. Use only when some nets are intentionally connected at higher hierarchy.'
     )
     comparison_layout.addRow('Implicit Nets:', @widgets[:implicit_nets_adv])
+    comparison_layout.addRow('', @widgets[:tap_ap_compare])
 
     netlist_ops_group = RBA::QGroupBox.new('Netlist Formatting')
     netlist_ops_layout = RBA::QFormLayout.new(netlist_ops_group)
@@ -633,6 +640,7 @@ module SG13G2LVSOptions
     options['implicit_nets'] = @widgets[:implicit_nets_adv].text.to_s
     options['no_net_names'] = @widgets[:no_net_names].checked
     options['spice_comments'] = @widgets[:spice_comments].checked
+    options['tap_ap_compare'] = @widgets[:tap_ap_compare].checked
     options['no_series_res'] = @widgets[:no_series_res].checked
     options['no_parallel_res'] = @widgets[:no_parallel_res].checked
     options['combine_devices'] = @widgets[:combine_devices].checked


### PR DESCRIPTION
This PR disables by default the comparison of A/P for `ptap1/ntap1` devices. 
It can be switched on using `--tap_ap_compare` CLI switch or by checking an option in GUI. 

<img width="819" height="169" alt="image" src="https://github.com/user-attachments/assets/f51a1432-cb2c-4124-8df8-11b4e5f339d0" />

