### PR TITLE
KLayout: centralize version in versions.txt and bump to 0.30.5

### DIFF
--- a/.github/workflows/drc_regression.yml
+++ b/.github/workflows/drc_regression.yml
@@ -37,26 +37,40 @@ jobs:
         with:
           submodules: recursive
 
+      - name: 🔢 Read KLayout version from versions.txt
+        id: klayout_version
+        run: |
+          VERSION=$(grep '^klayout ' versions.txt | awk '{print $2}')
+          if [ -z "$VERSION" ]; then
+            echo "ERROR: Could not read klayout version from versions.txt" >&2
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "version_underscore=${VERSION//./_}" >> "$GITHUB_OUTPUT"
+          echo "KLayout target version: $VERSION"
+
       - name: 💾 Restore KLayout .deb from cache
         id: cache-klayout
         uses: actions/cache@v4
         with:
-          path: klayout-0_30_3.deb
-          key: klayout-deb-cache-ubuntu-0_30_3
+          path: klayout-${{ steps.klayout_version.outputs.version_underscore }}.deb
+          key: klayout-deb-cache-ubuntu-${{ steps.klayout_version.outputs.version_underscore }}
           restore-keys: |
             klayout-deb-cache-
 
       - name: 🔽 Download KLayout .deb if not cached
         if: steps.cache-klayout.outputs.cache-hit != 'true'
         run: |
-          echo "Downloading KLayout .deb..."
+          VERSION="${{ steps.klayout_version.outputs.version }}"
+          VERSION_U="${{ steps.klayout_version.outputs.version_underscore }}"
+          echo "Downloading KLayout .deb (${VERSION})..."
           curl -L --retry 5 --retry-delay 5 --retry-all-errors \
-            -o klayout-0_30_3.deb https://www.klayout.org/downloads/Ubuntu-24/klayout_0.30.3-1_amd64.deb
+            -o "klayout-${VERSION_U}.deb" "https://www.klayout.org/downloads/Ubuntu-24/klayout_${VERSION}-1_amd64.deb"
 
       - name: ⚙️ Install KLayout
         run: |
           sudo apt update -qq -y
-          sudo apt install ./klayout-0_30_3.deb
+          sudo apt install ./klayout-${{ steps.klayout_version.outputs.version_underscore }}.deb
           echo "✅ KLayout version:"
           klayout -v
 
@@ -134,25 +148,42 @@ jobs:
         with:
           submodules: recursive
 
+      - name: 🔢 Read KLayout version from versions.txt
+        id: klayout_version
+        run: |
+          VERSION=$(grep '^klayout ' versions.txt | awk '{print $2}')
+          if [ -z "$VERSION" ]; then
+            echo "ERROR: Could not read klayout version from versions.txt" >&2
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "version_underscore=${VERSION//./_}" >> "$GITHUB_OUTPUT"
+          echo "KLayout target version: $VERSION"
+
       - name: 💾 Restore KLayout .deb from cache
         id: cache-klayout
         uses: actions/cache@v4
         with:
-          path: klayout-0_30_3.deb
-          key: klayout-deb-cache-ubuntu-0_30_3
+          path: klayout-${{ steps.klayout_version.outputs.version_underscore }}.deb
+          key: klayout-deb-cache-ubuntu-${{ steps.klayout_version.outputs.version_underscore }}
           restore-keys: |
             klayout-deb-cache-
+
       - name: 🔽 Download KLayout .deb if not cached
         if: steps.cache-klayout.outputs.cache-hit != 'true'
         run: |
-          echo "Downloading KLayout .deb..."
+          VERSION="${{ steps.klayout_version.outputs.version }}"
+          VERSION_U="${{ steps.klayout_version.outputs.version_underscore }}"
+          echo "Downloading KLayout .deb (${VERSION})..."
           curl -L --retry 5 --retry-delay 5 --retry-all-errors \
-            -o klayout-0_30_3.deb https://www.klayout.org/downloads/Ubuntu-24/klayout_0.30.3-1_amd64.deb
+            -o "klayout-${VERSION_U}.deb" "https://www.klayout.org/downloads/Ubuntu-24/klayout_${VERSION}-1_amd64.deb"
+
       - name: ⚙️ Install KLayout
         run: |
           sudo apt update -qq -y
-          sudo apt install ./klayout-0_30_3.deb
+          sudo apt install ./klayout-${{ steps.klayout_version.outputs.version_underscore }}.deb
           echo "✅ KLayout version:"
           klayout -v
+
       - name: 🧪 Run DRC Regression for SG13G2 Cells
         run: make test-DRC-cells

--- a/.github/workflows/drc_regression.yml
+++ b/.github/workflows/drc_regression.yml
@@ -74,6 +74,26 @@ jobs:
           echo "✅ KLayout version:"
           klayout -v
 
+      - name: 🔎 Verify binary and pip klayout versions agree
+        run: |
+          make env
+          EXPECTED="${{ steps.klayout_version.outputs.version }}"
+          BIN_V=$(klayout -b -v | tail -1 | awk '{print $NF}')
+          PIP_V=$(. actions_venv/bin/activate && python3 -c "import klayout; print(klayout.__version__)")
+          echo "Expected (versions.txt):        $EXPECTED"
+          echo "Binary   (klayout -b -v):       $BIN_V"
+          echo "Pip pkg  (klayout.__version__): $PIP_V"
+          fail=0
+          if [ "$BIN_V" != "$EXPECTED" ]; then
+            echo "ERROR: klayout binary ($BIN_V) != versions.txt ($EXPECTED)" >&2
+            fail=1
+          fi
+          if [ "$PIP_V" != "$EXPECTED" ]; then
+            echo "ERROR: klayout pip package ($PIP_V) != versions.txt ($EXPECTED)" >&2
+            fail=1
+          fi
+          exit $fail
+
       - name: 🧪 Run KLayout DRC Regression
         run: make test-DRC-main
 
@@ -184,6 +204,26 @@ jobs:
           sudo apt install ./klayout-${{ steps.klayout_version.outputs.version_underscore }}.deb
           echo "✅ KLayout version:"
           klayout -v
+
+      - name: 🔎 Verify binary and pip klayout versions agree
+        run: |
+          make env
+          EXPECTED="${{ steps.klayout_version.outputs.version }}"
+          BIN_V=$(klayout -b -v | tail -1 | awk '{print $NF}')
+          PIP_V=$(. actions_venv/bin/activate && python3 -c "import klayout; print(klayout.__version__)")
+          echo "Expected (versions.txt):        $EXPECTED"
+          echo "Binary   (klayout -b -v):       $BIN_V"
+          echo "Pip pkg  (klayout.__version__): $PIP_V"
+          fail=0
+          if [ "$BIN_V" != "$EXPECTED" ]; then
+            echo "ERROR: klayout binary ($BIN_V) != versions.txt ($EXPECTED)" >&2
+            fail=1
+          fi
+          if [ "$PIP_V" != "$EXPECTED" ]; then
+            echo "ERROR: klayout pip package ($PIP_V) != versions.txt ($EXPECTED)" >&2
+            fail=1
+          fi
+          exit $fail
 
       - name: 🧪 Run DRC Regression for SG13G2 Cells
         run: make test-DRC-cells

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -22,6 +22,8 @@ on:
     paths:
       - 'ihp-sg13g2/libs.tech/klayout/tech/drc/**'
       - 'ihp-sg13g2/libs.tech/klayout/tech/lvs/**'
+      - 'versions.txt'
+      - 'requirements.txt'
   workflow_dispatch:
 
 jobs:
@@ -34,3 +36,33 @@ jobs:
       - name: Lint with flake8
         run: |
           make lint_python
+
+  klayout_version_consistency:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check klayout pin in requirements.txt matches versions.txt
+        run: |
+          VERSIONS_TXT=$(grep '^klayout ' versions.txt | awk '{print $2}')
+          REQ_LINE=$(grep '^klayout' requirements.txt | head -1)
+          REQ_VERSION=$(echo "$REQ_LINE" | sed -nE 's/^klayout==([^[:space:]]+).*/\1/p')
+
+          echo "versions.txt klayout: '$VERSIONS_TXT'"
+          echo "requirements.txt klayout line: '$REQ_LINE'"
+          echo "requirements.txt klayout version (pinned): '$REQ_VERSION'"
+
+          if [ -z "$VERSIONS_TXT" ]; then
+            echo "ERROR: versions.txt is missing a 'klayout <version>' line" >&2
+            exit 1
+          fi
+          if [ -z "$REQ_VERSION" ]; then
+            echo "ERROR: requirements.txt must pin klayout exactly as 'klayout==<version>'" >&2
+            echo "       Current line: '$REQ_LINE'" >&2
+            exit 1
+          fi
+          if [ "$VERSIONS_TXT" != "$REQ_VERSION" ]; then
+            echo "ERROR: klayout version drift between versions.txt ($VERSIONS_TXT) and requirements.txt ($REQ_VERSION)" >&2
+            echo "       Update both to the same value." >&2
+            exit 1
+          fi
+          echo "OK: klayout version is consistent ($VERSIONS_TXT)"

--- a/.github/workflows/lvs_regression.yml
+++ b/.github/workflows/lvs_regression.yml
@@ -36,26 +36,40 @@ jobs:
         with:
           submodules: recursive
 
+      - name: 🔢 Read KLayout version from versions.txt
+        id: klayout_version
+        run: |
+          VERSION=$(grep '^klayout ' versions.txt | awk '{print $2}')
+          if [ -z "$VERSION" ]; then
+            echo "ERROR: Could not read klayout version from versions.txt" >&2
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "version_underscore=${VERSION//./_}" >> "$GITHUB_OUTPUT"
+          echo "KLayout target version: $VERSION"
+
       - name: 💾 Restore KLayout .deb from cache
         id: cache-klayout
         uses: actions/cache@v4
         with:
-          path: klayout-0_30_3.deb
-          key: klayout-deb-cache-ubuntu-0_30_3
+          path: klayout-${{ steps.klayout_version.outputs.version_underscore }}.deb
+          key: klayout-deb-cache-ubuntu-${{ steps.klayout_version.outputs.version_underscore }}
           restore-keys: |
             klayout-deb-cache-
 
       - name: 🔽 Download KLayout .deb if not cached
         if: steps.cache-klayout.outputs.cache-hit != 'true'
         run: |
-          echo "Downloading KLayout .deb..."
+          VERSION="${{ steps.klayout_version.outputs.version }}"
+          VERSION_U="${{ steps.klayout_version.outputs.version_underscore }}"
+          echo "Downloading KLayout .deb (${VERSION})..."
           curl -L --retry 5 --retry-delay 5 --retry-all-errors \
-            -o klayout-0_30_3.deb https://www.klayout.org/downloads/Ubuntu-24/klayout_0.30.3-1_amd64.deb
+            -o "klayout-${VERSION_U}.deb" "https://www.klayout.org/downloads/Ubuntu-24/klayout_${VERSION}-1_amd64.deb"
 
       - name: ⚙️ Install KLayout
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y ./klayout-0_30_3.deb
+          sudo apt-get install -y ./klayout-${{ steps.klayout_version.outputs.version_underscore }}.deb
           echo "✅ KLayout version:"
           klayout -v
 
@@ -73,26 +87,40 @@ jobs:
         with:
           submodules: recursive
 
+      - name: 🔢 Read KLayout version from versions.txt
+        id: klayout_version
+        run: |
+          VERSION=$(grep '^klayout ' versions.txt | awk '{print $2}')
+          if [ -z "$VERSION" ]; then
+            echo "ERROR: Could not read klayout version from versions.txt" >&2
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "version_underscore=${VERSION//./_}" >> "$GITHUB_OUTPUT"
+          echo "KLayout target version: $VERSION"
+
       - name: 💾 Restore KLayout .deb from cache
         id: cache-klayout
         uses: actions/cache@v4
         with:
-          path: klayout-0_30_3.deb
-          key: klayout-deb-cache-ubuntu-0_30_3
+          path: klayout-${{ steps.klayout_version.outputs.version_underscore }}.deb
+          key: klayout-deb-cache-ubuntu-${{ steps.klayout_version.outputs.version_underscore }}
           restore-keys: |
             klayout-deb-cache-
 
       - name: 🔽 Download KLayout .deb if not cached
         if: steps.cache-klayout.outputs.cache-hit != 'true'
         run: |
-          echo "Downloading KLayout .deb..."
+          VERSION="${{ steps.klayout_version.outputs.version }}"
+          VERSION_U="${{ steps.klayout_version.outputs.version_underscore }}"
+          echo "Downloading KLayout .deb (${VERSION})..."
           curl -L --retry 5 --retry-delay 5 --retry-all-errors \
-            -o klayout-0_30_3.deb https://www.klayout.org/downloads/Ubuntu-24/klayout_0.30.3-1_amd64.deb
+            -o "klayout-${VERSION_U}.deb" "https://www.klayout.org/downloads/Ubuntu-24/klayout_${VERSION}-1_amd64.deb"
 
       - name: ⚙️ Install KLayout
         run: |
           sudo apt update -qq -y
-          sudo apt install ./klayout-0_30_3.deb
+          sudo apt install ./klayout-${{ steps.klayout_version.outputs.version_underscore }}.deb
           echo "✅ KLayout version:"
           klayout -v
 

--- a/.github/workflows/lvs_regression.yml
+++ b/.github/workflows/lvs_regression.yml
@@ -73,6 +73,26 @@ jobs:
           echo "✅ KLayout version:"
           klayout -v
 
+      - name: 🔎 Verify binary and pip klayout versions agree
+        run: |
+          make env
+          EXPECTED="${{ steps.klayout_version.outputs.version }}"
+          BIN_V=$(klayout -b -v | tail -1 | awk '{print $NF}')
+          PIP_V=$(. actions_venv/bin/activate && python3 -c "import klayout; print(klayout.__version__)")
+          echo "Expected (versions.txt):        $EXPECTED"
+          echo "Binary   (klayout -b -v):       $BIN_V"
+          echo "Pip pkg  (klayout.__version__): $PIP_V"
+          fail=0
+          if [ "$BIN_V" != "$EXPECTED" ]; then
+            echo "ERROR: klayout binary ($BIN_V) != versions.txt ($EXPECTED)" >&2
+            fail=1
+          fi
+          if [ "$PIP_V" != "$EXPECTED" ]; then
+            echo "ERROR: klayout pip package ($PIP_V) != versions.txt ($EXPECTED)" >&2
+            fail=1
+          fi
+          exit $fail
+
       - name: 🧪 Run SG13G2 KLayout LVS Regression
         run: make test-LVS-main
 
@@ -123,6 +143,26 @@ jobs:
           sudo apt install ./klayout-${{ steps.klayout_version.outputs.version_underscore }}.deb
           echo "✅ KLayout version:"
           klayout -v
+
+      - name: 🔎 Verify binary and pip klayout versions agree
+        run: |
+          make env
+          EXPECTED="${{ steps.klayout_version.outputs.version }}"
+          BIN_V=$(klayout -b -v | tail -1 | awk '{print $NF}')
+          PIP_V=$(. actions_venv/bin/activate && python3 -c "import klayout; print(klayout.__version__)")
+          echo "Expected (versions.txt):        $EXPECTED"
+          echo "Binary   (klayout -b -v):       $BIN_V"
+          echo "Pip pkg  (klayout.__version__): $PIP_V"
+          fail=0
+          if [ "$BIN_V" != "$EXPECTED" ]; then
+            echo "ERROR: klayout binary ($BIN_V) != versions.txt ($EXPECTED)" >&2
+            fail=1
+          fi
+          if [ "$PIP_V" != "$EXPECTED" ]; then
+            echo "ERROR: klayout pip package ($PIP_V) != versions.txt ($EXPECTED)" >&2
+            fail=1
+          fi
+          exit $fail
 
       - name: 🧪 Run LVS Regression for SG13G2 Cells
         run: make test-LVS-cells

--- a/ihp-sg13g2/libs.tech/klayout/tech/drc/README.md
+++ b/ihp-sg13g2/libs.tech/klayout/tech/drc/README.md
@@ -32,11 +32,11 @@ Explains how to use the SG13G2 DRC rule decks.
 You need the following set of tools installed to be able to run SG13G2 DRC:
 
 - Python 3.9+
-- KLayout 0.30.3+
+- KLayout: see the version pinned in [`versions.txt`](../../../../../versions.txt) at the repository root (single source of truth shared by the runtime checks, CI workflows, and the pip pin in `requirements.txt`).
 
 We have tested this using the following setup:
 - Python 3.9.18
-- KLayout 0.30.3
+- KLayout 0.30.5
 
 ## Installation
 

--- a/ihp-sg13g2/libs.tech/klayout/tech/drc/run_drc.py
+++ b/ihp-sg13g2/libs.tech/klayout/tech/drc/run_drc.py
@@ -434,15 +434,37 @@ def generate_klayout_switches(arguments, layout_path: str) -> dict:
     return switches
 
 
+def _get_required_klayout_version() -> Tuple[Tuple[int, int, int], str]:
+    """
+    Read the required KLayout version from the repo-level versions.txt
+    (single source of truth). Returns ((major, minor, patch), raw_string).
+    """
+    versions_txt = Path(__file__).resolve().parents[5] / "versions.txt"
+    try:
+        with open(versions_txt, "r") as f:
+            for line in f:
+                parts = line.strip().split()
+                if len(parts) == 2 and parts[0] == "klayout":
+                    return tuple(int(x) for x in parts[1].split(".")), parts[1]
+    except (OSError, ValueError) as e:
+        logging.error(f"Could not read klayout version from {versions_txt}: {e}")
+        exit(1)
+    logging.error(f"klayout entry not found in {versions_txt}")
+    exit(1)
+
+
 def check_klayout_version():
     """
-    Checks if the installed KLayout version meets the minimum required version (>= 0.29.11).
+    Checks if the installed KLayout version meets the required version
+    specified in the repo-level versions.txt.
 
     Raises
     ------
     SystemExit
         If KLayout is not installed or version is below the required minimum.
     """
+    required_tuple, required_str = _get_required_klayout_version()
+
     try:
         klayout_version_output = os.popen("klayout -b -v").read().strip()
     except Exception as e:
@@ -468,12 +490,12 @@ def check_klayout_version():
         )
         exit(1)
 
-    if (major, minor, patch) < (0, 29, 11):
-        logging.error("Minimum required KLayout version is 0.29.11.")
+    if (major, minor, patch) < required_tuple:
+        logging.error(f"Minimum required KLayout version is {required_str} (from versions.txt).")
         logging.error(f"Your version: {version_str}")
         exit(1)
 
-    logging.info(f"KLayout version detected: {version_str}")
+    logging.info(f"KLayout version detected: {version_str} (required >= {required_str})")
 
 
 def check_layout_path(layout_path: str) -> str:

--- a/ihp-sg13g2/libs.tech/klayout/tech/drc/run_drc.py
+++ b/ihp-sg13g2/libs.tech/klayout/tech/drc/run_drc.py
@@ -19,6 +19,7 @@ import os
 from pathlib import Path
 import xml.etree.ElementTree as ET
 import logging
+import klayout
 import klayout.db
 from datetime import datetime, timezone
 import time
@@ -496,6 +497,17 @@ def check_klayout_version():
         exit(1)
 
     logging.info(f"KLayout version detected: {version_str} (required >= {required_str})")
+
+    # Warn if the imported klayout Python package version drifts from the binary.
+    # GUI/menu runs use KLayout's embedded interpreter so this never mismatches there;
+    # this catches CLI setups where the system binary and the pip-installed klayout package diverge.
+    pip_version = getattr(klayout, "__version__", None)
+    if pip_version and pip_version != version_str:
+        logging.warning(
+            f"KLayout binary version ({version_str}) differs from the imported "
+            f"klayout Python package version ({pip_version}). "
+            f"Re-align with: pip install klayout=={version_str}"
+        )
 
 
 def check_layout_path(layout_path: str) -> str:

--- a/ihp-sg13g2/libs.tech/klayout/tech/drc/testing/README.md
+++ b/ihp-sg13g2/libs.tech/klayout/tech/drc/testing/README.md
@@ -38,11 +38,11 @@ Explains how to test SG13G2 DRC rule decks.
 You need the following set of tools installed to be able to run SG13G2 DRC regression:
 
 - Python 3.9+
-- KLayout 0.30.3+
+- KLayout: see the version pinned in [`versions.txt`](../../../../../../versions.txt) at the repository root (single source of truth shared by the runtime checks, CI workflows, and the pip pin in `requirements.txt`).
 
 We have tested this using the following setup:
 - Python 3.9.18
-- KLayout 0.30.3
+- KLayout 0.30.5
 
 ## Installation
 

--- a/ihp-sg13g2/libs.tech/klayout/tech/drc/testing/gen_golden.py
+++ b/ihp-sg13g2/libs.tech/klayout/tech/drc/testing/gen_golden.py
@@ -41,11 +41,32 @@ GOLDEN_LAY_NUM = 222
 PATH_WIDTH = 0.01
 
 
+def _get_required_klayout_version():
+    """
+    Read the required KLayout version from the repo-level versions.txt
+    (single source of truth). Returns ([major, minor, patch], raw_string).
+    """
+    versions_txt = Path(__file__).resolve().parents[6] / "versions.txt"
+    try:
+        with open(versions_txt, "r") as f:
+            for line in f:
+                parts = line.strip().split()
+                if len(parts) == 2 and parts[0] == "klayout":
+                    return [int(x) for x in parts[1].split(".")], parts[1]
+    except (OSError, ValueError) as e:
+        logging.error(f"Could not read klayout version from {versions_txt}: {e}")
+        exit(1)
+    logging.error(f"klayout entry not found in {versions_txt}")
+    exit(1)
+
+
 def check_klayout_version():
     """
     check_klayout_version checks KLayout version and ensures
-    it meets the minimum required version for the DRC.
+    it meets the required version specified in the repo-level versions.txt.
     """
+    min_required, required_str = _get_required_klayout_version()
+
     klayout_v_output = os.popen("klayout -b -v").read().strip()
 
     if not klayout_v_output:
@@ -54,7 +75,7 @@ def check_klayout_version():
         )
         exit(1)
 
-    version_str = klayout_v_output.split()[-1]  # Expecting format: 'KLayout 0.29.11'
+    version_str = klayout_v_output.split()[-1]
     version_parts = version_str.split(".")
 
     try:
@@ -63,18 +84,15 @@ def check_klayout_version():
         logging.error(f"Could not parse KLayout version from string: '{version_str}'")
         exit(1)
 
-    # Pad to 3 parts if necessary
     while len(klayout_v_list) < 3:
         klayout_v_list.append(0)
 
-    # Minimum required version: 0.29.11
-    min_required = [0, 29, 11]
     if klayout_v_list < min_required:
-        logging.error("Minimum required KLayout version is 0.29.11")
+        logging.error(f"Minimum required KLayout version is {required_str} (from versions.txt)")
         logging.error(f"Your KLayout version is: {version_str}")
         exit(1)
 
-    logging.info(f"KLayout version: {version_str}")
+    logging.info(f"KLayout version: {version_str} (required >= {required_str})")
 
 
 def _move_and_rename_golden_files(run_dir: Path, pattern_merged: str, pattern_golden: str):

--- a/ihp-sg13g2/libs.tech/klayout/tech/drc/testing/gen_golden.py
+++ b/ihp-sg13g2/libs.tech/klayout/tech/drc/testing/gen_golden.py
@@ -29,6 +29,7 @@ from pathlib import Path
 from tqdm import tqdm
 import re
 import gdstk
+import klayout
 import klayout.db
 import numpy as np
 from fnmatch import fnmatch
@@ -93,6 +94,15 @@ def check_klayout_version():
         exit(1)
 
     logging.info(f"KLayout version: {version_str} (required >= {required_str})")
+
+    # Warn if the imported klayout Python package version drifts from the binary.
+    pip_version = getattr(klayout, "__version__", None)
+    if pip_version and pip_version != version_str:
+        logging.warning(
+            f"KLayout binary version ({version_str}) differs from the imported "
+            f"klayout Python package version ({pip_version}). "
+            f"Re-align with: pip install klayout=={version_str}"
+        )
 
 
 def _move_and_rename_golden_files(run_dir: Path, pattern_merged: str, pattern_golden: str):

--- a/ihp-sg13g2/libs.tech/klayout/tech/drc/testing/run_regression.py
+++ b/ihp-sg13g2/libs.tech/klayout/tech/drc/testing/run_regression.py
@@ -119,11 +119,32 @@ def get_unit_test_coverage(gds_file):
     return rules
 
 
+def _get_required_klayout_version():
+    """
+    Read the required KLayout version from the repo-level versions.txt
+    (single source of truth). Returns ([major, minor, patch], raw_string).
+    """
+    versions_txt = Path(__file__).resolve().parents[6] / "versions.txt"
+    try:
+        with open(versions_txt, "r") as f:
+            for line in f:
+                parts = line.strip().split()
+                if len(parts) == 2 and parts[0] == "klayout":
+                    return [int(x) for x in parts[1].split(".")], parts[1]
+    except (OSError, ValueError) as e:
+        logging.error(f"Could not read klayout version from {versions_txt}: {e}")
+        exit(1)
+    logging.error(f"klayout entry not found in {versions_txt}")
+    exit(1)
+
+
 def check_klayout_version():
     """
     check_klayout_version checks KLayout version and ensures
-    it meets the minimum required version for the DRC.
+    it meets the required version specified in the repo-level versions.txt.
     """
+    min_required, required_str = _get_required_klayout_version()
+
     klayout_v_output = os.popen("klayout -b -v").read().strip()
 
     if not klayout_v_output:
@@ -132,7 +153,7 @@ def check_klayout_version():
         )
         exit(1)
 
-    version_str = klayout_v_output.split()[-1]  # Expecting format: 'KLayout 0.29.11'
+    version_str = klayout_v_output.split()[-1]
     version_parts = version_str.split(".")
 
     try:
@@ -141,18 +162,15 @@ def check_klayout_version():
         logging.error(f"Could not parse KLayout version from string: '{version_str}'")
         exit(1)
 
-    # Pad to 3 parts if necessary
     while len(klayout_v_list) < 3:
         klayout_v_list.append(0)
 
-    # Minimum required version: 0.29.11
-    min_required = [0, 29, 11]
     if klayout_v_list < min_required:
-        logging.error("Minimum required KLayout version is 0.29.11")
+        logging.error(f"Minimum required KLayout version is {required_str} (from versions.txt)")
         logging.error(f"Your KLayout version is: {version_str}")
         exit(1)
 
-    logging.info(f"KLayout version: {version_str}")
+    logging.info(f"KLayout version: {version_str} (required >= {required_str})")
 
 
 def get_switches(yaml_file, rule_name):

--- a/ihp-sg13g2/libs.tech/klayout/tech/drc/testing/run_regression.py
+++ b/ihp-sg13g2/libs.tech/klayout/tech/drc/testing/run_regression.py
@@ -29,6 +29,7 @@ from pathlib import Path
 from tqdm import tqdm
 import re
 import gdstk
+import klayout
 import klayout.db
 import errno
 import numpy as np
@@ -171,6 +172,15 @@ def check_klayout_version():
         exit(1)
 
     logging.info(f"KLayout version: {version_str} (required >= {required_str})")
+
+    # Warn if the imported klayout Python package version drifts from the binary.
+    pip_version = getattr(klayout, "__version__", None)
+    if pip_version and pip_version != version_str:
+        logging.warning(
+            f"KLayout binary version ({version_str}) differs from the imported "
+            f"klayout Python package version ({pip_version}). "
+            f"Re-align with: pip install klayout=={version_str}"
+        )
 
 
 def get_switches(yaml_file, rule_name):

--- a/ihp-sg13g2/libs.tech/klayout/tech/lvs/README.md
+++ b/ihp-sg13g2/libs.tech/klayout/tech/lvs/README.md
@@ -31,11 +31,11 @@ Explains how to use the SG13G2 LVS rule decks.
 You need the following set of tools installed to be able to run SG13G2 LVS:
 
 - Python 3.9+
-- KLayout 0.30.2+
+- KLayout: see the version pinned in [`versions.txt`](../../../../../versions.txt) at the repository root (single source of truth shared by the runtime checks, CI workflows, and the pip pin in `requirements.txt`).
 
 We have tested this using the following setup:
 - Python 3.12.4
-- KLayout 0.30.3
+- KLayout 0.30.5
 
 ## Installation
 

--- a/ihp-sg13g2/libs.tech/klayout/tech/lvs/run_lvs.py
+++ b/ihp-sg13g2/libs.tech/klayout/tech/lvs/run_lvs.py
@@ -19,6 +19,7 @@
 
 import argparse
 import os
+from pathlib import Path
 import logging
 import klayout.db
 from datetime import datetime, timezone
@@ -272,33 +273,60 @@ def discover_run_artifacts(run_dir, main_log_path):
     }
 
 
+def _get_required_klayout_version():
+    """
+    Read the required KLayout version from the repo-level versions.txt
+    (single source of truth). Returns ((major, minor, patch), raw_string).
+    """
+    versions_txt = Path(__file__).resolve().parents[5] / "versions.txt"
+    try:
+        with open(versions_txt, "r") as f:
+            for line in f:
+                parts = line.strip().split()
+                if len(parts) == 2 and parts[0] == "klayout":
+                    return tuple(int(x) for x in parts[1].split(".")), parts[1]
+    except (OSError, ValueError) as e:
+        logging.error(f"Could not read klayout version from {versions_txt}: {e}")
+        exit(1)
+    logging.error(f"klayout entry not found in {versions_txt}")
+    exit(1)
+
+
 def check_klayout_version():
     """
-    Check klayout version and makes sure it would work with the LVS.
+    Check klayout version and makes sure it meets the required version
+    specified in the repo-level versions.txt.
     """
-    # ======= Checking Klayout version =======
+    required_tuple, required_str = _get_required_klayout_version()
+
     klayout_v_ = os.popen("klayout -b -v").read()
     klayout_v_ = klayout_v_.split("\n")[0]
-    klayout_v_list = []
 
     if klayout_v_ == "":
         logging.error("Klayout is not found. Please make sure klayout is installed.")
         exit(1)
-    else:
-        klayout_v_list = [int(v) for v in klayout_v_.split(" ")[-1].split(".")]
 
-    if len(klayout_v_list) < 1 or len(klayout_v_list) > 3:
+    try:
+        klayout_v_list = tuple(int(v) for v in klayout_v_.split(" ")[-1].split("."))
+    except ValueError:
+        logging.error(f"Was not able to parse klayout version from: '{klayout_v_}'")
+        exit(1)
+
+    if not 1 <= len(klayout_v_list) <= 3:
         logging.error("Was not able to get klayout version properly.")
         exit(1)
-    elif len(klayout_v_list) >= 2 or len(klayout_v_list) <= 3:
-        if klayout_v_list[1] < 30 or (klayout_v_list[1] == 30 and klayout_v_list[2] < 2):
-            logging.error("Prerequisites at a minimum: KLayout 0.30.2")
-            logging.error(
-                "Using this klayout version has not been assessed. Limits are unknown"
-            )
-            exit(1)
 
-    logging.info(f"Your Klayout version is: {klayout_v_}")
+    # Pad to 3 components for comparison
+    padded = klayout_v_list + (0,) * (3 - len(klayout_v_list))
+
+    if padded < required_tuple:
+        logging.error(f"Prerequisites at a minimum: KLayout {required_str} (from versions.txt)")
+        logging.error(
+            "Using this klayout version has not been assessed. Limits are unknown"
+        )
+        exit(1)
+
+    logging.info(f"Your Klayout version is: {klayout_v_} (required >= {required_str})")
 
 
 def check_layout_type(layout_path):

--- a/ihp-sg13g2/libs.tech/klayout/tech/lvs/run_lvs.py
+++ b/ihp-sg13g2/libs.tech/klayout/tech/lvs/run_lvs.py
@@ -21,6 +21,7 @@ import argparse
 import os
 from pathlib import Path
 import logging
+import klayout
 import klayout.db
 from datetime import datetime, timezone
 from subprocess import Popen, PIPE, STDOUT
@@ -327,6 +328,16 @@ def check_klayout_version():
         exit(1)
 
     logging.info(f"Your Klayout version is: {klayout_v_} (required >= {required_str})")
+
+    # Warn if the imported klayout Python package version drifts from the binary.
+    binary_version_str = klayout_v_.split(" ")[-1]
+    pip_version = getattr(klayout, "__version__", None)
+    if pip_version and pip_version != binary_version_str:
+        logging.warning(
+            f"KLayout binary version ({binary_version_str}) differs from the imported "
+            f"klayout Python package version ({pip_version}). "
+            f"Re-align with: pip install klayout=={binary_version_str}"
+        )
 
 
 def check_layout_type(layout_path):

--- a/ihp-sg13g2/libs.tech/klayout/tech/lvs/testing/README.md
+++ b/ihp-sg13g2/libs.tech/klayout/tech/lvs/testing/README.md
@@ -19,11 +19,11 @@ At a minimum:
 
 You need the following set of tools installed to be able to run the regression:
 - Python 3.9+
-- KLayout 0.30.2+
+- KLayout: see the version pinned in [`versions.txt`](../../../../../../versions.txt) at the repository root (single source of truth shared by the runtime checks, CI workflows, and the pip pin in `requirements.txt`).
 
 We have tested this using the following setup:
 - Python 3.12.4
-- KLayout 0.30.3
+- KLayout 0.30.5
 
 ## Installation
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 flake8
 docopt
 pandas
-klayout
+klayout==0.30.5
 pyyaml
 gdstk
 tqdm

--- a/versions.txt
+++ b/versions.txt
@@ -4,6 +4,6 @@ ngspice 43
 Xyce 7.8-opensource
 xschem 3.4.6
 qucs-s s25.2.0
-klayout 0.30.3
+klayout 0.30.5
 openEMS v0.0.35-108-gc651cce
 magic 8.3.589


### PR DESCRIPTION
Closes #982.

versions.txt is now the single source of truth for the KLayout version, and everything else reads from it. The DRC and LVS workflows extract the version when building the .deb URL, cache path, and cache key (no more hardcoded `klayout_0.30.3-1_amd64.deb` in four spots). The `check_klayout_version()` functions in `run_drc.py`, `run_lvs.py`, `testing/gen_golden.py` and `testing/run_regression.py` read versions.txt instead of carrying their own tuple, so the runtime check, docs and CI all agree. requirements.txt is pinned to `klayout==0.30.5`, and a new `klayout_version_consistency` job in linting.yml fails the build if that pin ever drifts from versions.txt. The DRC/LVS READMEs link to versions.txt instead of repeating a prerequisite string. Also bumping to 0.30.5 in the same go.

Cross-check between the system klayout binary and the imported pip package: the same `check_klayout_version()` functions now read `klayout.__version__` and log a warning when it differs from `klayout -b -v` (the CLI path is the one that can drift; the GUI/menu path uses KLayout's embedded interpreter so it cannot mismatch by construction). The DRC and LVS workflows have a matching "Verify binary and pip klayout versions agree" step that fails the build if either differs from versions.txt, so the binary == pip == versions.txt invariant is enforced in CI rather than just inferred.

Local sanity check: a grep across .py / .yml / .md finds no leftover `0.29.x` or `0.30.{0..4}` strings, and `run_drc.py --help` logs "required >= 0.30.5".

Heads up: `lint_python` was red on the first push because of pre-existing flake8 errors in `run_regression_cells.py` (C901 / E741 / E501); same as the last few linting runs on dev. Not introduced here.