### PR TITLE
Fix bug in RF MOS model geometry scaling 

### DIFF
--- a/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moshv_mod.lib
+++ b/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moshv_mod.lib
@@ -92,7 +92,7 @@
               + l=l
               + nf=1 mult='m*ng'
               + as='(max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2))/ng'
-              + ad='(max(w/ng,wmin)*z2/2*ng)/ng'
+              + ad='max(w/ng,wmin)*z2/2'
               + ps='(2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2))/ng'
               + pd='(max(w/ng,wmin)+z2)'
               + dta=trise
@@ -131,7 +131,7 @@
               + l=l
               + nf=1 mult='m*ng'
               + as='(max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2))/ng'
-              + ad='(max(w/ng,wmin)*z2/2*ng)/ng'
+              + ad='max(w/ng,wmin)*z2/2'
               + ps='(2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2))/ng'
               + pd='(max(w/ng,wmin)+z2)'
               + dta=trise
@@ -178,7 +178,7 @@
               + l=l
               + nf=1 mult='m*ng'
               + as='(max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2))/ng'
-              + ad='(max(w/ng,wmin)*z2/2*ng)/ng'
+              + ad='max(w/ng,wmin)*z2/2'
               + ps='(2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2))/ng'
               + pd='(max(w/ng,wmin)+z2)'
               + dta=trise
@@ -217,7 +217,7 @@
               + l=l
               + nf=1 mult='m*ng'
               + as='(max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2))/ng'
-              + ad='(max(w/ng,wmin)*z2/2*ng)/ng'
+              + ad='max(w/ng,wmin)*z2/2'
               + ps='(2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2))/ng'
               + pd='(max(w/ng,wmin)+z2)'
               + dta=trise

--- a/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moshv_mod.lib
+++ b/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moshv_mod.lib
@@ -94,7 +94,7 @@
               + as='(max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2))/ng'
               + ad='(max(w/ng,wmin)*z2/2*ng)/ng'
               + ps='(2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2))/ng'
-              + pd='((max(w/ng,wmin)+z2)*ng)/ng'
+              + pd='(max(w/ng,wmin)+z2)'
               + dta=trise
               + ngcon=2
               + delvto=0
@@ -133,7 +133,7 @@
               + as='(max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2))/ng'
               + ad='(max(w/ng,wmin)*z2/2*ng)/ng'
               + ps='(2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2))/ng'
-              + pd='((max(w/ng,wmin)+z2)*ng)/ng'
+              + pd='(max(w/ng,wmin)+z2)'
               + dta=trise
               + ngcon=2
               + delvto=0
@@ -180,7 +180,7 @@
               + as='(max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2))/ng'
               + ad='(max(w/ng,wmin)*z2/2*ng)/ng'
               + ps='(2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2))/ng'
-              + pd='((max(w/ng,wmin)+z2)*ng)/ng'
+              + pd='(max(w/ng,wmin)+z2)'
               + dta=trise
               + ngcon=2
               + delvto=0
@@ -219,7 +219,7 @@
               + as='(max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2))/ng'
               + ad='(max(w/ng,wmin)*z2/2*ng)/ng'
               + ps='(2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2))/ng'
-              + pd='((max(w/ng,wmin)+z2)*ng)/ng'
+              + pd='(max(w/ng,wmin)+z2)'
               + dta=trise
               + ngcon=2
               + delvto=0

--- a/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moshv_mod.lib
+++ b/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moshv_mod.lib
@@ -75,26 +75,26 @@
     .if (as <= 1e-50)
         .if (floor(floor(ng/2+0.501)*2+0.001) != ng)
             Nsg13_hv_nmos d g s b sg13g2_hv_nmos_psp
-              + w=w
+              + w='w/ng'
               + l=l
-              + nf='ng' mult='m'
-              + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
-              + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
-              + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
-              + pd='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+              + nf=1 mult='m*ng'
+              + as='(max(w/ng,wmin)*(z1+((ng-1)/2)*z2))/ng'
+              + ad='(max(w/ng,wmin)*(z1+((ng-1)/2)*z2))/ng'
+              + ps='(2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2))/ng'
+              + pd='(2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2))/ng'
               + dta=trise
               + ngcon=2
               + delvto=0
               + factuo=1
         .else
             Nsg13_hv_nmos d g s b sg13g2_hv_nmos_psp
-              + w=w
+              + w='w/ng'
               + l=l
-              + nf='ng' mult='m'
-              + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)'
-              + ad='max(w/ng,wmin)*z2/2*ng'
-              + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)'
-              + pd='(max(w/ng,wmin)+z2)*ng'
+              + nf=1 mult='m*ng'
+              + as='(max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2))/ng'
+              + ad='(max(w/ng,wmin)*z2/2*ng)/ng'
+              + ps='(2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2))/ng'
+              + pd='((max(w/ng,wmin)+z2)*ng)/ng'
               + dta=trise
               + ngcon=2
               + delvto=0
@@ -102,9 +102,9 @@
         .endif
     .else
         Nsg13_hv_nmos d g s b sg13g2_hv_nmos_psp
-          + w=w
+          + w='w/ng'
           + l=l
-          + as='as' ad='ad' pd='pd' ps='ps' nf='ng' mult='m'
+          + as='as/ng' ad='ad/ng' pd='pd/ng' ps='ps/ng' nf=1 mult='m*ng'
           + dta=trise
           + ngcon=2
           + delvto=0
@@ -114,26 +114,26 @@
     .if (as <= 1e-50)
         .if (floor(floor(ng/2+0.501)*2+0.001) != ng)
             Nsg13_hv_nmos d g s b sg13g2_hv_nmos_psp_rf
-              + w=w
+              + w='w/ng'
               + l=l
-              + nf='ng' mult='m'
-              + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
-              + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
-              + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
-              + pd='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+              + nf=1 mult='m*ng'
+              + as='(max(w/ng,wmin)*(z1+((ng-1)/2)*z2))/ng'
+              + ad='(max(w/ng,wmin)*(z1+((ng-1)/2)*z2))/ng'
+              + ps='(2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2))/ng'
+              + pd='(2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2))/ng'
               + dta=trise
               + ngcon=2
               + delvto=0
               + factuo=1
         .else
             Nsg13_hv_nmos d g s b sg13g2_hv_nmos_psp_rf
-              + w=w
+              + w='w/ng'
               + l=l
-              + nf='ng' mult='m'
-              + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)'
-              + ad='max(w/ng,wmin)*z2/2*ng'
-              + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)'
-              + pd='(max(w/ng,wmin)+z2)*ng'
+              + nf=1 mult='m*ng'
+              + as='(max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2))/ng'
+              + ad='(max(w/ng,wmin)*z2/2*ng)/ng'
+              + ps='(2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2))/ng'
+              + pd='((max(w/ng,wmin)+z2)*ng)/ng'
               + dta=trise
               + ngcon=2
               + delvto=0
@@ -141,9 +141,9 @@
         .endif
     .else
         Nsg13_hv_nmos d g s b sg13g2_hv_nmos_psp_rf
-          + w=w
+          + w='w/ng'
           + l=l
-          + as='as' ad='ad' pd='pd' ps='ps' nf='ng' mult='m'
+          + as='as/ng' ad='ad/ng' pd='pd/ng' ps='ps/ng' nf=1 mult='m*ng'
           + dta=trise
           + ngcon=2
           + delvto=0
@@ -161,26 +161,26 @@
     .if (as <= 1e-50)
         .if (floor(floor(ng/2+0.501)*2+0.001) != ng)
             Nsg13_hv_pmos d g s b sg13g2_hv_pmos_psp
-              + w=w
+              + w='w/ng'
               + l=l
-              + nf='ng' mult='m'
-              + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
-              + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
-              + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
-              + pd='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+              + nf=1 mult='m*ng'
+              + as='(max(w/ng,wmin)*(z1+((ng-1)/2)*z2))/ng'
+              + ad='(max(w/ng,wmin)*(z1+((ng-1)/2)*z2))/ng'
+              + ps='(2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2))/ng'
+              + pd='(2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2))/ng'
               + dta=trise
               + ngcon=2
               + delvto=0
               + factuo=1
         .else
             Nsg13_hv_pmos d g s b sg13g2_hv_pmos_psp
-              + w=w
+              + w='w/ng'
               + l=l
-              + nf='ng' mult='m'
-              + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)'
-              + ad='max(w/ng,wmin)*z2/2*ng'
-              + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)'
-              + pd='(max(w/ng,wmin)+z2)*ng'
+              + nf=1 mult='m*ng'
+              + as='(max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2))/ng'
+              + ad='(max(w/ng,wmin)*z2/2*ng)/ng'
+              + ps='(2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2))/ng'
+              + pd='((max(w/ng,wmin)+z2)*ng)/ng'
               + dta=trise
               + ngcon=2
               + delvto=0
@@ -188,9 +188,9 @@
         .endif
     .else
         Nsg13_hv_pmos d g s b sg13g2_hv_pmos_psp
-          + w=w
+          + w='w/ng'
           + l=l
-          + as='as' ad='ad' pd='pd' ps='ps' nf='ng' mult='m'
+          + as='as/ng' ad='ad/ng' pd='pd/ng' ps='ps/ng' nf=1 mult='m*ng'
           + dta=trise
           + ngcon=2
           + delvto=0
@@ -200,26 +200,26 @@
     .if (as <= 1e-50)
         .if (floor(floor(ng/2+0.501)*2+0.001) != ng)
             Nsg13_hv_pmos d g s b sg13g2_hv_pmos_psp_rf
-              + w=w
+              + w='w/ng'
               + l=l
-              + nf='ng' mult='m'
-              + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
-              + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
-              + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
-              + pd='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+              + nf=1 mult='m*ng'
+              + as='(max(w/ng,wmin)*(z1+((ng-1)/2)*z2))/ng'
+              + ad='(max(w/ng,wmin)*(z1+((ng-1)/2)*z2))/ng'
+              + ps='(2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2))/ng'
+              + pd='(2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2))/ng'
               + dta=trise
               + ngcon=2
               + delvto=0
               + factuo=1
         .else
             Nsg13_hv_pmos d g s b sg13g2_hv_pmos_psp_rf
-              + w=w
+              + w='w/ng'
               + l=l
-              + nf='ng' mult='m'
-              + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)'
-              + ad='max(w/ng,wmin)*z2/2*ng'
-              + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)'
-              + pd='(max(w/ng,wmin)+z2)*ng'
+              + nf=1 mult='m*ng'
+              + as='(max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2))/ng'
+              + ad='(max(w/ng,wmin)*z2/2*ng)/ng'
+              + ps='(2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2))/ng'
+              + pd='((max(w/ng,wmin)+z2)*ng)/ng'
               + dta=trise
               + ngcon=2
               + delvto=0
@@ -227,9 +227,9 @@
         .endif
     .else
         Nsg13_hv_pmos d g s b sg13g2_hv_pmos_psp_rf
-          + w=w
+          + w='w/ng'
           + l=l
-          + as='as' ad='ad' pd='pd' ps='ps' nf='ng' mult='m'
+          + as='as/ng' ad='ad/ng' pd='pd/ng' ps='ps/ng' nf=1 mult='m*ng'
           + dta=trise
           + ngcon=2
           + delvto=0
@@ -237,3 +237,4 @@
     .endif
 .endif
 .ends
+

--- a/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moshv_mod_mismatch.lib
+++ b/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moshv_mod_mismatch.lib
@@ -94,7 +94,7 @@
               + as='(max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2))/ng'
               + ad='(max(w/ng,wmin)*z2/2*ng)/ng'
               + ps='(2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2))/ng'
-              + pd='((max(w/ng,wmin)+z2)*ng)/ng'
+              + pd='(max(w/ng,wmin)+z2)'
               + dta=trise
               + ngcon=2
               + delvto='agauss(0, sg13g2_hv_nmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
@@ -133,7 +133,7 @@
               + as='(max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2))/ng'
               + ad='(max(w/ng,wmin)*z2/2*ng)/ng'
               + ps='(2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2))/ng'
-              + pd='((max(w/ng,wmin)+z2)*ng)/ng'
+              + pd='(max(w/ng,wmin)+z2)'
               + dta=trise
               + ngcon=2
               + delvto='agauss(0, sg13g2_hv_nmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
@@ -180,7 +180,7 @@
               + as='(max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2))/ng'
               + ad='(max(w/ng,wmin)*z2/2*ng)/ng'
               + ps='(2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2))/ng'
-              + pd='((max(w/ng,wmin)+z2)*ng)/ng'
+              + pd='(max(w/ng,wmin)+z2)'
               + dta=trise
               + ngcon=2
               + delvto='agauss(0, sg13g2_hv_pmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
@@ -219,7 +219,7 @@
               + as='(max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2))/ng'
               + ad='(max(w/ng,wmin)*z2/2*ng)/ng'
               + ps='(2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2))/ng'
-              + pd='((max(w/ng,wmin)+z2)*ng)/ng'
+              + pd='(max(w/ng,wmin)+z2)'
               + dta=trise
               + ngcon=2
               + delvto='agauss(0, sg13g2_hv_pmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'

--- a/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moshv_mod_mismatch.lib
+++ b/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moshv_mod_mismatch.lib
@@ -75,26 +75,26 @@
     .if (as <= 1e-50)
         .if (floor(floor(ng/2+0.501)*2+0.001) != ng)
             Nsg13_hv_nmos d g s b sg13g2_hv_nmos_psp
-              + w='agauss(w, sg13g2_hv_nmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
+              + w='agauss(w/ng, sg13g2_hv_nmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
               + l='agauss(l, sg13g2_hv_nmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
-              + nf='ng' mult='m'
-              + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
-              + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
-              + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
-              + pd='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+              + nf=1 mult='m*ng'
+              + as='(max(w/ng,wmin)*(z1+((ng-1)/2)*z2))/ng'
+              + ad='(max(w/ng,wmin)*(z1+((ng-1)/2)*z2))/ng'
+              + ps='(2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2))/ng'
+              + pd='(2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2))/ng'
               + dta=trise
               + ngcon=2
               + delvto='agauss(0, sg13g2_hv_nmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
               + factuo='agauss(1, sg13g2_hv_nmos_factuo_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
         .else
             Nsg13_hv_nmos d g s b sg13g2_hv_nmos_psp
-              + w='agauss(w, sg13g2_hv_nmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
+              + w='agauss(w/ng, sg13g2_hv_nmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
               + l='agauss(l, sg13g2_hv_nmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
-              + nf='ng' mult='m'
-              + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)'
-              + ad='max(w/ng,wmin)*z2/2*ng'
-              + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)'
-              + pd='(max(w/ng,wmin)+z2)*ng'
+              + nf=1 mult='m*ng'
+              + as='(max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2))/ng'
+              + ad='(max(w/ng,wmin)*z2/2*ng)/ng'
+              + ps='(2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2))/ng'
+              + pd='((max(w/ng,wmin)+z2)*ng)/ng'
               + dta=trise
               + ngcon=2
               + delvto='agauss(0, sg13g2_hv_nmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
@@ -102,9 +102,9 @@
         .endif
     .else
         Nsg13_hv_nmos d g s b sg13g2_hv_nmos_psp
-          + w='agauss(w, sg13g2_hv_nmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
+          + w='agauss(w/ng, sg13g2_hv_nmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
           + l='agauss(l, sg13g2_hv_nmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
-          + as='as' ad='ad' pd='pd' ps='ps' nf='ng' mult='m'
+          + as='as/ng' ad='ad/ng' pd='pd/ng' ps='ps/ng' nf=1 mult='m*ng'
           + dta=trise
           + ngcon=2
           + delvto='agauss(0, sg13g2_hv_nmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
@@ -114,26 +114,26 @@
     .if (as <= 1e-50)
         .if (floor(floor(ng/2+0.501)*2+0.001) != ng)
             Nsg13_hv_nmos d g s b sg13g2_hv_nmos_psp_rf
-              + w='agauss(w, sg13g2_hv_nmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
+              + w='agauss(w/ng, sg13g2_hv_nmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
               + l='agauss(l, sg13g2_hv_nmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
-              + nf='ng' mult='m'
-              + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
-              + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
-              + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
-              + pd='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+              + nf=1 mult='m*ng'
+              + as='(max(w/ng,wmin)*(z1+((ng-1)/2)*z2))/ng'
+              + ad='(max(w/ng,wmin)*(z1+((ng-1)/2)*z2))/ng'
+              + ps='(2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2))/ng'
+              + pd='(2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2))/ng'
               + dta=trise
               + ngcon=2
               + delvto='agauss(0, sg13g2_hv_nmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
               + factuo='agauss(1, sg13g2_hv_nmos_factuo_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
         .else
             Nsg13_hv_nmos d g s b sg13g2_hv_nmos_psp_rf
-              + w='agauss(w, sg13g2_hv_nmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
+              + w='agauss(w/ng, sg13g2_hv_nmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
               + l='agauss(l, sg13g2_hv_nmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
-              + nf='ng' mult='m'
-              + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)'
-              + ad='max(w/ng,wmin)*z2/2*ng'
-              + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)'
-              + pd='(max(w/ng,wmin)+z2)*ng'
+              + nf=1 mult='m*ng'
+              + as='(max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2))/ng'
+              + ad='(max(w/ng,wmin)*z2/2*ng)/ng'
+              + ps='(2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2))/ng'
+              + pd='((max(w/ng,wmin)+z2)*ng)/ng'
               + dta=trise
               + ngcon=2
               + delvto='agauss(0, sg13g2_hv_nmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
@@ -141,9 +141,9 @@
         .endif
     .else
         Nsg13_hv_nmos d g s b sg13g2_hv_nmos_psp_rf
-          + w='agauss(w, sg13g2_hv_nmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
+          + w='agauss(w/ng, sg13g2_hv_nmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
           + l='agauss(l, sg13g2_hv_nmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
-          + as='as' ad='ad' pd='pd' ps='ps' nf='ng' mult='m'
+          + as='as/ng' ad='ad/ng' pd='pd/ng' ps='ps/ng' nf=1 mult='m*ng'
           + dta=trise
           + ngcon=2
           + delvto='agauss(0, sg13g2_hv_nmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
@@ -161,26 +161,26 @@
     .if (as <= 1e-50)
         .if (floor(floor(ng/2+0.501)*2+0.001) != ng)
             Nsg13_hv_pmos d g s b sg13g2_hv_pmos_psp
-              + w='agauss(w, sg13g2_hv_pmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
+              + w='agauss(w/ng, sg13g2_hv_pmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
               + l='agauss(l, sg13g2_hv_pmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
-              + nf='ng' mult='m'
-              + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
-              + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
-              + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
-              + pd='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+              + nf=1 mult='m*ng'
+              + as='(max(w/ng,wmin)*(z1+((ng-1)/2)*z2))/ng'
+              + ad='(max(w/ng,wmin)*(z1+((ng-1)/2)*z2))/ng'
+              + ps='(2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2))/ng'
+              + pd='(2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2))/ng'
               + dta=trise
               + ngcon=2
               + delvto='agauss(0, sg13g2_hv_pmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
               + factuo='agauss(1, sg13g2_hv_pmos_factuo_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
         .else
             Nsg13_hv_pmos d g s b sg13g2_hv_pmos_psp
-              + w='agauss(w, sg13g2_hv_pmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
+              + w='agauss(w/ng, sg13g2_hv_pmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
               + l='agauss(l, sg13g2_hv_pmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
-              + nf='ng' mult='m'
-              + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)'
-              + ad='max(w/ng,wmin)*z2/2*ng'
-              + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)'
-              + pd='(max(w/ng,wmin)+z2)*ng'
+              + nf=1 mult='m*ng'
+              + as='(max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2))/ng'
+              + ad='(max(w/ng,wmin)*z2/2*ng)/ng'
+              + ps='(2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2))/ng'
+              + pd='((max(w/ng,wmin)+z2)*ng)/ng'
               + dta=trise
               + ngcon=2
               + delvto='agauss(0, sg13g2_hv_pmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
@@ -188,9 +188,9 @@
         .endif
     .else
         Nsg13_hv_pmos d g s b sg13g2_hv_pmos_psp
-          + w='agauss(w, sg13g2_hv_pmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
+          + w='agauss(w/ng, sg13g2_hv_pmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
           + l='agauss(l, sg13g2_hv_pmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
-          + as='as' ad='ad' pd='pd' ps='ps' nf='ng' mult='m'
+          + as='as/ng' ad='ad/ng' pd='pd/ng' ps='ps/ng' nf=1 mult='m*ng'
           + dta=trise
           + ngcon=2
           + delvto='agauss(0, sg13g2_hv_pmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
@@ -200,26 +200,26 @@
     .if (as <= 1e-50)
         .if (floor(floor(ng/2+0.501)*2+0.001) != ng)
             Nsg13_hv_pmos d g s b sg13g2_hv_pmos_psp_rf
-              + w='agauss(w, sg13g2_hv_pmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
+              + w='agauss(w/ng, sg13g2_hv_pmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
               + l='agauss(l, sg13g2_hv_pmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
-              + nf='ng' mult='m'
-              + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
-              + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
-              + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
-              + pd='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+              + nf=1 mult='m*ng'
+              + as='(max(w/ng,wmin)*(z1+((ng-1)/2)*z2))/ng'
+              + ad='(max(w/ng,wmin)*(z1+((ng-1)/2)*z2))/ng'
+              + ps='(2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2))/ng'
+              + pd='(2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2))/ng'
               + dta=trise
               + ngcon=2
               + delvto='agauss(0, sg13g2_hv_pmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
               + factuo='agauss(1, sg13g2_hv_pmos_factuo_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
         .else
             Nsg13_hv_pmos d g s b sg13g2_hv_pmos_psp_rf
-              + w='agauss(w, sg13g2_hv_pmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
+              + w='agauss(w/ng, sg13g2_hv_pmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
               + l='agauss(l, sg13g2_hv_pmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
-              + nf='ng' mult='m'
-              + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)'
-              + ad='max(w/ng,wmin)*z2/2*ng'
-              + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)'
-              + pd='(max(w/ng,wmin)+z2)*ng'
+              + nf=1 mult='m*ng'
+              + as='(max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2))/ng'
+              + ad='(max(w/ng,wmin)*z2/2*ng)/ng'
+              + ps='(2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2))/ng'
+              + pd='((max(w/ng,wmin)+z2)*ng)/ng'
               + dta=trise
               + ngcon=2
               + delvto='agauss(0, sg13g2_hv_pmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
@@ -227,9 +227,9 @@
         .endif
     .else
         Nsg13_hv_pmos d g s b sg13g2_hv_pmos_psp_rf
-          + w='agauss(w, sg13g2_hv_pmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
+          + w='agauss(w/ng, sg13g2_hv_pmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
           + l='agauss(l, sg13g2_hv_pmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
-          + as='as' ad='ad' pd='pd' ps='ps' nf='ng' mult='m'
+          + as='as/ng' ad='ad/ng' pd='pd/ng' ps='ps/ng' nf=1 mult='m*ng'
           + dta=trise
           + ngcon=2
           + delvto='agauss(0, sg13g2_hv_pmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
@@ -237,3 +237,4 @@
     .endif
 .endif
 .ends
+

--- a/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moshv_mod_mismatch.lib
+++ b/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moshv_mod_mismatch.lib
@@ -92,7 +92,7 @@
               + l='agauss(l, sg13g2_hv_nmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
               + nf=1 mult='m*ng'
               + as='(max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2))/ng'
-              + ad='(max(w/ng,wmin)*z2/2*ng)/ng'
+              + ad='max(w/ng,wmin)*z2/2'
               + ps='(2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2))/ng'
               + pd='(max(w/ng,wmin)+z2)'
               + dta=trise
@@ -131,7 +131,7 @@
               + l='agauss(l, sg13g2_hv_nmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
               + nf=1 mult='m*ng'
               + as='(max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2))/ng'
-              + ad='(max(w/ng,wmin)*z2/2*ng)/ng'
+              + ad='max(w/ng,wmin)*z2/2'
               + ps='(2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2))/ng'
               + pd='(max(w/ng,wmin)+z2)'
               + dta=trise
@@ -178,7 +178,7 @@
               + l='agauss(l, sg13g2_hv_pmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
               + nf=1 mult='m*ng'
               + as='(max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2))/ng'
-              + ad='(max(w/ng,wmin)*z2/2*ng)/ng'
+              + ad='max(w/ng,wmin)*z2/2'
               + ps='(2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2))/ng'
               + pd='(max(w/ng,wmin)+z2)'
               + dta=trise
@@ -217,7 +217,7 @@
               + l='agauss(l, sg13g2_hv_pmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
               + nf=1 mult='m*ng'
               + as='(max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2))/ng'
-              + ad='(max(w/ng,wmin)*z2/2*ng)/ng'
+              + ad='max(w/ng,wmin)*z2/2'
               + ps='(2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2))/ng'
               + pd='(max(w/ng,wmin)+z2)'
               + dta=trise

--- a/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moslv_mod.lib
+++ b/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moslv_mod.lib
@@ -92,7 +92,7 @@
               + l=l
               + nf=1 mult='m*ng'
               + as='(max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2))/ng'
-              + ad='(max(w/ng,wmin)*z2/2*ng)/ng'
+              + ad='max(w/ng,wmin)*z2/2'
               + ps='(2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2))/ng'
               + pd='(max(w/ng,wmin)+z2)'
               + dta=trise
@@ -131,7 +131,7 @@
               + l=l
               + nf=1 mult='m*ng'
               + as='(max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2))/ng'
-              + ad='(max(w/ng,wmin)*z2/2*ng)/ng'
+              + ad='max(w/ng,wmin)*z2/2'
               + ps='(2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2))/ng'
               + pd='(max(w/ng,wmin)+z2)'
               + dta=trise
@@ -178,7 +178,7 @@
               + l=l
               + nf=1 mult='m*ng'
               + as='(max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2))/ng'
-              + ad='(max(w/ng,wmin)*z2/2*ng)/ng'
+              + ad='max(w/ng,wmin)*z2/2'
               + ps='(2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2))/ng'
               + pd='(max(w/ng,wmin)+z2)'
               + dta=trise
@@ -217,7 +217,7 @@
               + l=l
               + nf=1 mult='m*ng'
               + as='(max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2))/ng'
-              + ad='(max(w/ng,wmin)*z2/2*ng)/ng'
+              + ad='max(w/ng,wmin)*z2/2'
               + ps='(2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2))/ng'
               + pd='(max(w/ng,wmin)+z2)'
               + dta=trise

--- a/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moslv_mod.lib
+++ b/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moslv_mod.lib
@@ -75,26 +75,26 @@
     .if (as <= 1e-50)
         .if (floor(floor(ng/2+0.501)*2+0.001) != ng)
             Nsg13_lv_nmos d g s b sg13g2_lv_nmos_psp
-              + w=w 
+              + w='w/ng' 
               + l=l
-              + nf='ng' mult='m'
-              + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
-              + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
-              + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
-              + pd='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+              + nf=1 mult='m*ng'
+              + as='(max(w/ng,wmin)*(z1+((ng-1)/2)*z2))/ng'
+              + ad='(max(w/ng,wmin)*(z1+((ng-1)/2)*z2))/ng'
+              + ps='(2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2))/ng'
+              + pd='(2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2))/ng'
               + dta=trise
               + ngcon=2
               + delvto=0
               + factuo=1
         .else
             Nsg13_lv_nmos d g s b sg13g2_lv_nmos_psp
-              + w=w
+              + w='w/ng'
               + l=l
-              + nf='ng' mult='m'
-              + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)'
-              + ad='max(w/ng,wmin)*z2/2*ng'
-              + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)'
-              + pd='(max(w/ng,wmin)+z2)*ng'
+              + nf=1 mult='m*ng'
+              + as='(max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2))/ng'
+              + ad='(max(w/ng,wmin)*z2/2*ng)/ng'
+              + ps='(2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2))/ng'
+              + pd='((max(w/ng,wmin)+z2)*ng)/ng'
               + dta=trise
               + ngcon=2
               + delvto=0
@@ -102,9 +102,9 @@
         .endif
     .else
         Nsg13_lv_nmos d g s b sg13g2_lv_nmos_psp
-          + w=w
+          + w='w/ng'
           + l=l
-          + as='as' ad='ad' pd='pd' ps='ps' nf='ng' mult='m'
+          + as='as/ng' ad='ad/ng' pd='pd/ng' ps='ps/ng' nf=1 mult='m*ng'
           + dta=trise
           + ngcon=2
           + delvto=0
@@ -114,26 +114,26 @@
     .if (as <= 1e-50)
         .if (floor(floor(ng/2+0.501)*2+0.001) != ng)
             Nsg13_lv_nmos d g s b sg13g2_lv_nmos_psp_rf
-              + w=w 
+              + w='w/ng' 
               + l=l
-              + nf='ng' mult='m'
-              + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
-              + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
-              + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
-              + pd='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+              + nf=1 mult='m*ng'
+              + as='(max(w/ng,wmin)*(z1+((ng-1)/2)*z2))/ng'
+              + ad='(max(w/ng,wmin)*(z1+((ng-1)/2)*z2))/ng'
+              + ps='(2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2))/ng'
+              + pd='(2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2))/ng'
               + dta=trise
               + ngcon=2
               + delvto=0
               + factuo=1
         .else
             Nsg13_lv_nmos d g s b sg13g2_lv_nmos_psp_rf
-              + w=w
+              + w='w/ng'
               + l=l
-              + nf='ng' mult='m'
-              + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)'
-              + ad='max(w/ng,wmin)*z2/2*ng'
-              + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)'
-              + pd='(max(w/ng,wmin)+z2)*ng'
+              + nf=1 mult='m*ng'
+              + as='(max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2))/ng'
+              + ad='(max(w/ng,wmin)*z2/2*ng)/ng'
+              + ps='(2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2))/ng'
+              + pd='((max(w/ng,wmin)+z2)*ng)/ng'
               + dta=trise
               + ngcon=2
               + delvto=0
@@ -141,9 +141,9 @@
         .endif
     .else
         Nsg13_lv_nmos d g s b sg13g2_lv_nmos_psp_rf
-          + w=w
+          + w='w/ng'
           + l=l
-          + as='as' ad='ad' pd='pd' ps='ps' nf='ng' mult='m'
+          + as='as/ng' ad='ad/ng' pd='pd/ng' ps='ps/ng' nf=1 mult='m*ng'
           + dta=trise
           + ngcon=2
           + delvto=0
@@ -161,26 +161,26 @@
     .if (as <= 1e-50)
         .if (floor(floor(ng/2+0.501)*2+0.001) != ng)
             Nsg13_lv_pmos d g s b sg13g2_lv_pmos_psp
-              + w=w
+              + w='w/ng'
               + l=l
-              + nf='ng' mult='m'
-              + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
-              + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
-              + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
-              + pd='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+              + nf=1 mult='m*ng'
+              + as='(max(w/ng,wmin)*(z1+((ng-1)/2)*z2))/ng'
+              + ad='(max(w/ng,wmin)*(z1+((ng-1)/2)*z2))/ng'
+              + ps='(2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2))/ng'
+              + pd='(2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2))/ng'
               + dta=trise
               + ngcon=2
               + delvto=0
               + factuo=1
         .else
             Nsg13_lv_pmos d g s b sg13g2_lv_pmos_psp
-              + w=w
+              + w='w/ng'
               + l=l
-              + nf='ng' mult='m'
-              + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)'
-              + ad='max(w/ng,wmin)*z2/2*ng'
-              + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)'
-              + pd='(max(w/ng,wmin)+z2)*ng'
+              + nf=1 mult='m*ng'
+              + as='(max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2))/ng'
+              + ad='(max(w/ng,wmin)*z2/2*ng)/ng'
+              + ps='(2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2))/ng'
+              + pd='((max(w/ng,wmin)+z2)*ng)/ng'
               + dta=trise
               + ngcon=2
               + delvto=0
@@ -188,9 +188,9 @@
         .endif
     .else
         Nsg13_lv_pmos d g s b sg13g2_lv_pmos_psp
-          + w=w
+          + w='w/ng'
           + l=l
-          + as='as' ad='ad' pd='pd' ps='ps' nf='ng' mult='m'
+          + as='as/ng' ad='ad/ng' pd='pd/ng' ps='ps/ng' nf=1 mult='m*ng'
           + dta=trise
           + ngcon=2
           + delvto=0
@@ -200,26 +200,26 @@
     .if (as <= 1e-50)
         .if (floor(floor(ng/2+0.501)*2+0.001) != ng)
             Nsg13_lv_pmos d g s b sg13g2_lv_pmos_psp_rf
-              + w=w
+              + w='w/ng'
               + l=l
-              + nf='ng' mult='m'
-              + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
-              + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
-              + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
-              + pd='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+              + nf=1 mult='m*ng'
+              + as='(max(w/ng,wmin)*(z1+((ng-1)/2)*z2))/ng'
+              + ad='(max(w/ng,wmin)*(z1+((ng-1)/2)*z2))/ng'
+              + ps='(2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2))/ng'
+              + pd='(2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2))/ng'
               + dta=trise
               + ngcon=2
               + delvto=0
               + factuo=1
         .else
             Nsg13_lv_pmos d g s b sg13g2_lv_pmos_psp_rf
-              + w=w
+              + w='w/ng'
               + l=l
-              + nf='ng' mult='m'
-              + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)'
-              + ad='max(w/ng,wmin)*z2/2*ng'
-              + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)'
-              + pd='(max(w/ng,wmin)+z2)*ng'
+              + nf=1 mult='m*ng'
+              + as='(max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2))/ng'
+              + ad='(max(w/ng,wmin)*z2/2*ng)/ng'
+              + ps='(2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2))/ng'
+              + pd='((max(w/ng,wmin)+z2)*ng)/ng'
               + dta=trise
               + ngcon=2
               + delvto=0
@@ -227,9 +227,9 @@
         .endif
     .else
         Nsg13_lv_pmos d g s b sg13g2_lv_pmos_psp_rf
-          + w=w
+          + w='w/ng'
           + l=l
-          + as='as' ad='ad' pd='pd' ps='ps' nf='ng' mult='m'
+          + as='as/ng' ad='ad/ng' pd='pd/ng' ps='ps/ng' nf=1 mult='m*ng'
           + dta=trise
           + ngcon=2
           + delvto=0
@@ -264,3 +264,4 @@
 .ends nmoscl_4
 
 *****************************************************************
+

--- a/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moslv_mod.lib
+++ b/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moslv_mod.lib
@@ -94,7 +94,7 @@
               + as='(max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2))/ng'
               + ad='(max(w/ng,wmin)*z2/2*ng)/ng'
               + ps='(2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2))/ng'
-              + pd='((max(w/ng,wmin)+z2)*ng)/ng'
+              + pd='(max(w/ng,wmin)+z2)'
               + dta=trise
               + ngcon=2
               + delvto=0
@@ -133,7 +133,7 @@
               + as='(max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2))/ng'
               + ad='(max(w/ng,wmin)*z2/2*ng)/ng'
               + ps='(2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2))/ng'
-              + pd='((max(w/ng,wmin)+z2)*ng)/ng'
+              + pd='(max(w/ng,wmin)+z2)'
               + dta=trise
               + ngcon=2
               + delvto=0
@@ -180,7 +180,7 @@
               + as='(max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2))/ng'
               + ad='(max(w/ng,wmin)*z2/2*ng)/ng'
               + ps='(2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2))/ng'
-              + pd='((max(w/ng,wmin)+z2)*ng)/ng'
+              + pd='(max(w/ng,wmin)+z2)'
               + dta=trise
               + ngcon=2
               + delvto=0
@@ -219,7 +219,7 @@
               + as='(max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2))/ng'
               + ad='(max(w/ng,wmin)*z2/2*ng)/ng'
               + ps='(2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2))/ng'
-              + pd='((max(w/ng,wmin)+z2)*ng)/ng'
+              + pd='(max(w/ng,wmin)+z2)'
               + dta=trise
               + ngcon=2
               + delvto=0

--- a/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moslv_mod_mismatch.lib
+++ b/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moslv_mod_mismatch.lib
@@ -94,7 +94,7 @@
               + as='(max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2))/ng'
               + ad='(max(w/ng,wmin)*z2/2*ng)/ng'
               + ps='(2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2))/ng'
-              + pd='((max(w/ng,wmin)+z2)*ng)/ng'
+              + pd='(max(w/ng,wmin)+z2)'
               + dta=trise
               + ngcon=2
               + delvto='agauss(0, sg13g2_lv_nmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
@@ -133,7 +133,7 @@
               + as='(max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2))/ng'
               + ad='(max(w/ng,wmin)*z2/2*ng)/ng'
               + ps='(2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2))/ng'
-              + pd='((max(w/ng,wmin)+z2)*ng)/ng'
+              + pd='(max(w/ng,wmin)+z2)'
               + dta=trise
               + ngcon=2
               + delvto='agauss(0, sg13g2_lv_nmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
@@ -180,7 +180,7 @@
               + as='(max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2))/ng'
               + ad='(max(w/ng,wmin)*z2/2*ng)/ng'
               + ps='(2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2))/ng'
-              + pd='((max(w/ng,wmin)+z2)*ng)/ng'
+              + pd='(max(w/ng,wmin)+z2)'
               + dta=trise
               + ngcon=2
               + delvto='agauss(0, sg13g2_lv_pmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
@@ -219,7 +219,7 @@
               + as='(max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2))/ng'
               + ad='(max(w/ng,wmin)*z2/2*ng)/ng'
               + ps='(2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2))/ng'
-              + pd='((max(w/ng,wmin)+z2)*ng)/ng'
+              + pd='(max(w/ng,wmin)+z2)'
               + dta=trise
               + ngcon=2
               + delvto='agauss(0, sg13g2_lv_pmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'

--- a/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moslv_mod_mismatch.lib
+++ b/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moslv_mod_mismatch.lib
@@ -75,26 +75,26 @@
     .if (as <= 1e-50)
         .if (floor(floor(ng/2+0.501)*2+0.001) != ng)
             Nsg13_lv_nmos d g s b sg13g2_lv_nmos_psp
-              + w='agauss(w, sg13g2_lv_nmos_dw_mm, (mm_ok != 1 ? 0 : 1))' 
+              + w='agauss(w/ng, sg13g2_lv_nmos_dw_mm, (mm_ok != 1 ? 0 : 1))' 
               + l='agauss(l, sg13g2_lv_nmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
-              + nf='ng' mult='m'
-              + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
-              + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
-              + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
-              + pd='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+              + nf=1 mult='m*ng'
+              + as='(max(w/ng,wmin)*(z1+((ng-1)/2)*z2))/ng'
+              + ad='(max(w/ng,wmin)*(z1+((ng-1)/2)*z2))/ng'
+              + ps='(2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2))/ng'
+              + pd='(2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2))/ng'
               + dta=trise
               + ngcon=2
               + delvto='agauss(0, sg13g2_lv_nmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
               + factuo='agauss(1, sg13g2_lv_nmos_factuo_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
         .else
             Nsg13_lv_nmos d g s b sg13g2_lv_nmos_psp
-              + w='agauss(w, sg13g2_lv_nmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
+              + w='agauss(w/ng, sg13g2_lv_nmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
               + l='agauss(l, sg13g2_lv_nmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
-              + nf='ng' mult='m'
-              + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)'
-              + ad='max(w/ng,wmin)*z2/2*ng'
-              + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)'
-              + pd='(max(w/ng,wmin)+z2)*ng'
+              + nf=1 mult='m*ng'
+              + as='(max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2))/ng'
+              + ad='(max(w/ng,wmin)*z2/2*ng)/ng'
+              + ps='(2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2))/ng'
+              + pd='((max(w/ng,wmin)+z2)*ng)/ng'
               + dta=trise
               + ngcon=2
               + delvto='agauss(0, sg13g2_lv_nmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
@@ -102,9 +102,9 @@
         .endif
     .else
         Nsg13_lv_nmos d g s b sg13g2_lv_nmos_psp
-          + w='agauss(w, sg13g2_lv_nmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
+          + w='agauss(w/ng, sg13g2_lv_nmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
           + l='agauss(l, sg13g2_lv_nmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
-          + as='as' ad='ad' pd='pd' ps='ps' nf='ng' mult='m'
+          + as='as/ng' ad='ad/ng' pd='pd/ng' ps='ps/ng' nf=1 mult='m*ng'
           + dta=trise
           + ngcon=2
           + delvto='agauss(0, sg13g2_lv_nmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
@@ -114,26 +114,26 @@
     .if (as <= 1e-50)
         .if (floor(floor(ng/2+0.501)*2+0.001) != ng)
             Nsg13_lv_nmos d g s b sg13g2_lv_nmos_psp_rf
-              + w='agauss(w, sg13g2_lv_nmos_dw_mm, (mm_ok != 1 ? 0 : 1))' 
+              + w='agauss(w/ng, sg13g2_lv_nmos_dw_mm, (mm_ok != 1 ? 0 : 1))' 
               + l='agauss(l, sg13g2_lv_nmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
-              + nf='ng' mult='m'
-              + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
-              + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
-              + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
-              + pd='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+              + nf=1 mult='m*ng'
+              + as='(max(w/ng,wmin)*(z1+((ng-1)/2)*z2))/ng'
+              + ad='(max(w/ng,wmin)*(z1+((ng-1)/2)*z2))/ng'
+              + ps='(2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2))/ng'
+              + pd='(2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2))/ng'
               + dta=trise
               + ngcon=2
               + delvto='agauss(0, sg13g2_lv_nmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
               + factuo='agauss(1, sg13g2_lv_nmos_factuo_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
         .else
             Nsg13_lv_nmos d g s b sg13g2_lv_nmos_psp_rf
-              + w='agauss(w, sg13g2_lv_nmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
+              + w='agauss(w/ng, sg13g2_lv_nmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
               + l='agauss(l, sg13g2_lv_nmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
-              + nf='ng' mult='m'
-              + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)'
-              + ad='max(w/ng,wmin)*z2/2*ng'
-              + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)'
-              + pd='(max(w/ng,wmin)+z2)*ng'
+              + nf=1 mult='m*ng'
+              + as='(max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2))/ng'
+              + ad='(max(w/ng,wmin)*z2/2*ng)/ng'
+              + ps='(2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2))/ng'
+              + pd='((max(w/ng,wmin)+z2)*ng)/ng'
               + dta=trise
               + ngcon=2
               + delvto='agauss(0, sg13g2_lv_nmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
@@ -141,9 +141,9 @@
         .endif
     .else
         Nsg13_lv_nmos d g s b sg13g2_lv_nmos_psp_rf
-          + w='agauss(w, sg13g2_lv_nmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
+          + w='agauss(w/ng, sg13g2_lv_nmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
           + l='agauss(l, sg13g2_lv_nmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
-          + as='as' ad='ad' pd='pd' ps='ps' nf='ng' mult='m'
+          + as='as/ng' ad='ad/ng' pd='pd/ng' ps='ps/ng' nf=1 mult='m*ng'
           + dta=trise
           + ngcon=2
           + delvto='agauss(0, sg13g2_lv_nmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
@@ -161,26 +161,26 @@
     .if (as <= 1e-50)
         .if (floor(floor(ng/2+0.501)*2+0.001) != ng)
             Nsg13_lv_pmos d g s b sg13g2_lv_pmos_psp
-              + w='agauss(w, sg13g2_lv_pmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
+              + w='agauss(w/ng, sg13g2_lv_pmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
               + l='agauss(l, sg13g2_lv_pmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
-              + nf='ng' mult='m'
-              + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
-              + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
-              + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
-              + pd='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+              + nf=1 mult='m*ng'
+              + as='(max(w/ng,wmin)*(z1+((ng-1)/2)*z2))/ng'
+              + ad='(max(w/ng,wmin)*(z1+((ng-1)/2)*z2))/ng'
+              + ps='(2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2))/ng'
+              + pd='(2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2))/ng'
               + dta=trise
               + ngcon=2
               + delvto='agauss(0, sg13g2_lv_pmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
               + factuo='agauss(1, sg13g2_lv_pmos_factuo_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
         .else
             Nsg13_lv_pmos d g s b sg13g2_lv_pmos_psp
-              + w='agauss(w, sg13g2_lv_pmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
+              + w='agauss(w/ng, sg13g2_lv_pmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
               + l='agauss(l, sg13g2_lv_pmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
-              + nf='ng' mult='m'
-              + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)'
-              + ad='max(w/ng,wmin)*z2/2*ng'
-              + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)'
-              + pd='(max(w/ng,wmin)+z2)*ng'
+              + nf=1 mult='m*ng'
+              + as='(max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2))/ng'
+              + ad='(max(w/ng,wmin)*z2/2*ng)/ng'
+              + ps='(2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2))/ng'
+              + pd='((max(w/ng,wmin)+z2)*ng)/ng'
               + dta=trise
               + ngcon=2
               + delvto='agauss(0, sg13g2_lv_pmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
@@ -188,9 +188,9 @@
         .endif
     .else
         Nsg13_lv_pmos d g s b sg13g2_lv_pmos_psp
-          + w='agauss(w, sg13g2_lv_pmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
+          + w='agauss(w/ng, sg13g2_lv_pmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
           + l='agauss(l, sg13g2_lv_pmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
-          + as='as' ad='ad' pd='pd' ps='ps' nf='ng' mult='m'
+          + as='as/ng' ad='ad/ng' pd='pd/ng' ps='ps/ng' nf=1 mult='m*ng'
           + dta=trise
           + ngcon=2
           + delvto='agauss(0, sg13g2_lv_pmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
@@ -200,26 +200,26 @@
     .if (as <= 1e-50)
         .if (floor(floor(ng/2+0.501)*2+0.001) != ng)
             Nsg13_lv_pmos d g s b sg13g2_lv_pmos_psp_rf
-              + w='agauss(w, sg13g2_lv_pmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
+              + w='agauss(w/ng, sg13g2_lv_pmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
               + l='agauss(l, sg13g2_lv_pmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
-              + nf='ng' mult='m'
-              + as='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
-              + ad='max(w/ng,wmin)*(z1+((ng-1)/2)*z2)'
-              + ps='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
-              + pd='2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2)'
+              + nf=1 mult='m*ng'
+              + as='(max(w/ng,wmin)*(z1+((ng-1)/2)*z2))/ng'
+              + ad='(max(w/ng,wmin)*(z1+((ng-1)/2)*z2))/ng'
+              + ps='(2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2))/ng'
+              + pd='(2*(max(w/ng,wmin)*((ng-1)/2+1)+z1+(ng-1)/2*z2))/ng'
               + dta=trise
               + ngcon=2
               + delvto='agauss(0, sg13g2_lv_pmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
               + factuo='agauss(1, sg13g2_lv_pmos_factuo_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
         .else
             Nsg13_lv_pmos d g s b sg13g2_lv_pmos_psp_rf
-              + w='agauss(w, sg13g2_lv_pmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
+              + w='agauss(w/ng, sg13g2_lv_pmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
               + l='agauss(l, sg13g2_lv_pmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
-              + nf='ng' mult='m'
-              + as='max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2)'
-              + ad='max(w/ng,wmin)*z2/2*ng'
-              + ps='2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2)'
-              + pd='(max(w/ng,wmin)+z2)*ng'
+              + nf=1 mult='m*ng'
+              + as='(max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2))/ng'
+              + ad='(max(w/ng,wmin)*z2/2*ng)/ng'
+              + ps='(2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2))/ng'
+              + pd='((max(w/ng,wmin)+z2)*ng)/ng'
               + dta=trise
               + ngcon=2
               + delvto='agauss(0, sg13g2_lv_pmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
@@ -227,9 +227,9 @@
         .endif
     .else
         Nsg13_lv_pmos d g s b sg13g2_lv_pmos_psp_rf
-          + w='agauss(w, sg13g2_lv_pmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
+          + w='agauss(w/ng, sg13g2_lv_pmos_dw_mm, (mm_ok != 1 ? 0 : 1))'
           + l='agauss(l, sg13g2_lv_pmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
-          + as='as' ad='ad' pd='pd' ps='ps' nf='ng' mult='m'
+          + as='as/ng' ad='ad/ng' pd='pd/ng' ps='ps/ng' nf=1 mult='m*ng'
           + dta=trise
           + ngcon=2
           + delvto='agauss(0, sg13g2_lv_pmos_delvto_mm/sqrt(m*l*w*1e12), (mm_ok != 1 ? 0 : 1))'
@@ -264,3 +264,4 @@
 .ends nmoscl_4
 
 *****************************************************************
+

--- a/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moslv_mod_mismatch.lib
+++ b/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_moslv_mod_mismatch.lib
@@ -92,7 +92,7 @@
               + l='agauss(l, sg13g2_lv_nmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
               + nf=1 mult='m*ng'
               + as='(max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2))/ng'
-              + ad='(max(w/ng,wmin)*z2/2*ng)/ng'
+              + ad='max(w/ng,wmin)*z2/2'
               + ps='(2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2))/ng'
               + pd='(max(w/ng,wmin)+z2)'
               + dta=trise
@@ -131,7 +131,7 @@
               + l='agauss(l, sg13g2_lv_nmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
               + nf=1 mult='m*ng'
               + as='(max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2))/ng'
-              + ad='(max(w/ng,wmin)*z2/2*ng)/ng'
+              + ad='max(w/ng,wmin)*z2/2'
               + ps='(2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2))/ng'
               + pd='(max(w/ng,wmin)+z2)'
               + dta=trise
@@ -178,7 +178,7 @@
               + l='agauss(l, sg13g2_lv_pmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
               + nf=1 mult='m*ng'
               + as='(max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2))/ng'
-              + ad='(max(w/ng,wmin)*z2/2*ng)/ng'
+              + ad='max(w/ng,wmin)*z2/2'
               + ps='(2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2))/ng'
               + pd='(max(w/ng,wmin)+z2)'
               + dta=trise
@@ -217,7 +217,7 @@
               + l='agauss(l, sg13g2_lv_pmos_dl_mm, (mm_ok != 1 ? 0 : 1))'
               + nf=1 mult='m*ng'
               + as='(max(w/ng,wmin)*(2*z1+max(0,(ng-2)/2)*z2))/ng'
-              + ad='(max(w/ng,wmin)*z2/2*ng)/ng'
+              + ad='max(w/ng,wmin)*z2/2'
               + ps='(2*(max(w/ng,wmin)*(2+max(ng-2,0)/2)+2*z1+max(ng-2,0)/2*z2))/ng'
               + pd='(max(w/ng,wmin)+z2)'
               + dta=trise


### PR DESCRIPTION
## Summary

This PR fixes multi-finger geometry scaling for LV/HV NMOS and PMOS PSP wrappers.

Primitive calls now use per-finger width and explicit multiplicity:

```spice
w='w/ng'
nf=1
mult='m*ng'
```

Source/drain geometry is also passed per finger.

## Motivation

I found this while simulating an RF oscillator with `rfmode=1`. The design worked with `rfmode=0`, but with `rfmode=1` it behaved completely incorrectly (way too much off) and did not oscillate.

Reproducer:

https://github.com/p-fath/iruwbtx7

Without this PR, the oscillator does not oscillate using `rfmode=1` at the cross-coupled pair.

## Scope

Updated LV/HV NMOS/PMOS wrappers and mismatch wrappers. The PR did not change any behaviour if  `rfmode=0`, but it fixed the faulty behaviour if  `rfmode=1`.

ESD MOS clamp devices are unchanged.
