### PR TITLE
Corrected metal surround around "contbar" contacts in the resistors.

### DIFF
--- a/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-cifout.tech
+++ b/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-cifout.tech
@@ -1276,24 +1276,6 @@ style drc
 	grow 150
 	and *pdiff
 
- # Check for 50nm metal surround of ContBar.  ContBar is
- # generated only for certain devices such as resistors,
- # where it can only be distinguished from Cont by
- # detecting the resistor area.
-
- templayer resistors
-	bloat-all nres,pres,xres (*poly)/a
-
- templayer contbar
-	mask-hints CONTBAR
-	and allcont
-
- templayer contbar_enclosure_error pc
-	and resistors
-	or contbar
-	grow 50
-	and-not *m1
-
  # There are no specific rules for seal metal overlap of seal
  # vias, so seal metal width rules can only be calculated by
  # cifdrc rules.

--- a/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-drc.tech
+++ b/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-drc.tech
@@ -396,17 +396,15 @@ drc
 # CONTBAR
 #-------------------------------------------------------------
 
- # This rule is violated in all example cells.
- # surround pbc,sdic m1 50 absence_illegal \
- #	"Metal enclosure of ContBar < %d (CntB.h1)"
+ # Note: BJTs and Schottky diode are exempted from this rule, so
+ # it does not include pbc or sdic.
 
- variants (full)
- cifmaxwidth contbar_enclosure_error 0 bend_illegal \
-	"Metal enclosure of ContBar < 0.05um (CntB.h1)"
- cifwidth contbar 160 "ContBar width < 0.16um (CntB.a)"
- cifspacing contbar contbar 280 touching_illegal \
-	"ContBar spacing < 0.28um (CntB.b)"
- variants *
+ exception CONTBAR
+ surround allcont *m1 50 absence_illegal \
+ 	"Metal enclosure of ContBar < %d (CntB.h1)"
+ spacing allcont allcont 280 touching_illegal \
+	"ContBar spacing < %d (CntB.b)"
+ exception none
 
 #-------------------------------------------------------------
 # METAL1 -

--- a/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-res.tcl
+++ b/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-res.tcl
@@ -539,7 +539,7 @@ proc sg13g2::res_device {parameters} {
     	}
 	set cext [sg13g2::unionbox $cext [sg13g2::draw_contact ${cpl} 0 \
 		${end_surround} ${metal_surround} \
-		${end_contact_size} ${end_type} ${end_contact_type} m1 horz]]
+		${end_contact_size} ${end_type} ${end_contact_type} m1 full]]
     }
     popbox
 
@@ -580,7 +580,7 @@ proc sg13g2::res_device {parameters} {
     	}
 	set cext [sg13g2::unionbox $cext [sg13g2::draw_contact ${cpl} 0 \
 		${end_surround} ${metal_surround} \
-		${end_contact_size} ${end_type} ${end_contact_type} m1 horz]]
+		${end_contact_size} ${end_type} ${end_contact_type} m1 full]]
     }
     # Cover the device area with property MASKHINTS_CONTBAR to specify
     # that all contacts in the area are bar contacts
@@ -693,7 +693,7 @@ proc sg13g2::res_snake_device {nf parameters} {
 	}
 	set cext [sg13g2::draw_contact ${cpl} 0 \
 		${end_surround} ${metal_surround} \
-		${end_contact_size} ${end_type} ${end_contact_type} m1 horz]
+		${end_contact_size} ${end_type} ${end_contact_type} m1 full]
     }
     popbox
 
@@ -810,7 +810,7 @@ proc sg13g2::res_snake_device {nf parameters} {
 	}
 	set cext [sg13g2::unionbox $cext [sg13g2::draw_contact ${cpl} 0 \
 		${end_surround} ${metal_surround} \
-		${end_contact_size} ${end_type} ${end_contact_type} m1 horz]]
+		${end_contact_size} ${end_type} ${end_contact_type} m1 full]]
     }
     popbox
     # Draw portion between resistor end and contact.


### PR DESCRIPTION
Corrected metal surround around "contbar" contacts in the resistors, which previously did not ensure Cntb.h1 (0.05um metal 1 surround) on all four sides of the bar contact, resulting in DRC errors in the resistor layouts.

Also:  Simplified DRC checking for Cntb rules using the new "exception" DRC statement.  The new rule implementation notes that bipolars and the Schottky diode bar contacts are exempted from the metal1 surround requirement.  This is an edge-based DRC check, and so it is much quicker than the previous implementation, and can be added to the default ("fast") rule set.

Please note that an error was found in the implementation of "exception" DRC rules in magic and was fixed in version 8.3.644.  Therefore, please use magic version 8.3.644 or higher when testing this fix.

Fixes #972 

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR
