### PR TITLE
Getting Monte Carlo Sampling to work for xyce (LV)

### DIFF
--- a/ihp-sg13g2/libs.tech/xyce/models/cornerMOSlv.lib
+++ b/ihp-sg13g2/libs.tech/xyce/models/cornerMOSlv.lib
@@ -72,7 +72,7 @@
 **************** CORNER_LIB OF sg13g2_lv TT MODEL ****************
 * Typical
 .LIB mos_tt
-.param sg13g2_lv_nmos_vfbo_mm= 1.0
+.param sg13g2_lv_nmos_vfbo_mm= 1.0000
 .param sg13g2_lv_nmos_ctl    = 1.2080
 .param sg13g2_lv_nmos_rsw1   = 0.7200
 .param sg13g2_lv_nmos_muew   = 0.8500
@@ -89,8 +89,12 @@
 .param sg13g2_lv_nmos_cjorbot= 1.0000
 .param sg13g2_lv_nmos_cjorsti= 1.0000
 .param sg13g2_lv_nmos_cjorgat= 1.0000
+.param sg13g2_lv_nmos_delvto_mm = 0
+.param sg13g2_lv_nmos_factuo_mm = 0
+.param sg13g2_lv_nmos_dw_mm     = 0
+.param sg13g2_lv_nmos_dl_mm     = 0
 
-.param sg13g2_lv_pmos_vfbo_mm   = 1.0
+.param sg13g2_lv_pmos_vfbo_mm= 1.0000
 .param sg13g2_lv_pmos_ctl    = 1.9570
 .param sg13g2_lv_pmos_rsw1   = 0.7720
 .param sg13g2_lv_pmos_muew   = 1.0520
@@ -107,6 +111,10 @@
 .param sg13g2_lv_pmos_cjorbot= 1.0000
 .param sg13g2_lv_pmos_cjorsti= 1.0000
 .param sg13g2_lv_pmos_cjorgat= 1.0000
+.param sg13g2_lv_pmos_delvto_mm = 0
+.param sg13g2_lv_pmos_factuo_mm = 0
+.param sg13g2_lv_pmos_dw_mm     = 0
+.param sg13g2_lv_pmos_dl_mm     = 0
 
 .param sg13g2_lv_svaricap_lap   = 1.082
 .param sg13g2_lv_svaricap_toxo  = 1
@@ -116,7 +124,7 @@
 
 * Typical with statistical modeling
 .LIB mos_tt_stat
-.param sg13g2_lv_nmos_vfbo_norm   = 1.0
+.param sg13g2_lv_nmos_vfbo_norm     = 1.0000
 .param sg13g2_lv_nmos_ctl_norm    = 1.2080
 .param sg13g2_lv_nmos_rsw1_norm   = 0.7200
 .param sg13g2_lv_nmos_muew_norm   = 0.8500
@@ -134,7 +142,7 @@
 .param sg13g2_lv_nmos_cjorsti_norm= 1.0000
 .param sg13g2_lv_nmos_cjorgat_norm= 1.0000
 
-.param sg13g2_lv_pmos_vfbo_norm   = 1.0
+.param sg13g2_lv_pmos_vfbo_norm     = 1.0000
 .param sg13g2_lv_pmos_ctl_norm    = 1.2080
 .param sg13g2_lv_pmos_rsw1_norm   = 0.7200
 .param sg13g2_lv_pmos_muew_norm   = 0.8500
@@ -159,6 +167,60 @@
 .include sg13g2_moslv_mod.lib
 .ENDL mos_tt_stat
 
+* Typical + local mismatch only (no global process variation)
+.LIB mos_tt_mismatch
+.param sg13g2_lv_nmos_vfbo_mm    = 1.0000
+.param sg13g2_lv_nmos_ctl        = 1.2080
+.param sg13g2_lv_nmos_rsw1       = 0.7200
+.param sg13g2_lv_nmos_muew       = 0.8500
+.param sg13g2_lv_nmos_dphibo     = 0.9915
+.param sg13g2_lv_nmos_dphibl     = 0.9693
+.param sg13g2_lv_nmos_dphibw     = 0.9749
+.param sg13g2_lv_nmos_dphiblw    = 0.9754
+.param sg13g2_lv_nmos_themuo     = 0.8757
+.param sg13g2_lv_nmos_thesatl    = 0.7850
+.param sg13g2_lv_nmos_thesatw    = 1.5000
+.param sg13g2_lv_nmos_thesatlw   = 0.6127
+.param sg13g2_lv_nmos_toxo       = 1.0000
+.param sg13g2_lv_nmos_toxovo     = 1.0000
+.param sg13g2_lv_nmos_cjorbot    = 1.0000
+.param sg13g2_lv_nmos_cjorsti    = 1.0000
+.param sg13g2_lv_nmos_cjorgat    = 1.0000
+.param sg13g2_lv_nmos_delvto_mm  = 0.0039
+.param sg13g2_lv_nmos_factuo_mm  = 0.005
+.param sg13g2_lv_nmos_dw_mm      = 4e-9
+.param sg13g2_lv_nmos_dl_mm      = 2e-9
+
+.param sg13g2_lv_pmos_vfbo_mm    = 1.0000
+.param sg13g2_lv_pmos_ctl        = 1.9570
+.param sg13g2_lv_pmos_rsw1       = 0.7720
+.param sg13g2_lv_pmos_muew       = 1.0520
+.param sg13g2_lv_pmos_dphibo     = 0.9050
+.param sg13g2_lv_pmos_dphibl     = 0.8550
+.param sg13g2_lv_pmos_dphibw     = -1.5800
+.param sg13g2_lv_pmos_dphiblw    = 1.0000
+.param sg13g2_lv_pmos_themuo     = 0.9580
+.param sg13g2_lv_pmos_thesatl    = 0.5510
+.param sg13g2_lv_pmos_thesatw    = 1.0800
+.param sg13g2_lv_pmos_thesatlw   = 1.0000
+.param sg13g2_lv_pmos_toxo       = 1.0000
+.param sg13g2_lv_pmos_toxovo     = 1.0000
+.param sg13g2_lv_pmos_cjorbot    = 1.0000
+.param sg13g2_lv_pmos_cjorsti    = 1.0000
+.param sg13g2_lv_pmos_cjorgat    = 1.0000
+.param sg13g2_lv_pmos_delvto_mm  = 0.0022
+.param sg13g2_lv_pmos_factuo_mm  = 0.0033
+.param sg13g2_lv_pmos_dw_mm      = 4e-9
+.param sg13g2_lv_pmos_dl_mm      = 2e-9
+
+
+.param sg13g2_lv_svaricap_lap    = 1.082
+.param sg13g2_lv_svaricap_toxo   = 1
+
+* Mismatch sigma values active — no global stats file included
+.include sg13g2_moslv_mod.lib
+.ENDL mos_tt_mismatch
+
 **************** CORNER_LIB OF sg13g2_lv SS MODEL ****************
 * Slow n, Slow p without statistical
 .LIB mos_ss
@@ -179,6 +241,10 @@
 .param sg13g2_lv_nmos_cjorbot= 1.0800
 .param sg13g2_lv_nmos_cjorsti= 1.0800
 .param sg13g2_lv_nmos_cjorgat= 1.0800
+.param sg13g2_lv_nmos_delvto_mm = 0
+.param sg13g2_lv_nmos_factuo_mm = 0
+.param sg13g2_lv_nmos_dw_mm     = 0
+.param sg13g2_lv_nmos_dl_mm     = 0
 
 .param sg13g2_lv_pmos_vfbo_mm= 1.0
 .param sg13g2_lv_pmos_ctl    = 1.3520
@@ -197,6 +263,11 @@
 .param sg13g2_lv_pmos_cjorbot= 1.0800
 .param sg13g2_lv_pmos_cjorsti= 1.0800
 .param sg13g2_lv_pmos_cjorgat= 1.0800
+.param sg13g2_lv_pmos_delvto_mm = 0
+.param sg13g2_lv_pmos_factuo_mm = 0
+.param sg13g2_lv_pmos_dw_mm     = 0
+.param sg13g2_lv_pmos_dl_mm     = 0
+
 
 .param sg13g2_lv_svaricap_lap   = 1
 .param sg13g2_lv_svaricap_toxo  = 1.04
@@ -224,6 +295,10 @@
 .param sg13g2_lv_nmos_cjorbot= 0.9200
 .param sg13g2_lv_nmos_cjorsti= 0.9200
 .param sg13g2_lv_nmos_cjorgat= 0.9200
+.param sg13g2_lv_nmos_delvto_mm = 0
+.param sg13g2_lv_nmos_factuo_mm = 0
+.param sg13g2_lv_nmos_dw_mm     = 0
+.param sg13g2_lv_nmos_dl_mm     = 0
 
 .param sg13g2_lv_pmos_vfbo_mm= 1.0
 .param sg13g2_lv_pmos_ctl    = 2.4800
@@ -242,6 +317,11 @@
 .param sg13g2_lv_pmos_cjorbot= 0.9200
 .param sg13g2_lv_pmos_cjorsti= 0.9200
 .param sg13g2_lv_pmos_cjorgat= 0.9200
+.param sg13g2_lv_pmos_delvto_mm = 0
+.param sg13g2_lv_pmos_factuo_mm = 0
+.param sg13g2_lv_pmos_dw_mm     = 0
+.param sg13g2_lv_pmos_dl_mm     = 0
+
 
 .param sg13g2_lv_svaricap_lap   = 1.24
 .param sg13g2_lv_svaricap_toxo  = 0.96
@@ -269,6 +349,10 @@
 .param sg13g2_lv_nmos_cjorbot= 1.0400
 .param sg13g2_lv_nmos_cjorsti= 1.0400
 .param sg13g2_lv_nmos_cjorgat= 1.0400
+.param sg13g2_lv_nmos_delvto_mm = 0
+.param sg13g2_lv_nmos_factuo_mm = 0
+.param sg13g2_lv_nmos_dw_mm     = 0
+.param sg13g2_lv_nmos_dl_mm     = 0
 
 .param sg13g2_lv_pmos_vfbo_mm= 1.0
 .param sg13g2_lv_pmos_ctl    = 2.2185
@@ -287,6 +371,11 @@
 .param sg13g2_lv_pmos_cjorbot= 0.9600
 .param sg13g2_lv_pmos_cjorsti= 0.9600
 .param sg13g2_lv_pmos_cjorgat= 0.9600
+.param sg13g2_lv_pmos_delvto_mm = 0
+.param sg13g2_lv_pmos_factuo_mm = 0
+.param sg13g2_lv_pmos_dw_mm     = 0
+.param sg13g2_lv_pmos_dl_mm     = 0
+
 
 .param sg13g2_lv_svaricap_lap   = 1.161
 .param sg13g2_lv_svaricap_toxo  = 0.98
@@ -314,6 +403,10 @@
 .param sg13g2_lv_nmos_cjorbot= 0.9600
 .param sg13g2_lv_nmos_cjorsti= 0.9600
 .param sg13g2_lv_nmos_cjorgat= 0.9600
+.param sg13g2_lv_nmos_delvto_mm = 0
+.param sg13g2_lv_nmos_factuo_mm = 0
+.param sg13g2_lv_nmos_dw_mm     = 0
+.param sg13g2_lv_nmos_dl_mm     = 0
 
 .param sg13g2_lv_pmos_vfbo_mm= 1.0
 .param sg13g2_lv_pmos_ctl    = 1.6545
@@ -332,6 +425,11 @@
 .param sg13g2_lv_pmos_cjorbot= 1.0400
 .param sg13g2_lv_pmos_cjorsti= 1.0400
 .param sg13g2_lv_pmos_cjorgat= 1.0400
+.param sg13g2_lv_pmos_delvto_mm = 0
+.param sg13g2_lv_pmos_factuo_mm = 0
+.param sg13g2_lv_pmos_dw_mm     = 0
+.param sg13g2_lv_pmos_dl_mm     = 0
+
 
 .param sg13g2_lv_svaricap_lap   = 1.041
 .param sg13g2_lv_svaricap_toxo  = 1.02

--- a/ihp-sg13g2/libs.tech/xyce/models/sg13g2_moslv_mod.lib
+++ b/ihp-sg13g2/libs.tech/xyce/models/sg13g2_moslv_mod.lib
@@ -63,7 +63,7 @@
 *
 
 .subckt sg13_lv_nmos d g s b
-+ w=0.35u l=0.34u ng=1 m=1 as=0 ad=0 pd=0 ps=0 trise=0 z1=0.34e-6 z2=0.38e-6 wmin=0.15e-6 rfmode=0 pre_layout=1
++ w=0.35u l=0.34u ng=1 m=1 mm_ok=1 as=0 ad=0 pd=0 ps=0 trise=0 z1=0.34e-6 z2=0.38e-6 wmin=0.15e-6 rfmode=0 pre_layout=1
 * if as = 0, calculate value, else take it
 * if as is given externally, no adjustment for ng is done! -> must be done in the extractor
 * if ng>1 and as=0 (in schematic) recalculate!
@@ -71,21 +71,31 @@
 * include the model parameters
 .include sg13g2_moslv_parm.lib
 
-YPSP103_VA M1 d g s b sg13g2_lv_nmos_psp w='w' l='l' nf='ng' as='as' ad='ad' pd='pd' ps='ps' mult='m'
+YPSP103_VA M1 d g s b sg13g2_lv_nmos_psp 
++ w={AGAUSS(w, sg13g2_lv_nmos_dw_mm, 1)}
++ l={AGAUSS(l, sg13g2_lv_nmos_dl_mm, 1)}
++ nf='ng' as='as' ad='ad' pd='pd' ps='ps' mult='m'
 + dta=trise
 + ngcon=2
++ delvto={AGAUSS(0, sg13g2_lv_nmos_delvto_mm/sqrt(m*l*w*1e12), 1)}
++ factuo={AGAUSS(1, sg13g2_lv_nmos_factuo_mm/sqrt(m*l*w*1e12), 1)}
 .ends
 
 
 .subckt sg13_lv_pmos d g s b
-+ w=0.35u l=0.28u ng=1 m=1 as=0 ad=0 pd=0 ps=0 trise=0 z1=0.34e-6 z2=0.38e-6 wmin=0.15e-6 rfmode=0 pre_layout=1
++ w=0.35u l=0.28u ng=1 m=1 mm_ok=1 as=0 ad=0 pd=0 ps=0 trise=0 z1=0.34e-6 z2=0.38e-6 wmin=0.15e-6 rfmode=0 pre_layout=1
 
 * include the model parameters
 .include sg13g2_moslv_parm.lib
 
-YPSP103_VA M1 d g s b sg13g2_lv_pmos_psp w='w' l='l' nf='ng' as='as' ad='ad' pd='pd' ps='ps' mult='m'
+YPSP103_VA M1 d g s b sg13g2_lv_pmos_psp 
++ w={AGAUSS(w, sg13g2_lv_pmos_dw_mm, 1)}
++ l={AGAUSS(l, sg13g2_lv_pmos_dl_mm, 1)}
++ nf='ng' as='as' ad='ad' pd='pd' ps='ps' mult='m'
 + dta=trise
 + ngcon=2
++ delvto={AGAUSS(0, sg13g2_lv_pmos_delvto_mm/sqrt(m*l*w*1e12), 1)}
++ factuo={AGAUSS(1, sg13g2_lv_pmos_factuo_mm/sqrt(m*l*w*1e12), 1)}
 .ends
 
 

--- a/ihp-sg13g2/libs.tech/xyce/models/sg13g2_moslv_parm.lib
+++ b/ihp-sg13g2/libs.tech/xyce/models/sg13g2_moslv_parm.lib
@@ -66,11 +66,11 @@
 + swign         =  1.0                         qmc           =  1.0                         lvaro         =  0.0
 + lvarl         =  0.0                         lvarw         =  0.0                         lap           =  2.9423e-08
 + wvaro         =  0.0                         wvarl         =  0.0                         wvarw         =  0.0
-+ wot           = -1e-08                       dlq           = '-1.3721e-08 -((1-pre_layout)*2e-08 )+rfmode*(-1.5368e-08 +(ng<3 ? 4e-08 : 0) )' dwq           = '-1e-08 +rfmode*(4.8062e-07 )'
-+ vfbo          = '-0.94312*(1+(sg13g2_lv_nmos_vfbo_mm-1)/sqrt(m*l*w*1e12)) '             vfbl          =  0.013965                    vfbw          = -0.027122
++ wot           = -1e-08                       dlq           = {-1.3721e-08 -((1-pre_layout)*2e-08 )+rfmode*(-1.5368e-08 +((ng<3)*4e-08) )} dwq           = {-1e-08 +rfmode*(4.8062e-07 )}
++ vfbo = {-0.94312*sg13g2_lv_nmos_vfbo_mm}            vfbl          =  0.013965                    vfbw          = -0.027122
 + vfblw         =  0.0044814                   stvfbo        =  0.00068785                  stvfbl        =  2.8624e-05
 + stvfbw        = -1.8689e-05                  stvfblw       =  5.1435e-07                  st2vfbo       =  0.0
-+ toxo          =  '2.2404e-09*sg13g2_lv_nmos_toxo'                                           epsroxo       =  3.9                         nsubo         =  1.0483e+23
++ toxo          =  {2.2404e-09*sg13g2_lv_nmos_toxo}                                           epsroxo       =  3.9                         nsubo         =  1.0483e+23
 + nsubw         =  7.5708                      wseg          =  5.3426e-06                  npck          =  1.743e+21
 + npckw         = -1.484                       wsegp         =  1e-08                       lpck          =  3.171e-07
 + lpckw         =  0.0                         fol1          = -0.0091066                   fol2          =  0.0021139
@@ -78,14 +78,14 @@
 + facneffaclw   =  0.0                         gfacnudo      =  1.0                         gfacnudl      =  0.0
 + gfacnudlexp   =  1.0                         gfacnudw      =  0.0                         gfacnudlw     =  0.0
 + vsbnudo       =  0.0                         dvsbnudo      =  1.0                         vnsubo        =  0.0
-+ nslpo         =  0.05                        dnsubo        =  4.4409e-16                  dphibo        = '-0.25737*sg13g2_lv_nmos_dphibo'
-+ dphibl        =  '0.24027*sg13g2_lv_nmos_dphibl'                                            dphiblexp     =  0.068979                    dphibw        =  '0.0168*sg13g2_lv_nmos_dphibw'
-+ dphiblw       = '-0.0036959*sg13g2_lv_nmos_dphiblw'                                         delvtaco      =  0.0                         delvtacl      =  0.0
++ nslpo         =  0.05                        dnsubo        =  4.4409e-16                  dphibo        = {-0.25737*sg13g2_lv_nmos_dphibo}
++ dphibl        =  {0.24027*sg13g2_lv_nmos_dphibl}                                            dphiblexp     =  0.068979                    dphibw        =  {0.0168*sg13g2_lv_nmos_dphibw}
++ dphiblw       = {-0.0036959*sg13g2_lv_nmos_dphiblw}                                         delvtaco      =  0.0                         delvtacl      =  0.0
 + delvtaclexp   =  1.0                         delvtacw      =  0.0                         delvtaclw     =  0.0
-+ npo           =  4.6457e+26                  npl           =  0.0                         toxovo        =  '2.2404e-09*sg13g2_lv_nmos_toxovo'
-+ toxovdo       =  2e-09                       lov           =  '2.9423e-08 -((1-pre_layout)*9e-09 )'                                      lovd          =  0.0
++ npo           =  4.6457e+26                  npl           =  0.0                         toxovo        =  {2.2404e-09*sg13g2_lv_nmos_toxovo}
++ toxovdo       =  2e-09                       lov           =  {2.9423e-08 -((1-pre_layout)*9e-09 )}                                      lovd          =  0.0
 + novo          =  3.5714e+25                  novdo         =  5e+25                       cto           =  0.054556
-+ ctl           =  '0.015058*sg13g2_lv_nmos_ctl' ctlexp        =  0.85719                     ctw           = -0.096878
++ ctl           =  {0.015058*sg13g2_lv_nmos_ctl} ctlexp        =  0.85719                     ctw           = -0.096878
 + ctlw          =  0.008767                    ctgo          =  0.0                         ctbo          =  0.0
 + stcto         =  1.0                         cfl           =  8.9001e-08                  cflexp        =  3.9688
 + cfw           = -0.17956                     cfbo          =  0.6952                      cfdo          =  0.0
@@ -95,16 +95,16 @@
 + lp1w          = -0.1544                      fbet2         = -2.302                       lp2           =  1.9441e-08
 + betw1         = -0.020925                    betw2         =  0.0087681                   wbet          =  5.9171e-08
 + stbeto        =  2.4165                      stbetl        = -0.036997                    stbetw        =  0.0046613
-+ stbetlw       =  0.0062828                   mueo          =  0.77874                     muew          =  '0.030943*sg13g2_lv_nmos_muew '
-+ stmueo        =  0.98971                     themuo        =  '2.0546*sg13g2_lv_nmos_themuo'                                             stthemuo      =  4.441e-15
++ stbetlw       =  0.0062828                   mueo          =  0.77874                     muew          =  {0.030943*sg13g2_lv_nmos_muew }
++ stmueo        =  0.98971                     themuo        =  {2.0546*sg13g2_lv_nmos_themuo}                                             stthemuo      =  4.441e-15
 + cso           =  0.3164                      csl           =  0.12341                     cslexp        =  1.1398
 + csw           =  0.19805                     cslw          = -0.00044184                  stcso         =  2.9406
 + thecso        =  1.1822                      stthecso      =  0.0                         xcoro         =  0.053934
 + xcorl         = -0.11292                     xcorw         = -0.10913                     xcorlw        = -0.014959
-+ stxcoro       =  2.0                         fetao         =  1.0                         rsw1          =  '130.0*sg13g2_lv_nmos_rsw1'
++ stxcoro       =  2.0                         fetao         =  1.0                         rsw1          =  {130.0*sg13g2_lv_nmos_rsw1}
 + rsw2          =  0.0                         strso         = -0.49693                     rsbo          = -0.099725
-+ rsgo          =  0.074518                    thesato       =  0.39843                     thesatl       =  '0.43388*sg13g2_lv_nmos_thesatl'
-+ thesatlexp    =  1.0316                      thesatw       =  '0.12825*sg13g2_lv_nmos_thesatw'                                           thesatlw      = '-0.0044*sg13g2_lv_nmos_thesatlw'
++ rsgo          =  0.074518                    thesato       =  0.39843                     thesatl       =  {0.43388*sg13g2_lv_nmos_thesatl}
++ thesatlexp    =  1.0316                      thesatw       =  {0.12825*sg13g2_lv_nmos_thesatw}                                           thesatlw      = {-0.0044*sg13g2_lv_nmos_thesatlw}
 + stthesato     =  2.7784                      stthesatl     = -0.091893                    stthesatw     = -0.065908
 + stthesatlw    =  0.01292                     thesatbo      =  0.08213                     thesatgo      =  0.1146
 + axo           =  13.547                      axl           =  1.0186                      alpl          =  0.0088345
@@ -115,7 +115,7 @@
 + a1l           =  0.052176                    a1w           = -0.052179                    a2o           =  17.75
 + sta2o         =  0.068723                    a3o           =  0.708                       a3l           = -0.045201
 + a3w           = -0.041992                    a4o           =  0.04649                     a4l           =  0.0
-+ a4w           =  1.581e-16                   gcoo          =  10.0                        iginvlw       =  '121290.0 *(1+2.4761e-07 /l)*(1+-2.1167e-08 /w)'
++ a4w           =  1.581e-16                   gcoo          =  10.0                        iginvlw       =  {121290.0 *(1+2.4761e-07 /l)*(1+-2.1167e-08 /w)}
 + igovw         =  3026.8                      igovdw        =  0.0                         stigo         =  2.9949
 + gc2o          =  0.8413                      gc3o          = -0.4698                      chibo         =  3.1
 + agidlw        =  0.001262                    agidldw       =  0.0                         bgidlo        =  19.92
@@ -149,8 +149,8 @@
 + kvthowel      =  0.0                         kvthowew      =  0.0                         kvthowelw     =  0.0
 + kuoweo        =  0.0                         kuowel        =  0.0                         kuowew        =  0.0
 + kuowelw       =  0.0                         trj           =  21.0                        swjunexp      =  0.0
-+ imax          =  0.0015358                   frev          =  1000.0                      cjorbot       =  '0.00097636*sg13g2_lv_nmos_cjorbot'
-+ cjorsti       =  '2.5279e-11*sg13g2_lv_nmos_cjorsti'                                        cjorgat       =  '3e-11*sg13g2_lv_nmos_cjorgat'                                             vbirbot       =  0.70829
++ imax          =  0.0015358                   frev          =  1000.0                      cjorbot       =  {0.00097636*sg13g2_lv_nmos_cjorbot}
++ cjorsti       =  {2.5279e-11*sg13g2_lv_nmos_cjorsti}                                        cjorgat       =  {3e-11*sg13g2_lv_nmos_cjorgat}                                             vbirbot       =  0.70829
 + vbirsti       =  0.79368                     vbirgat       =  2.0                         pbot          =  0.31309
 + psti          =  0.27362                     pgat          =  0.5424                      cjorbotd      =  0.001
 + cjorstid      =  1e-09                       cjorgatd      =  1e-09                       vbirbotd      =  1.0
@@ -181,11 +181,12 @@
 + fjunqd        =  0.03                        rint          =  1.3025e-11
 + rvpoly        =  0.0                         dlsil         =  0.0
 + rsh           =  0.0                         rshd          =  0.0
-+ munqso        =  1.0
-+ swnqs         =  'rfmode * 5.0'                cfrw          =  '((1-rfmode)*2e-16 + rfmode * (1e-18 + pre_layout * (ng>0 ? 3.8525e-17 : 0)))/ng'
-+ rshg          =  'rfmode * 3.0'                rgo           =  'rfmode * 40.0'
-+ rbulko        =  'rfmode * 0.002 * ng/w'       rwello        =  'rfmode * 0.002 * ng/w'
-+ rjunso        =  'rfmode * 5000.0 * l/w'       rjundo        =  'rfmode * 5000.0 * l/w'
+*+ munqso        =  1.0
+*+ swnqs         =  {rfmode * 5.0}                
++ cfrw          =  {((1-rfmode)*2e-16 + rfmode * (1e-18 + pre_layout * ((ng>0)*3.8525e-17)))/ng}
++ rshg          =  {rfmode * 3.0}                rgo           =  {rfmode * 40.0}
++ rbulko        =  {rfmode * 0.002 * ng/w}       rwello        =  {rfmode * 0.002 * ng/w}
++ rjunso        =  {rfmode * 5000.0 * l/w}       rjundo        =  {rfmode * 5000.0 * l/w}
 
 *******************************************************************************
 *
@@ -216,11 +217,11 @@
 + swign         =  1.0                         qmc           =  1.0                         lvaro         =  9.695e-08
 + lvarl         = -0.03438                     lvarw         =  0.0                         lap           =  2.5254e-08
 + wvaro         =  0.0                         wvarl         =  0.0                         wvarw         =  0.0
-+ wot           =  1.5e-08                     dlq           = '-9.5922e-08 -((1-pre_layout)*3e-08 )+rfmode*(-2e-08 +(ng<3 ? 3.3917e-08 : 0) )' dwq           =  '1.5e-08 +rfmode*(4.7599e-07 )'
-+ vfbo          = '-0.88703*(1+(sg13g2_lv_pmos_vfbo_mm-1)/sqrt(m*l*w*1e12))'              vfbl          =  0.0089886                   vfbw          =  0.0071805
++ wot           =  1.5e-08                     dlq           = {-9.5922e-08 -((1-pre_layout)*3e-08 )+rfmode*(-2e-08 +(ng<3 ? 3.3917e-08 : 0) )} dwq           =  {1.5e-08 +rfmode*(4.7599e-07 )}
++ vfbo = {-0.88703*sg13g2_lv_pmos_vfbo_mm}              vfbl          =  0.0089886                   vfbw          =  0.0071805
 + vfblw         =  0.004075                    stvfbo        =  0.00075111                  stvfbl        =  2.4487e-06
 + stvfbw        =  6.217e-06                   stvfblw       =  2.2668e-07                  st2vfbo       =  0.0
-+ toxo          =  '1.9704e-09*sg13g2_lv_pmos_toxo'                                           epsroxo       =  3.9                         nsubo         =  4.6011e+23
++ toxo          =  {1.9704e-09*sg13g2_lv_pmos_toxo}                                           epsroxo       =  3.9                         nsubo         =  4.6011e+23
 + nsubw         = -0.013639                    wseg          =  1.058e-08                   npck          =  5.7416e+24
 + npckw         = -1.0                         wsegp         =  1e-10                       lpck          =  1.1576e-10
 + lpckw         = -0.022414                    fol1          = -0.0081173                   fol2          =  0.0081347
@@ -228,14 +229,14 @@
 + facneffaclw   =  0.0                         gfacnudo      =  1.0                         gfacnudl      =  0.0
 + gfacnudlexp   =  1.0                         gfacnudw      =  0.0                         gfacnudlw     =  0.0
 + vsbnudo       =  0.0                         dvsbnudo      =  1.0                         vnsubo        =  0.0
-+ nslpo         =  0.05                        dnsubo        =  0.039707                    dphibo        = '-0.099209*sg13g2_lv_pmos_dphibo'
-+ dphibl        =  '0.00020745*sg13g2_lv_pmos_dphibl'                                         dphiblexp     =  2.9957                      dphibw        = '-0.00069395*sg13g2_lv_pmos_dphibw'
-+ dphiblw       = '-0.0030829*sg13g2_lv_pmos_dphiblw'                                         delvtaco      =  0.0                         delvtacl      =  0.0
++ nslpo         =  0.05                        dnsubo        =  0.039707                    dphibo        = {-0.099209*sg13g2_lv_pmos_dphibo}
++ dphibl        =  {0.00020745*sg13g2_lv_pmos_dphibl}                                         dphiblexp     =  2.9957                      dphibw        = {-0.00069395*sg13g2_lv_pmos_dphibw}
++ dphiblw       = {-0.0030829*sg13g2_lv_pmos_dphiblw}                                         delvtaco      =  0.0                         delvtacl      =  0.0
 + delvtaclexp   =  1.0                         delvtacw      =  0.0                         delvtaclw     =  0.0
-+ npo           =  1.2699e+26                  npl           = -0.095923                    toxovo        =  '1.9704e-09*sg13g2_lv_pmos_toxovo'
-+ toxovdo       =  2e-09                       lov           =  '2.5254e-08 -((1-pre_layout)*8.85e-09 ) '                                  lovd          =  0.0
++ npo           =  1.2699e+26                  npl           = -0.095923                    toxovo        =  {1.9704e-09*sg13g2_lv_pmos_toxovo}
++ toxovdo       =  2e-09                       lov           =  {2.5254e-08 -((1-pre_layout)*8.85e-09 ) }                                  lovd          =  0.0
 + novo          =  3.104e+25                   novdo         =  5e+25                       cto           =  1.1814e-05
-+ ctl           =  '0.0069387*sg13g2_lv_pmos_ctl'                                             ctlexp        =  1.4316                      ctw           =  0.36122
++ ctl           =  {0.0069387*sg13g2_lv_pmos_ctl}                                             ctlexp        =  1.4316                      ctw           =  0.36122
 + ctlw          = -0.014902                    ctgo          =  0.0                         ctbo          =  0.0
 + stcto         =  1.0                         cfl           =  0.00011247                  cflexp        =  3.0355
 + cfw           = -0.012199                    cfbo          =  0.57877                     cfdo          =  0.0
@@ -245,16 +246,16 @@
 + lp1w          =  0.0                         fbet2         = -6.171                       lp2           =  1.2564e-08
 + betw1         = -0.3268                      betw2         =  0.060181                    wbet          =  5.424e-10
 + stbeto        =  1.6974                      stbetl        = -0.037605                    stbetw        = -0.0083384
-+ stbetlw       =  0.0013663                   mueo          =  2.3326                      muew          = '-0.067414*sg13g2_lv_pmos_muew'
-+ stmueo        =  0.84805                     themuo        =  '1.3169*sg13g2_lv_pmos_themuo'                                             stthemuo      =  4.441e-15
++ stbetlw       =  0.0013663                   mueo          =  2.3326                      muew          = {-0.067414*sg13g2_lv_pmos_muew}
++ stmueo        =  0.84805                     themuo        =  {1.3169*sg13g2_lv_pmos_themuo}                                             stthemuo      =  4.441e-15
 + cso           =  0.94214                     csl           =  0.34682                     cslexp        =  1.5813
 + csw           = -0.11045                     cslw          =  0.014762                    stcso         =  1.0269
 + thecso        =  1.4566                      stthecso      =  0.0                         xcoro         =  0.092591
 + xcorl         =  0.11698                     xcorw         = -0.095907                    xcorlw        =  0.029574
-+ stxcoro       =  2.7756e-17                  fetao         =  1.0                         rsw1          =  '697.38*sg13g2_lv_pmos_rsw1'
++ stxcoro       =  2.7756e-17                  fetao         =  1.0                         rsw1          =  {697.38*sg13g2_lv_pmos_rsw1}
 + rsw2          = -0.088444                    strso         = -0.3508                      rsbo          =  0.06
-+ rsgo          =  0.495                       thesato       =  0.099164                    thesatl       =  '0.010142*sg13g2_lv_pmos_thesatl'
-+ thesatlexp    =  2.4434                      thesatw       = '-0.13745*sg13g2_lv_pmos_thesatw'                                           thesatlw      = '-0.103*sg13g2_lv_pmos_thesatlw'
++ rsgo          =  0.495                       thesato       =  0.099164                    thesatl       =  {0.010142*sg13g2_lv_pmos_thesatl}
++ thesatlexp    =  2.4434                      thesatw       = {-0.13745*sg13g2_lv_pmos_thesatw}                                           thesatlw      = {-0.103*sg13g2_lv_pmos_thesatlw}
 + stthesato     =  12.733                      stthesatl     = -1.9651                      stthesatw     = -0.047465
 + stthesatlw    =  0.07117                     thesatbo      =  0.0                         thesatgo      =  0.0
 + axo           =  8.1825                      axl           =  0.58095                     alpl          =  0.0047346
@@ -265,7 +266,7 @@
 + a1l           =  5.741                       a1w           =  5.78                        a2o           =  13.33
 + sta2o         =  2.0                         a3o           =  1.526                       a3l           = -0.08391
 + a3w           = -0.004911                    a4o           = -0.005545                    a4l           =  0.2771
-+ a4w           =  0.7101                      gcoo          =  0.01231                     iginvlw       =  '4880.4 *(1+-5.803e-09 /l)*(1+5.1659e-08 /w)'
++ a4w           =  0.7101                      gcoo          =  0.01231                     iginvlw       =  {4880.4 *(1+-5.803e-09 /l)*(1+5.1659e-08 /w)}
 + igovw         =  1327.0                      igovdw        =  0.0                         stigo         =  2.3506
 + gc2o          =  0.54762                     gc3o          = -0.29543                     chibo         =  3.1
 + agidlw        =  7.371e-05                   agidldw       =  0.0                         bgidlo        =  15.12
@@ -299,8 +300,8 @@
 + kvthowel      =  0.0                         kvthowew      =  0.0                         kvthowelw     =  0.0
 + kuoweo        =  0.0                         kuowel        =  0.0                         kuowew        =  0.0
 + kuowelw       =  0.0                         trj           =  21.0                        swjunexp      =  0.0
-+ imax          =  0.0016551                   frev          =  1000.0                      cjorbot       =  '0.00086306*sg13g2_lv_pmos_cjorbot'
-+ cjorsti       =  '3.1915e-11*sg13g2_lv_pmos_cjorsti'                                        cjorgat       =  '2.7474e-11*sg13g2_lv_pmos_cjorgat'                                        vbirbot       =  0.7686
++ imax          =  0.0016551                   frev          =  1000.0                      cjorbot       =  {0.00086306*sg13g2_lv_pmos_cjorbot}
++ cjorsti       =  {3.1915e-11*sg13g2_lv_pmos_cjorsti}                                        cjorgat       =  {2.7474e-11*sg13g2_lv_pmos_cjorgat}                                        vbirbot       =  0.7686
 + vbirsti       =  1.7036                      vbirgat       =  1.399                       pbot          =  0.3618
 + psti          =  0.2548                      pgat          =  0.6475                      cjorbotd      =  0.001
 + cjorstid      =  1e-09                       cjorgatd      =  1e-09                       vbirbotd      =  1.0
@@ -331,11 +332,12 @@
 + fjunqd        =  0.03                        rint          =  1e-12
 + rvpoly        =  0.0                         dlsil         =  0.0
 + rsh           =  0.0                         rshd          =  0.0
-+ munqso        =  1.0
-+ swnqs         =  'rfmode * 5.0'                cfrw          =  '(1e-16 + rfmode * (1e-18 + pre_layout * (ng>0 ? 1.2382e-16 : 0)))/ng'
-+ rshg          =  'rfmode * 20.0'               rgo           =  'rfmode * 22.0'
-+ rbulko        =  'rfmode * 0.002 * ng/w'       rwello        =  'rfmode * 0.001 * ng/w'
-+ rjunso        =  'rfmode * 5000.0 * l/w'       rjundo        =  'rfmode * 5000.0 * l/w'
+*+ munqso        =  1.0
+*+ swnqs         =  {rfmode * 5.0}                
++ cfrw          =  {(1e-16 + rfmode * (1e-18 + pre_layout * ((ng>0)*1.2382e-16)))/ng}
++ rshg          =  {rfmode * 20.0}               rgo           =  {rfmode * 22.0}
++ rbulko        =  {rfmode * 0.002 * ng/w}       rwello        =  {rfmode * 0.001 * ng/w}
++ rjunso        =  {rfmode * 5000.0 * l/w}       rjundo        =  {rfmode * 5000.0 * l/w}
 
 
 
@@ -347,11 +349,11 @@
 + swign         =  1.0                         qmc           =  1.0                         lvaro         =  0.0
 + lvarl         =  0.0                         lvarw         =  0.0                         lap           =  2.9423e-08
 + wvaro         =  0.0                         wvarl         =  0.0                         wvarw         =  0.0
-+ wot           = -1e-08                       dlq           = '-1.3721e-08 -((1-pre_layout)*2e-08 )+rfmode*(-1.5368e-08 +(ng<3 ? 4e-08 : 0) )' dwq           = '-1e-08 +rfmode*(4.8062e-07 )'
-+ vfbo          = '-0.94312*(1+(sg13g2_lv_nmos_vfbo_mm-1)/sqrt(m*l*w*1e12)) '             vfbl          =  0.013965                    vfbw          = -0.027122
++ wot           = -1e-08                       dlq           = {-1.3721e-08 -((1-pre_layout)*2e-08 )+rfmode*(-1.5368e-08 +((ng<3)*4e-08) )} dwq           = {-1e-08 +rfmode*(4.8062e-07 )}
++ vfbo = {-0.94312*sg13g2_lv_nmos_vfbo_mm}            vfbl          =  0.013965                    vfbw          = -0.027122
 + vfblw         =  0.0044814                   stvfbo        =  0.00068785                  stvfbl        =  2.8624e-05
 + stvfbw        = -1.8689e-05                  stvfblw       =  5.1435e-07                  st2vfbo       =  0.0
-+ toxo          =  '2.2404e-09*sg13g2_lv_nmos_toxo'                                           epsroxo       =  3.9                         nsubo         =  1.0483e+23
++ toxo          =  {2.2404e-09*sg13g2_lv_nmos_toxo}                                           epsroxo       =  3.9                         nsubo         =  1.0483e+23
 + nsubw         =  7.5708                      wseg          =  5.3426e-06                  npck          =  1.743e+21
 + npckw         = -1.484                       wsegp         =  1e-08                       lpck          =  3.171e-07
 + lpckw         =  0.0                         fol1          = -0.0091066                   fol2          =  0.0021139
@@ -359,14 +361,14 @@
 + facneffaclw   =  0.0                         gfacnudo      =  1.0                         gfacnudl      =  0.0
 + gfacnudlexp   =  1.0                         gfacnudw      =  0.0                         gfacnudlw     =  0.0
 + vsbnudo       =  0.0                         dvsbnudo      =  1.0                         vnsubo        =  0.0
-+ nslpo         =  0.05                        dnsubo        =  4.4409e-16                  dphibo        = '-0.25737*sg13g2_lv_nmos_dphibo'
-+ dphibl        =  '0.24027*sg13g2_lv_nmos_dphibl'                                            dphiblexp     =  0.068979                    dphibw        =  '0.0168*sg13g2_lv_nmos_dphibw'
-+ dphiblw       = '-0.0036959*sg13g2_lv_nmos_dphiblw'                                         delvtaco      =  0.0                         delvtacl      =  0.0
++ nslpo         =  0.05                        dnsubo        =  4.4409e-16                  dphibo        = {-0.25737*sg13g2_lv_nmos_dphibo}
++ dphibl        =  {0.24027*sg13g2_lv_nmos_dphibl}                                            dphiblexp     =  0.068979                    dphibw        =  {0.0168*sg13g2_lv_nmos_dphibw}
++ dphiblw       = {-0.0036959*sg13g2_lv_nmos_dphiblw}                                         delvtaco      =  0.0                         delvtacl      =  0.0
 + delvtaclexp   =  1.0                         delvtacw      =  0.0                         delvtaclw     =  0.0
-+ npo           =  4.6457e+26                  npl           =  0.0                         toxovo        =  '2.2404e-09*sg13g2_lv_nmos_toxovo'
-+ toxovdo       =  2e-09                       lov           =  '2.9423e-08 -((1-pre_layout)*9e-09 )'                                      lovd          =  0.0
++ npo           =  4.6457e+26                  npl           =  0.0                         toxovo        =  {2.2404e-09*sg13g2_lv_nmos_toxovo}
++ toxovdo       =  2e-09                       lov           =  {2.9423e-08 -((1-pre_layout)*9e-09 )}                                      lovd          =  0.0
 + novo          =  3.5714e+25                  novdo         =  5e+25                       cto           =  0.054556
-+ ctl           =  '0.015058*sg13g2_lv_nmos_ctl' ctlexp        =  0.85719                     ctw           = -0.096878
++ ctl           =  {0.015058*sg13g2_lv_nmos_ctl} ctlexp        =  0.85719                     ctw           = -0.096878
 + ctlw          =  0.008767                    ctgo          =  0.0                         ctbo          =  0.0
 + stcto         =  1.0                         cfl           =  8.9001e-08                  cflexp        =  3.9688
 + cfw           = -0.17956                     cfbo          =  0.6952                      cfdo          =  0.0
@@ -376,16 +378,16 @@
 + lp1w          = -0.1544                      fbet2         = -2.302                       lp2           =  1.9441e-08
 + betw1         = -0.020925                    betw2         =  0.0087681                   wbet          =  5.9171e-08
 + stbeto        =  2.4165                      stbetl        = -0.036997                    stbetw        =  0.0046613
-+ stbetlw       =  0.0062828                   mueo          =  0.77874                     muew          =  '0.030943*sg13g2_lv_nmos_muew '
-+ stmueo        =  0.98971                     themuo        =  '2.0546*sg13g2_lv_nmos_themuo'                                             stthemuo      =  4.441e-15
++ stbetlw       =  0.0062828                   mueo          =  0.77874                     muew          =  {0.030943*sg13g2_lv_nmos_muew }
++ stmueo        =  0.98971                     themuo        =  {2.0546*sg13g2_lv_nmos_themuo}                                             stthemuo      =  4.441e-15
 + cso           =  0.3164                      csl           =  0.12341                     cslexp        =  1.1398
 + csw           =  0.19805                     cslw          = -0.00044184                  stcso         =  2.9406
 + thecso        =  1.1822                      stthecso      =  0.0                         xcoro         =  0.053934
 + xcorl         = -0.11292                     xcorw         = -0.10913                     xcorlw        = -0.014959
-+ stxcoro       =  2.0                         fetao         =  1.0                         rsw1          =  '130.0*sg13g2_lv_nmos_rsw1'
++ stxcoro       =  2.0                         fetao         =  1.0                         rsw1          =  {130.0*sg13g2_lv_nmos_rsw1}
 + rsw2          =  0.0                         strso         = -0.49693                     rsbo          = -0.099725
-+ rsgo          =  0.074518                    thesato       =  0.39843                     thesatl       =  '0.43388*sg13g2_lv_nmos_thesatl'
-+ thesatlexp    =  1.0316                      thesatw       =  '0.12825*sg13g2_lv_nmos_thesatw'                                           thesatlw      = '-0.0044*sg13g2_lv_nmos_thesatlw'
++ rsgo          =  0.074518                    thesato       =  0.39843                     thesatl       =  {0.43388*sg13g2_lv_nmos_thesatl}
++ thesatlexp    =  1.0316                      thesatw       =  {0.12825*sg13g2_lv_nmos_thesatw}                                           thesatlw      = {-0.0044*sg13g2_lv_nmos_thesatlw}
 + stthesato     =  2.7784                      stthesatl     = -0.091893                    stthesatw     = -0.065908
 + stthesatlw    =  0.01292                     thesatbo      =  0.08213                     thesatgo      =  0.1146
 + axo           =  13.547                      axl           =  1.0186                      alpl          =  0.0088345
@@ -396,7 +398,7 @@
 + a1l           =  0.052176                    a1w           = -0.052179                    a2o           =  17.75
 + sta2o         =  0.068723                    a3o           =  0.708                       a3l           = -0.045201
 + a3w           = -0.041992                    a4o           =  0.04649                     a4l           =  0.0
-+ a4w           =  1.581e-16                   gcoo          =  10.0                        iginvlw       =  '121290.0 *(1+2.4761e-07 /l)*(1+-2.1167e-08 /w)'
++ a4w           =  1.581e-16                   gcoo          =  10.0                        iginvlw       =  {121290.0 *(1+2.4761e-07 /l)*(1+-2.1167e-08 /w)}
 + igovw         =  3026.8                      igovdw        =  0.0                         stigo         =  2.9949
 + gc2o          =  0.8413                      gc3o          = -0.4698                      chibo         =  3.1
 + agidlw        =  0.001262                    agidldw       =  0.0                         bgidlo        =  19.92
@@ -430,8 +432,8 @@
 + kvthowel      =  0.0                         kvthowew      =  0.0                         kvthowelw     =  0.0
 + kuoweo        =  0.0                         kuowel        =  0.0                         kuowew        =  0.0
 + kuowelw       =  0.0                         trj           =  21.0                        swjunexp      =  0.0
-+ imax          =  0.0015358                   frev          =  1000.0                      cjorbot       =  '0.00097636*sg13g2_lv_nmos_cjorbot'
-+ cjorsti       =  '2.5279e-11*sg13g2_lv_nmos_cjorsti'                                        cjorgat       =  '3e-11*sg13g2_lv_nmos_cjorgat'                                             vbirbot       =  0.70829
++ imax          =  0.0015358                   frev          =  1000.0                      cjorbot       =  {0.00097636*sg13g2_lv_nmos_cjorbot}
++ cjorsti       =  {2.5279e-11*sg13g2_lv_nmos_cjorsti}                                        cjorgat       =  {3e-11*sg13g2_lv_nmos_cjorgat}                                             vbirbot       =  0.70829
 + vbirsti       =  0.79368                     vbirgat       =  2.0                         pbot          =  0.31309
 + psti          =  0.27362                     pgat          =  0.5424                      cjorbotd      =  0.001
 + cjorstid      =  1e-09                       cjorgatd      =  1e-09                       vbirbotd      =  1.0
@@ -462,8 +464,9 @@
 + fjunqd        =  0.03                        rint          =  1.3025e-11
 + rvpoly        =  0.0                         dlsil         =  0.0
 + rsh           =  0.0                         rshd          =  0.0
-+ munqso        =  1.0
-+ swnqs         =  'rfmode * 5.0'                cfrw          =  '((1-rfmode)*2e-16 + rfmode * (1e-18 + pre_layout * (ng>0 ? 3.8525e-17 : 0)))/ng'
-+ rshg          =  'rfmode * 3.0'                rgo           =  'rfmode * 40.0'
-+ rbulko        =  'rfmode * 0.002 * ng/w'       rwello        =  'rfmode * 0.002 * ng/w'
-+ rjunso        =  'rfmode * 5000.0 * l/w'       rjundo        =  'rfmode * 5000.0 * l/w'
+*+ munqso        =  1.0
+*+ swnqs         =  {rfmode * 5.0}                
++ cfrw          =  {((1-rfmode)*2e-16 + rfmode * (1e-18 + pre_layout * ((ng>0)*3.8525e-17)))/ng}
++ rshg          =  {rfmode * 3.0}                rgo           =  {rfmode * 40.0}
++ rbulko        =  {rfmode * 0.002 * ng/w}       rwello        =  {rfmode * 0.002 * ng/w}
++ rjunso        =  {rfmode * 5000.0 * l/w}       rjundo        =  {rfmode * 5000.0 * l/w}

--- a/ihp-sg13g2/libs.tech/xyce/models/sg13g2_moslv_stat.lib
+++ b/ihp-sg13g2/libs.tech/xyce/models/sg13g2_moslv_stat.lib
@@ -6,7 +6,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 *
-*    https://www.apache.org/licenses/LICENSE-2.0
+* https://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,40 +16,52 @@
 *
 *#######################################################################
 
-* ngspice statistical parameters
-.param sg13g2_lv_nmos_vfbo     ='gauss(sg13g2_lv_nmos_vfbo_norm ,    0.01,   mc_ok)'
-.param sg13g2_lv_nmos_toxo     ='gauss(sg13g2_lv_nmos_toxo_norm,     0.0133, mc_ok)'
-.param sg13g2_lv_nmos_dphibo   ='gauss(sg13g2_lv_nmos_dphibo_norm,   0.0656, mc_ok)'
-.param sg13g2_lv_nmos_dphibl   ='gauss(sg13g2_lv_nmos_dphibl_norm,   0.1135, mc_ok)'
-.param sg13g2_lv_nmos_dphibw   ='gauss(sg13g2_lv_nmos_dphibw_norm,   0.1197, mc_ok)'
-.param sg13g2_lv_nmos_dphiblw  ='gauss(sg13g2_lv_nmos_dphiblw_norm,  0.0135, mc_ok)'
-.param sg13g2_lv_nmos_toxovo   ='gauss(sg13g2_lv_nmos_toxovo_norm,   0.0133, mc_ok)'
-.param sg13g2_lv_nmos_ctl      ='gauss(sg13g2_lv_nmos_ctl_norm,      0.1562, mc_ok)'
-.param sg13g2_lv_nmos_muew     ='gauss(sg13g2_lv_nmos_muew_norm,     0.032,  mc_ok)'
-.param sg13g2_lv_nmos_themuo   ='gauss(sg13g2_lv_nmos_themuo_norm,   0.0026, mc_ok)'
-.param sg13g2_lv_nmos_rsw1     ='gauss(sg13g2_lv_nmos_rsw1_norm,     0.0407, mc_ok)'
-.param sg13g2_lv_nmos_thesatl  ='gauss(sg13g2_lv_nmos_thesatl_norm,  0.0908, mc_ok)'
-.param sg13g2_lv_nmos_thesatw  ='gauss(sg13g2_lv_nmos_thesatw_norm,  0.0272, mc_ok)'
-.param sg13g2_lv_nmos_thesatlw ='gauss(sg13g2_lv_nmos_thesatlw_norm, 0.1503, mc_ok)'
-.param sg13g2_lv_nmos_cjorbot  ='gauss(sg13g2_lv_nmos_cjorbot_norm,  0.0267, mc_ok)'
-.param sg13g2_lv_nmos_cjorsti  ='gauss(sg13g2_lv_nmos_cjorsti_norm,  0.0267, mc_ok)'
-.param sg13g2_lv_nmos_cjorgat  ='gauss(sg13g2_lv_nmos_cjorgat_norm,  0.0267, mc_ok)'
+* Xyce statistical parameters
+.param sg13g2_lv_nmos_vfbo_mm   ={GAUSS(sg13g2_lv_nmos_vfbo_norm,     0.0050, 1)}
+.param sg13g2_lv_nmos_toxo   ={GAUSS(sg13g2_lv_nmos_toxo_norm,     0.0133, 1)}
+.param sg13g2_lv_nmos_dphibo ={GAUSS(sg13g2_lv_nmos_dphibo_norm,   0.0656, 1)}
+.param sg13g2_lv_nmos_dphibl ={GAUSS(sg13g2_lv_nmos_dphibl_norm,   0.1135, 1)}
+.param sg13g2_lv_nmos_dphibw ={GAUSS(sg13g2_lv_nmos_dphibw_norm,   0.1197, 1)}
+.param sg13g2_lv_nmos_dphiblw ={GAUSS(sg13g2_lv_nmos_dphiblw_norm,  0.0135, 1)}
+.param sg13g2_lv_nmos_toxovo ={GAUSS(sg13g2_lv_nmos_toxovo_norm,   0.0133, 1)}
+.param sg13g2_lv_nmos_ctl    ={GAUSS(sg13g2_lv_nmos_ctl_norm,      0.1562, 1)}
+.param sg13g2_lv_nmos_muew   ={GAUSS(sg13g2_lv_nmos_muew_norm,     0.032,  1)}
+.param sg13g2_lv_nmos_themuo ={GAUSS(sg13g2_lv_nmos_themuo_norm,   0.0026, 1)}
+.param sg13g2_lv_nmos_rsw1   ={GAUSS(sg13g2_lv_nmos_rsw1_norm,     0.0407, 1)}
+.param sg13g2_lv_nmos_thesatl ={GAUSS(sg13g2_lv_nmos_thesatl_norm,  0.0908, 1)}
+.param sg13g2_lv_nmos_thesatw ={GAUSS(sg13g2_lv_nmos_thesatw_norm,  0.0272, 1)}
+.param sg13g2_lv_nmos_thesatlw ={GAUSS(sg13g2_lv_nmos_thesatlw_norm, 0.1503, 1)}
+.param sg13g2_lv_nmos_cjorbot ={GAUSS(sg13g2_lv_nmos_cjorbot_norm,  0.0267, 1)}
+.param sg13g2_lv_nmos_cjorsti ={GAUSS(sg13g2_lv_nmos_cjorsti_norm,  0.0267, 1)}
+.param sg13g2_lv_nmos_cjorgat ={GAUSS(sg13g2_lv_nmos_cjorgat_norm,  0.0267, 1)}
+* Pelgrom local mismatch sigma coefficients (one-sigma values)
+* Ported from ngspice sg13g2_moslv_mismatch.lib
+.param sg13g2_lv_nmos_delvto_mm = 0.0039
+.param sg13g2_lv_nmos_factuo_mm = 0.005
+.param sg13g2_lv_nmos_dw_mm     = 4e-9
+.param sg13g2_lv_nmos_dl_mm     = 2e-9
 
-.param sg13g2_lv_pmos_vfbo     ='gauss(sg13g2_lv_pmos_vfbo_norm,     0.01,   mc_ok)'
-.param sg13g2_lv_pmos_toxo     ='gauss(sg13g2_lv_pmos_toxo_norm,     0.0133, mc_ok)'
-.param sg13g2_lv_pmos_dphibo   ='gauss(sg13g2_lv_pmos_dphibo_norm,   0.0656, mc_ok)'
-.param sg13g2_lv_pmos_dphibl   ='gauss(sg13g2_lv_pmos_dphibl_norm,   0.1135, mc_ok)'
-.param sg13g2_lv_pmos_dphibw   ='gauss(sg13g2_lv_pmos_dphibw_norm,   0.1197, mc_ok)'
-.param sg13g2_lv_pmos_dphiblw  ='gauss(sg13g2_lv_pmos_dphiblw_norm,  0.0135, mc_ok)'
-.param sg13g2_lv_pmos_toxovo   ='gauss(sg13g2_lv_pmos_toxovo_norm,   0.0133, mc_ok)'
-.param sg13g2_lv_pmos_ctl      ='gauss(sg13g2_lv_pmos_ctl_norm,      0.1562, mc_ok)'
-.param sg13g2_lv_pmos_muew     ='gauss(sg13g2_lv_pmos_muew_norm,     0.032,  mc_ok)'
-.param sg13g2_lv_pmos_themuo   ='gauss(sg13g2_lv_pmos_themuo_norm,   0.0026, mc_ok)'
-.param sg13g2_lv_pmos_rsw1     ='gauss(sg13g2_lv_pmos_rsw1_norm,     0.0407, mc_ok)'
-.param sg13g2_lv_pmos_thesatl  ='gauss(sg13g2_lv_pmos_thesatl_norm,  0.0908, mc_ok)'
-.param sg13g2_lv_pmos_thesatw  ='gauss(sg13g2_lv_pmos_thesatw_norm,  0.0272, mc_ok)'
-.param sg13g2_lv_pmos_thesatlw ='gauss(sg13g2_lv_pmos_thesatlw_norm, 0.1503, mc_ok)'
-.param sg13g2_lv_pmos_cjorbot  ='gauss(sg13g2_lv_pmos_cjorbot_norm,  0.0267, mc_ok)'
-.param sg13g2_lv_pmos_cjorsti  ='gauss(sg13g2_lv_pmos_cjorsti_norm,  0.0267, mc_ok)'
-.param sg13g2_lv_pmos_cjorgat  ='gauss(sg13g2_lv_pmos_cjorgat_norm,  0.0267, mc_ok)'
+.param sg13g2_lv_pmos_vfbo_mm   ={GAUSS(sg13g2_lv_pmos_vfbo_norm,     0.0050, 1)}
+.param sg13g2_lv_pmos_toxo   ={GAUSS(sg13g2_lv_pmos_toxo_norm,     0.0133, 1)}
+.param sg13g2_lv_pmos_dphibo ={GAUSS(sg13g2_lv_pmos_dphibo_norm,   0.0656, 1)}
+.param sg13g2_lv_pmos_dphibl ={GAUSS(sg13g2_lv_pmos_dphibl_norm,   0.1135, 1)}
+.param sg13g2_lv_pmos_dphibw ={GAUSS(sg13g2_lv_pmos_dphibw_norm,   0.1197, 1)}
+.param sg13g2_lv_pmos_dphiblw ={GAUSS(sg13g2_lv_pmos_dphiblw_norm,  0.0135, 1)}
+.param sg13g2_lv_pmos_toxovo ={GAUSS(sg13g2_lv_pmos_toxovo_norm,   0.0133, 1)}
+.param sg13g2_lv_pmos_ctl    ={GAUSS(sg13g2_lv_pmos_ctl_norm,      0.1562, 1)}
+.param sg13g2_lv_pmos_muew   ={GAUSS(sg13g2_lv_pmos_muew_norm,     0.032,  1)}
+.param sg13g2_lv_pmos_themuo ={GAUSS(sg13g2_lv_pmos_themuo_norm,   0.0026, 1)}
+.param sg13g2_lv_pmos_rsw1   ={GAUSS(sg13g2_lv_pmos_rsw1_norm,     0.0407, 1)}
+.param sg13g2_lv_pmos_thesatl ={GAUSS(sg13g2_lv_pmos_thesatl_norm,  0.0908, 1)}
+.param sg13g2_lv_pmos_thesatw ={GAUSS(sg13g2_lv_pmos_thesatw_norm,  0.0272, 1)}
+.param sg13g2_lv_pmos_thesatlw ={GAUSS(sg13g2_lv_pmos_thesatlw_norm, 0.1503, 1)}
+.param sg13g2_lv_pmos_cjorbot ={GAUSS(sg13g2_lv_pmos_cjorbot_norm,  0.0267, 1)}
+.param sg13g2_lv_pmos_cjorsti ={GAUSS(sg13g2_lv_pmos_cjorsti_norm,  0.0267, 1)}
+.param sg13g2_lv_pmos_cjorgat ={GAUSS(sg13g2_lv_pmos_cjorgat_norm,  0.0267, 1)}
 
+* Pelgrom local mismatch sigma coefficients (one-sigma values)
+* Ported from ngspice sg13g2_moslv_mismatch.lib
+.param sg13g2_lv_pmos_delvto_mm = 0.0022
+.param sg13g2_lv_pmos_factuo_mm = 0.0033
+.param sg13g2_lv_pmos_dw_mm     = 4e-9
+.param sg13g2_lv_pmos_dl_mm     = 2e-9


### PR DESCRIPTION
Suggestion to fix Monte-Carlo Simulation for the sg13g2_lv_mos to work with xyce for high performance parallel simulation.
Very open to suggestions, shown changes work as a workaround for me but I am no IHP-dev.
Changes needed for my research internship.