### PR TITLE
DRC: optional diagnostic decks + filler/PolyRes check (#917)

### DIFF
--- a/ihp-sg13g2/libs.tech/klayout/tech/drc/rule_decks/optional/LIMITATION_gatpoly_filler_polyres.md
+++ b/ihp-sg13g2/libs.tech/klayout/tech/drc/rule_decks/optional/LIMITATION_gatpoly_filler_polyres.md
@@ -1,0 +1,106 @@
+# Limitation: GatPoly:filler over PolyRes.drawing is not caught by the KLayout DRC
+
+Proposed final location: `ihp-sg13g2/libs.tech/klayout/tech/drc/rule_decks/optional/LIMITATION_gatpoly_filler_polyres.md`
+(or an equivalent DRC-adjacent docs folder, at IHP's discretion)
+
+Related: issue [#917](https://github.com/IHP-GmbH/IHP-Open-PDK/issues/917), PR [#924](https://github.com/IHP-GmbH/IHP-Open-PDK/pull/924), PR [#940](https://github.com/IHP-GmbH/IHP-Open-PDK/pull/940).
+
+## Summary
+
+The KLayout DRC for `sg13g2` does not flag `GatPoly:filler` (5/22) overlapping `PolyRes.drawing` (128/0), even though the same overlap is a physical poly short according to our own 2.5D stackup. The gap is documented in [`SG13G2_os_layout_rules.pdf`](https://github.com/IHP-GmbH/IHP-Open-PDK/blob/dev/ihp-sg13g2/libs.doc/doc/SG13G2_os_layout_rules.pdf) as much as it is in the DRC decks and the filler generator; all three are mutually consistent, but out of step with the stackup model.
+
+## Evidence
+
+`FPGA8213.gds.gz` from the HeiChips'25 submission (see issue #917) exhibits 154 filler-over-PolyRes overlaps. Running `run_drc.py --precheck_drc` on current `dev` (HEAD `ef9a8bce`, post PR #924 merge) reports "KLayout DRC Check Passed: No DRC violations detected".
+
+Chip-wide intersections measured with `klayout.db`:
+
+| Intersection | Polygons |
+|---|---|
+| `GatPoly.filler` ∩ `PolyRes.drawing` (128/0) | 154 |
+| `GatPoly.filler` ∩ `RES.drawing` (24/0) | 154 (same sites) |
+| `GatPoly.filler` ∩ `HeatRes.drawing` (52/0) | 154 (same sites) |
+| `GatPoly.filler` ∩ `GatPoly.drawing` (5/0) | 0 |
+| `GatPoly.filler` ∩ `SalBlock` / `Activ` / `Cont` | 0 |
+
+Because there is no `GatPoly.drawing` under the filler, PR #924's `drw.join(filler).space(0.18 um)` catches nothing; and because `PolyRes` is not in the `GFil.d` layer list, `GFil.d` stays silent too. PR #940 adds `.and()` overlap detection to the existing filler rules but does not extend them to `PolyRes`, so it does not cover this case either.
+
+## Why `SG13G2_os_layout_rules.pdf` does not catch it
+
+`SG13G2_os_layout_rules.pdf` Rev. 0.4:
+
+- §5.9 `GFil.d`: "Min. GatPoly:filler space to Activ, GatPoly, Cont, pSD, nSD:block, SalBlock = 1.10 um". `PolyRes` is not in this list.
+- §5.8 `Gat.b`: "Min. GatPoly space or notch = 0.18 um". Defined on `GatPoly.drawing`; does not pull in `PolyRes`.
+- §2 Layer Table: `PolyRes 128/0` is described as "used to mark net resistors", i.e., a marker rather than a physical body layer.
+- §6.2 `Rsil`: defines `Rsil = RES + GatPoly` with the poly resistor body drawn on `GatPoly.drawing`, not on `PolyRes`.
+
+Following `SG13G2_os_layout_rules.pdf` strictly, filler over `PolyRes` is not a DRC violation.
+
+## Why physics disagrees
+
+`ihp-sg13g2/libs.tech/klayout/tech/d25/sg13g2_beol.lyd25` contains:
+
+```
+GatPoly  = input(5,0) | PolyRes
+Rhigh    = SalBlock & pSD & nSD
+Rppd     = SalBlock & pSD - nSD
+Rsil     = PolyRes - Rhigh - Rppd
+RGatPoly = GatPoly - Rhigh - Rppd - Rsil
+```
+
+Two things follow:
+
+1. `GatPoly` in the 2.5D stackup is the union `GatPoly.drawing | PolyRes`. Filler placed on `PolyRes` sits on the same physical polysilicon sheet as normal gate poly.
+2. `Rsil` is derived from `PolyRes` minus the other resistor flavours, i.e., the salicided n+ poly resistor body is expressed as `PolyRes` in the post-pycell layout, not as `GatPoly.drawing` + `RES`.
+
+That is why the `FPGA8213.gds.gz` resistor cell has 154 filler shapes on `PolyRes` with zero underlying `GatPoly.drawing`; the pycell flow writes `PolyRes` and the DRC only looks at `GatPoly.drawing`.
+
+## Why the existing DRC rule and the KLayout filler macro behave the same way
+
+Both follow `SG13G2_os_layout_rules.pdf` literally, which means both reproduce the same gap.
+
+DRC: `ihp-sg13g2/libs.tech/klayout/tech/drc/rule_decks/feol/5_9_gatpolyfiller.drc`, line 27:
+
+```
+gfil_d_g = activ_drw.join(gatpoly_drw).join(cont_drw).join(psd_drw).join(nsd_block).join(salblock_drw)
+```
+
+Filler generator: `ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_filler_ActGatP.lym`, line 213:
+
+```
+GFil_d = Activ_gp_cpy | Poly_gp_cpy | Cnt_gp_cpy | pSD_cpy | nSD_block_cpy | SalBlock_cpy
+```
+
+Neither includes `PolyRes`. A layout filled by our KLayout macro would therefore carry the same bug that Magic's filler had before PR #908, and the DRC would stay silent on it in both cases.
+
+## Interim workaround (opt-in, not wired into precheck or maximal)
+
+`filler_polyres_overlap_check.drc` runs standalone via KLayout's `-b -r` mode. It emits two categories:
+
+- `GatPolyFil.PolyRes.overlap`: literal overlap (filler on PolyRes). This is the real short.
+- `GatPolyFil.PolyRes.sep`: filler within 1.10 um of PolyRes, mirroring `GFil.d`'s intent extended to PolyRes.
+
+Proposed install path once accepted upstream: `ihp-sg13g2/libs.tech/klayout/tech/drc/rule_decks/optional/filler_polyres_overlap_check.drc`.
+
+Invocation:
+
+```
+klayout -b -r filler_polyres_overlap_check.drc \
+        -rd input=<layout.gds[.gz]> -rd report=<out.lyrdb>
+```
+
+Verified on `FPGA8213.gds.gz`: 154 overlap items and 118 proximity edge pairs reported, matching the independent `klayout.db` count.
+
+The rule deck does not modify any file under `precheck_drc` or `maximal`; it is strictly additional and opt-in. It should not be made mandatory until IHP updates `SG13G2_os_layout_rules.pdf`.
+
+## Plan
+
+The direction is an internal IHP call, not a decision to be taken in the public issue. Two paths on the table:
+
+1. Update `SG13G2_os_layout_rules.pdf` to list `PolyRes` under `GFil.d` (and possibly under `Gat.b` or a companion `PolyRes` section), then extend `5_9_gatpolyfiller.drc`, `5_8_gatpoly.drc`, and `sg13g2_filler_ActGatP.lym` symmetrically. Physically faithful and consistent with the 2.5D stackup.
+2. Keep `SG13G2_os_layout_rules.pdf` as is but state explicitly that `PolyRes` is a recognition-only marker and that keeping filler off poly resistor bodies is the filler generator's responsibility (Magic, KLayout, and any third-party flow). The DRC gap then becomes a tooling requirement rather than a rule violation.
+
+Until the direction is picked, this document and the opt-in rule deck are intentionally conservative; neither `precheck_drc` nor `maximal` changes classification. Once the call is made:
+
+- Path 1: migrate `filler_polyres_overlap_check.drc` into `rule_decks/feol/5_9_gatpolyfiller.drc` (GFil.d extended with `PolyRes`) and `rule_decks/feol/5_8_gatpoly.drc` (Gat.b joined with `PolyRes`), classified in the appropriate `precheck_drc` / `maximal` tiers in `sg13g2_tech_default.json` and `sg13g2_tech_mod.json`. Update `sg13g2_filler_ActGatP.lym` so the KLayout filler generator respects the same keep-out.
+- Path 2: retire the opt-in deck (or keep it as a hygiene-only tool), update `SG13G2_os_layout_rules.pdf` to make `PolyRes` recognition-only explicit, and require filler generators (Magic, KLayout, third-party) to carry the PolyRes keep-out by construction.

--- a/ihp-sg13g2/libs.tech/klayout/tech/drc/rule_decks/optional/filler_polyres_overlap_check.drc
+++ b/ihp-sg13g2/libs.tech/klayout/tech/drc/rule_decks/optional/filler_polyres_overlap_check.drc
@@ -1,0 +1,47 @@
+# filler_polyres_overlap_check.drc
+#
+# Standalone optional check. Not wired into run_drc.py, precheck_drc or maximal.
+# Flags GatPoly:filler (5/22) overlapping or too close to PolyRes.drawing (128/0),
+# which is the scenario reported in issue #917.
+#
+# Why this lives outside the main decks:
+#   sg13g2_beol.lyd25 declares GatPoly = input(5,0) | PolyRes and Rsil =
+#   PolyRes - Rhigh - Rppd, so PolyRes is part of the physical poly silicon in
+#   the 2.5D stackup; filler on PolyRes is a poly short. SG13G2_os_layout_rules.pdf
+#   Rev. 0.4 (ihp-sg13g2/libs.doc/doc/SG13G2_os_layout_rules.pdf) does not list
+#   PolyRes in GFil.d or Gat.b, so extending the official decks requires a DRM
+#   update. Until that happens, this deck is an opt-in sanity check and nothing
+#   more.
+#
+# Usage:
+#   klayout -b -r filler_polyres_overlap_check.drc \
+#       -rd input=<layout.gds[.gz]> -rd report=<out.lyrdb>
+#
+# Proposed final path if accepted upstream:
+#   ihp-sg13g2/libs.tech/klayout/tech/drc/rule_decks/optional/filler_polyres_overlap_check.drc
+
+raise 'no input layout (pass -rd input=<path>)' unless $input
+
+report_path = $report || 'filler_polyres_overlap.lyrdb'
+
+source($input)
+report 'Filler over PolyRes, extended check (issue #917)', report_path
+
+gatpoly_filler = input(5, 22)
+polyres_drw    = input(128, 0)
+
+puts "[info] GatPoly.filler polygons (5/22): #{gatpoly_filler.count}"
+puts "[info] PolyRes.drawing polygons (128/0): #{polyres_drw.count}"
+
+# A. Overlap; a real poly short per the 2.5D stackup
+overlap = gatpoly_filler & polyres_drw
+puts "[info] Overlap polygons (filler on PolyRes): #{overlap.count}"
+overlap.output('GatPolyFil.PolyRes.overlap',
+               'GatPoly:filler overlaps PolyRes.drawing; physical poly short per D25 (GatPoly = 5/0 | PolyRes)')
+
+# B. Proximity; mirrors GFil.d intent (1.10 um) extended to PolyRes.
+#    Uses sep(), so it catches external edge pairs only, not overlap (A covers that).
+near = polyres_drw.sep(gatpoly_filler, 1.10.um, euclidian)
+puts "[info] Proximity edge pairs (<1.10 um): #{near.count}"
+near.output('GatPolyFil.PolyRes.sep',
+            'GatPoly:filler closer than 1.10 um to PolyRes.drawing (GFil.d intent, extended)')

--- a/ihp-sg13g2/libs.tech/klayout/tech/drc/run_drc.py
+++ b/ihp-sg13g2/libs.tech/klayout/tech/drc/run_drc.py
@@ -626,6 +626,15 @@ def run_parallel_run(
                 rule_deck_full_path / "rule_decks" / "sg13g2_maximal.drc"
             )
 
+        # Opt-in optional diagnostic decks (not part of precheck_drc or maximal).
+        if args.optional_diag:
+            optional_dir = rule_deck_full_path / "rule_decks" / "optional"
+            if optional_dir.is_dir():
+                for deck in sorted(optional_dir.glob("*.drc")):
+                    rule_deck_files[deck.stem] = deck
+            else:
+                logging.warning("--optional_diag requested but rule_decks/optional/ does not exist.")
+
     # Main table-based checks
     table_list = args.table if args.table else get_list_of_tables(rule_deck_full_path, switches)
     for table in table_list:
@@ -718,6 +727,18 @@ def run_single_processor(
         run_check_by_flag(not args.no_density, "density")
         run_check_by_flag(not args.disable_extra_rules, "sg13g2_maximal")
 
+        # Opt-in optional diagnostic decks enumerated from rule_decks/optional/.
+        # Not part of precheck_drc or maximal; each deck runs as an independent
+        # klayout subprocess producing its own lyrdb.
+        if args.optional_diag:
+            optional_dir = rule_deck_full_path / "rule_decks" / "optional"
+            if optional_dir.is_dir():
+                for deck in sorted(optional_dir.glob("*.drc")):
+                    result_dbs.append(run_check(deck, [deck.stem], layout_path, run_dir, switches))
+                    logging.info(f"Completed running optional diagnostic: {deck.name}")
+            else:
+                logging.warning("--optional_diag requested but rule_decks/optional/ does not exist.")
+
     # Final result verification
     return check_drc_results(result_dbs, run_dir, layout_path, switches)
 
@@ -772,6 +793,7 @@ def parse_args():
             [--precheck_drc] [--disable_extra_rules] [--no_feol] [--no_beol] [--density_sanity] [--no_density]
             [--density_thr=<density_threads>] [--density_only] [--antenna]
             [--antenna_only] [--no_offgrid] [--no_angle] [--no_recommended]
+            [--optional_diag]
     """
 
     parser = argparse.ArgumentParser(
@@ -878,6 +900,11 @@ def parse_args():
     )
     parser.add_argument(
         "--no_recommended", action="store_true", help="Disable recommended rule checks."
+    )
+    parser.add_argument(
+        "--optional_diag",
+        action="store_true",
+        help="Also run each .drc under rule_decks/optional/ as an opt-in diagnostic pass. Not part of precheck_drc or maximal.",
     )
 
     return parser.parse_args()

--- a/ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_drc.lym
+++ b/ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_drc.lym
@@ -78,6 +78,7 @@ def set_default_options
     'no_offgrid' =&gt; false,
     'no_angle' =&gt; false,
     'no_recommended' =&gt; false,
+    'optional_diag' =&gt; false,
   }
 end
 
@@ -148,7 +149,7 @@ cmd_opts = [
   "--density_thr=#{options['density_thr']}"
 ]
 
-%w[no_feol no_beol disable_extra_rules no_density density_only density_sanity antenna antenna_only no_offgrid no_angle no_recommended].each do |flag|
+%w[no_feol no_beol disable_extra_rules no_density density_only density_sanity antenna antenna_only no_offgrid no_angle no_recommended optional_diag].each do |flag|
   cmd_opts &lt;&lt; "--#{flag}" if options[flag]
 end
 

--- a/ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_drc_options.lym
+++ b/ihp-sg13g2/libs.tech/klayout/tech/macros/sg13g2_drc_options.lym
@@ -114,6 +114,7 @@
         'no_offgrid' => false,
         'no_angle' => false,
         'no_recommended' => false,
+        'optional_diag' => false,
       }
 
       defaults.merge(opts)
@@ -150,6 +151,7 @@
       'no_offgrid' => false,
       'no_angle' => false,
       'no_recommended' => false,
+      'optional_diag' => false,
     }
     save_options(yaml_file_path, defaults) rescue nil
     defaults
@@ -275,6 +277,7 @@
     @chk_offgrid = create_check_box("Disable Offgrid Checks", options['no_offgrid'], "Skips offgrid checks.")
     @chk_angle = create_check_box("Disable Angle Checks", options['no_angle'], "Skips angle checks.")
     @chk_recommended = create_check_box("Disable Recommended Checks", options['no_recommended'], "Skips recommended checks.")
+    @chk_optional_diag = create_check_box("Run Optional Diagnostic Decks", options['optional_diag'], "Runs each .drc under rule_decks/optional/ as an opt-in diagnostic pass (e.g. issue #917 filler-over-PolyRes). Not part of precheck_drc or maximal.")
 
     [
       @chk_density,
@@ -284,7 +287,8 @@
       @chk_antenna_only,
       @chk_offgrid,
       @chk_angle,
-      @chk_recommended
+      @chk_recommended,
+      @chk_optional_diag
     ].each { |chk| @checks_layout.addRow("", chk) }
 
     @advanced_layout_setup.addWidget(@runtime_group)
@@ -639,6 +643,7 @@
     options['no_offgrid'] = @chk_offgrid.checked if @chk_offgrid
     options['no_angle'] = @chk_angle.checked if @chk_angle
     options['no_recommended'] = @chk_recommended.checked if @chk_recommended
+    options['optional_diag'] = @chk_optional_diag.checked if @chk_optional_diag
   end
 
  end


### PR DESCRIPTION
Adds an opt-in way to run diagnostic DRC decks from `rule_decks/optional/` via a new `--optional_diag` flag in `run_drc.py` and a matching checkbox in the SG13G2 DRC Options dialog. Default flow stays as it is; `precheck_drc`, `maximal`, the tech JSONs and the filler macro are not touched.

The first deck, `filler_polyres_overlap_check.drc`, catches the case from #917: `GatPoly:filler` (5/22) sitting on or too close to `PolyRes.drawing` (128/0). On `FPGA8213.gds.gz` the problematic fillers sit on `PolyRes` with no `GatPoly.drawing` underneath, so `Gat.b`, `GFil.d`, and the extensions in PR #924 / #940 never fire; none of them look at `PolyRes`. That matches [`SG13G2_os_layout_rules.pdf`](https://github.com/IHP-GmbH/IHP-Open-PDK/blob/dev/ihp-sg13g2/libs.doc/doc/SG13G2_os_layout_rules.pdf) Rev. 0.4 §5.8 and §5.9, which do not mention `PolyRes`. But `sg13g2_beol.lyd25` does: `GatPoly = input(5,0) | PolyRes` and `Rsil = PolyRes - Rhigh - Rppd`. Physically `PolyRes` is poly silicon, so filler on top shorts the resistor. 
Extending the default DRC to include `PolyRes` is a DRM call for IHP; until that lands this deck is opt-in. Full rationale in `LIMITATION_gatpoly_filler_polyres.md`.

### Files

- `drc/run_drc.py` — `--optional_diag` flag; enumerates `rule_decks/optional/*.drc` after the main flow and runs each via the existing `run_check()`.
- `macros/sg13g2_drc_options.lym` — checkbox under Advanced > Optional Rule Sets, persists as `optional_diag` in `~/.ihp_pdk/ihp_sg13g2_drc_options.yml`.
- `macros/sg13g2_drc.lym` — pass-through.
- `rule_decks/optional/filler_polyres_overlap_check.drc` — the deck. Outputs `GatPolyFil.PolyRes.overlap` and `GatPolyFil.PolyRes.sep`.
- `rule_decks/optional/LIMITATION_gatpoly_filler_polyres.md` — the write-up.

### Usage

```
python3 ihp-sg13g2/libs.tech/klayout/tech/drc/run_drc.py \
    --path=<layout.gds[.gz]> --optional_diag --mp=$(nproc)
```

Or from the GUI: tick the new box in DRC Options > Advanced, then Run DRC.

### Validation

`FPGA8213.gds.gz` from #917: 154 overlap items + 118 proximity edge pairs. Checked three ways: standalone `klayout -b -r`, `run_drc.py --optional_diag` (mp=1 and mp=4 on `testing/testcases/unit/gatpoly.gds`), and GUI end-to-end on FPGA8213. Cross-checked against an independent `klayout.db` intersection script; 73 of the 154 overlaps fall within ±50 um of (2418, 1645), the coord from the issue. Without the flag, no extra categories show up.

### Note: the KLayout filler macro has the same gap

`sg13g2_filler_ActGatP.lym` line 213 builds its GatPoly filler keep-out from the same layer list as `GFil.d`, no `PolyRes`. A layout filled with that macro over a `PolyRes`-based resistor reproduces the pre-PR #908 Magic bug. Not fixed here; tracked in #948.

### Follow-up

A second PR closes the gap after IHP picks, internally, between (1) adding `PolyRes` to `GFil.d` and likely `Gat.b` in the DRM, then updating the DRC decks and the filler macro to match, or (2) leaving the DRM as is, stating that `PolyRes` is recognition-only, and moving the keep-out to the filler macro. The edit in `sg13g2_filler_ActGatP.lym` is the same either way.

IMO both (1) and (2) should be fixed. External (not klayout base) fillers generators should just follow updated DRM

### Reviewer check

On this branch, open DRC Options in KLayout; the new checkbox sits under Advanced > Optional Rule Sets. Tick it, save, run DRC. The merged `full.lyrdb` should list `GatPolyFil.PolyRes.overlap` and `GatPolyFil.PolyRes.sep`.
