### PR TITLE
fix(KLayout/PyCell/rppd,rhigh): handle large poly spacing and even-number bends

### DIFF
--- a/ihp-sg13g2/libs.tech/klayout/python/sg13g2_pycell_lib/ihp/rhigh_code.py
+++ b/ihp-sg13g2/libs.tech/klayout/python/sg13g2_pycell_lib/ihp/rhigh_code.py
@@ -373,7 +373,7 @@ class rhigh(ResistorBase):
                     dbCreateRect(self, sallayer, Box(xpos1+w+ps-salover, ypos1, xpos1+stripes*(w+ps)-ps+salover, ypos1-w-salover))
                     # 09.02.07 GGa added EXTBlock
                     dbCreateRect(self, extBlocklayer, Box(xpos1-salover, ypos2, xpos1+(stripes-1)*(w+ps)-ps+salover, ypos2+w+salover))
-                    dbCreateRect(self, sallayer, Box(xpos1+w+ps-salover, ypos1, xpos1+stripes*(w+ps)-ps+salover, ypos1-w-salover))
+                    dbCreateRect(self, sallayer, Box(xpos1-salover, ypos2, xpos1+(stripes-1)*(w+ps)-ps+salover, ypos2+w+salover))
                     # 09.02.07 GGa added EXTBlock
                     dbCreateRect(self, extBlocklayer, Box(xpos1+w+ps-salover, ypos1, xpos1+stripes*(w+ps)-ps+salover, ypos1-w-salover))
                     dbCreateRect(self, psdlayer, Box(xpos1-psdover, ypos2, xpos1+(stripes-1)*(w+ps)-ps+psdover, ypos2+w+psdover))

--- a/ihp-sg13g2/libs.tech/klayout/python/sg13g2_pycell_lib/ihp/rppd_code.py
+++ b/ihp-sg13g2/libs.tech/klayout/python/sg13g2_pycell_lib/ihp/rppd_code.py
@@ -343,7 +343,7 @@ class rppd(ResistorBase):
             if stripes > 1 :  # cover Bends
                 if oddp(stripes) :   # odd stripesnumber
                     dbCreateRect(self, sallayer, Box(xpos1-salover, ypos2,
-                                                     xpos1+(stripes-1)*(self.w+self.ps)-ps+salover, ypos2+self.w+salover))
+                                                     xpos1+(stripes-1)*(self.w+self.ps)-self.ps+salover, ypos2+self.w+salover))
                     dbCreateRect(self, extBlocklayer, Box(xpos1-salover, ypos2,
                                                           xpos1+(stripes-1)*(self.w+self.ps)-self.ps+salover, ypos2+self.w+salover))
                     dbCreateRect(self, sallayer, Box(xpos1+self.w+self.ps-salover, ypos1,
@@ -463,7 +463,7 @@ class rppd(ResistorBase):
     
             if stripes > 2:
                 xpos1 = xpos1 - self.w - self.ps
-                dbCreateRect(self, psdlayer, Box(xpos1+w+psdover, ypos2, xpos1+self.w+self.ps-psdover, ypos2+dir*(li_salblock+poly_cont_len+psdover)))
+                dbCreateRect(self, psdlayer, Box(xpos1+self.w+psdover, ypos2, xpos1+self.w+self.ps-psdover, ypos2+dir*(li_salblock+poly_cont_len+psdover)))
                 
         # **************************************************************
         # now draw the label


### PR DESCRIPTION
## What

This fixes some bugs seen when using large poly spacing (`ps >= 0.4u`) and when using even-numbered bends.

## How

* b03be81: Fixes the issue in #987, where the PyCell creation stopped due to a Python error. The fix was to consistently refer to the parameters relative to `self`; in this particular case, it was `self.ps` and `self.w`.

* 88a0f58: Fixes the issue in #986, where `SalBlock.drawing` was missing on the "top" of the resistor when using an even number of bends and `ps >= 0.4u`. The fix removes a duplicate box, replacing its geometry with the matching `EXTBlock.drawing` rectangle coordinates.

## Example

### `rhigh`: missing salblock

| Before | This PR |
| ------- | ---------|
|<img width="100%" height="938" alt="Image" src="https://github.com/user-attachments/assets/6a15bc9c-0857-4543-91f6-ad81abddd5ed" /><br> NOTE: Image from the bug report (#986)  | <img width="100%" height="1051" alt="image" src="https://github.com/user-attachments/assets/9e517a85-7ea3-455a-93be-c7b6a9469610" /> |


### `rppd`: crashing during layout generation

| Before | This PR |
| ------- | ---------|
| <img width="100%" height="825" alt="image" src="https://github.com/user-attachments/assets/1d1e6492-a031-4da6-95bb-2922efe2f4d2" /><br> NOTE: Image from the bug report (#987)| <img width="100%" height="880" alt="image" src="https://github.com/user-attachments/assets/6305889a-1081-43a4-8cdb-080bb19cbdbf" /> |

Fixes #986
Fixes #987
