### PR TITLE
mm_ok param in instance for  Resistors, Capacitors, HBTs and MOS's for Qucs-S

### DIFF
--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/cap_cmim.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/cap_cmim.xml
@@ -46,7 +46,7 @@
         <Parameter name="C" unit="F" equation="m*((w*l*1.e-3) + 2*(w+l)*40e-12)" show="true">
             <Description>Capacitance value</Description>
         </Parameter>
-        <Parameter name="mm_ok" unit="" default_value="0" show="false">
+        <Parameter name="mm_ok" unit="" default_value="1" show="false">
             <Description>[0,1]</Description>
         </Parameter>
     </Parameters>

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/cap_cmim.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/cap_cmim.xml
@@ -15,10 +15,13 @@
     <Netlists>
         <NgspiceNetlist value=
             "{{{Letter}}}::schematic_id='nequal'C{PartCounter} {nets} {{{model}}}::model='nonempty'
-            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' m={m}">
+            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' m={m} mm_ok={mm_ok}">
         </NgspiceNetlist>
-        <CDLNetlist value="{NgspiceNetlist}"></CDLNetlist>
-    </Netlists>
+        <CDLNetlist value=
+            "{{{Letter}}}::schematic_id='nequal'C{PartCounter} {nets} {{{model}}}::model='nonempty'
+            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' m={m}">
+        </CDLNetlist>
+   </Netlists>
     <Symbols>
         <Symbol id="Standard">
             <File>{QUCS_S_COMPONENTS_LIBRARY}/Capacitor.sym</File>
@@ -42,6 +45,9 @@
         </Parameter>
         <Parameter name="C" unit="F" equation="m*((w*l*1.e-3) + 2*(w+l)*40e-12)" show="true">
             <Description>Capacitance value</Description>
+        </Parameter>
+        <Parameter name="mm_ok" unit="" default_value="0" show="false">
+            <Description>[0,1]</Description>
         </Parameter>
     </Parameters>
 </Component>

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/cap_rfcmim.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/cap_rfcmim.xml
@@ -15,9 +15,12 @@
     <Netlists>
         <NgspiceNetlist value=
             "{{{Letter}}}::schematic_id='nequal'C{PartCounter} {nets} {bulk} {{{model}}}::model='nonempty'
-            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty'  {{wfeed={wfeed}}}::wfeed='nonempty'  {{m={m}}}::m='nonempty' ">
+            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty'  {{wfeed={wfeed}}}::wfeed='nonempty'  {{m={m}}}::m='nonempty' mm_ok={mm_ok}">
         </NgspiceNetlist>
-        <CDLNetlist value="{NgspiceNetlist}"></CDLNetlist>
+        <CDLNetlist value=
+            "{{{Letter}}}::schematic_id='nequal'C{PartCounter} {nets} {bulk} {{{model}}}::model='nonempty'
+            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty'  {{wfeed={wfeed}}}::wfeed='nonempty'  {{m={m}}}::m='nonempty' ">
+        </CDLNetlist>
     </Netlists>
     <Symbols>
         <Symbol id="Standard">
@@ -48,6 +51,9 @@
         </Parameter>
         <Parameter name="m" unit="" default_value="1" show="false">
             <Description>Multiplier</Description>
+        </Parameter>
+        <Parameter name="mm_ok" unit="" default_value="0" show="false">
+            <Description>[0,1]</Description>
         </Parameter>
     </Parameters>
 </Component>

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/cap_rfcmim.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/cap_rfcmim.xml
@@ -52,7 +52,7 @@
         <Parameter name="m" unit="" default_value="1" show="false">
             <Description>Multiplier</Description>
         </Parameter>
-        <Parameter name="mm_ok" unit="" default_value="0" show="false">
+        <Parameter name="mm_ok" unit="" default_value="1" show="false">
             <Description>[0,1]</Description>
         </Parameter>
     </Parameters>

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/nmos.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/nmos.xml
@@ -48,7 +48,7 @@
         <Parameter name="m" unit="" default_value="1" show="false">
             <Description>Multiplier</Description>
         </Parameter>
-        <Parameter name="mm_ok" unit="" default_value="0" show="false">
+        <Parameter name="mm_ok" unit="" default_value="1" show="false">
             <Description>[0,1]</Description>
         </Parameter>
     </Parameters>

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/nmos.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/nmos.xml
@@ -15,9 +15,11 @@
     <Netlists>
         <NgspiceNetlist value=
             "{{{Letter}}}::schematic_id='nequal'M{PartCounter} {nets} {{{model}}}::model='nonempty'
-            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{m={m}}}::m='nonempty'">
+            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{m={m}}}::m='nonempty' mm_ok={mm_ok}">
         </NgspiceNetlist>
-        <CDLNetlist value="{NgspiceNetlist}"> </CDLNetlist>
+        <CDLNetlist value=
+            "{{{Letter}}}::schematic_id='nequal'M{PartCounter} {nets} {{{model}}}::model='nonempty'
+            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{m={m}}}::m='nonempty'"> </CDLNetlist>
     </Netlists>
     <Symbols>
         <Symbol id="Standard">
@@ -45,6 +47,9 @@
         </Parameter>
         <Parameter name="m" unit="" default_value="1" show="false">
             <Description>Multiplier</Description>
+        </Parameter>
+        <Parameter name="mm_ok" unit="" default_value="0" show="false">
+            <Description>[0,1]</Description>
         </Parameter>
     </Parameters>
 </Component>

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/nmosHV.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/nmosHV.xml
@@ -48,7 +48,7 @@
         <Parameter name="m" unit="" default_value="1" show="false">
             <Description>Multiplier</Description>
         </Parameter>
-        <Parameter name="mm_ok" unit="" default_value="0" show="false">
+        <Parameter name="mm_ok" unit="" default_value="1" show="false">
             <Description>[0,1]</Description>
         </Parameter>
     </Parameters>

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/nmosHV.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/nmosHV.xml
@@ -15,9 +15,11 @@
     <Netlists>
         <NgspiceNetlist value=
             "{{{Letter}}}::schematic_id='nequal'M{PartCounter} {nets} {{{model}}}::model='nonempty'
-            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{m={m}}}::m='nonempty'">
+            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{m={m}}}::m='nonempty' mm_ok={mm_ok}">
         </NgspiceNetlist>
-        <CDLNetlist value="{NgspiceNetlist}"> </CDLNetlist>
+        <CDLNetlist value=
+            "{{{Letter}}}::schematic_id='nequal'M{PartCounter} {nets} {{{model}}}::model='nonempty'
+            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{m={m}}}::m='nonempty'"> </CDLNetlist>
     </Netlists>
     <Symbols>
         <Symbol id="Standard">
@@ -45,6 +47,9 @@
         </Parameter>
         <Parameter name="m" unit="" default_value="1" show="false">
             <Description>Multiplier</Description>
+        </Parameter>
+        <Parameter name="mm_ok" unit="" default_value="0" show="false">
+            <Description>[0,1]</Description>
         </Parameter>
     </Parameters>
 </Component>

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/npn13g2.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/npn13g2.xml
@@ -40,7 +40,7 @@
         <Parameter name="type" unit="" default_value="npn" show="false">
             <Description>Device type</Description>
         </Parameter>
-        <Parameter name="mm_ok" unit="" default_value="0" show="false">
+        <Parameter name="mm_ok" unit="" default_value="1" show="false">
             <Description>[0,1]</Description>
         </Parameter>
     </Parameters>

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/npn13g2.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/npn13g2.xml
@@ -15,9 +15,9 @@
     <Netlists>
         <NgspiceNetlist value=
             "{{{Letter}}}::schematic_id='nequal'Q{PartCounter} {nets} {bulk} {{{model}}}::model='nonempty'
-            {{Nx={Nx}}}::Nx='nonempty' ">
+            {{Nx={Nx}}}::Nx='nonempty' mm_ok={mm_ok}">
         </NgspiceNetlist>
-        <CDLNetlist value="{NgspiceNetlist}"></CDLNetlist>
+        <CDLNetlist value="{{{Letter}}}::schematic_id='nequal'Q{PartCounter} {nets} {bulk} {{{model}}}::model='nonempty' {{Nx={Nx}}}::Nx='nonempty'"></CDLNetlist>
     </Netlists>
     <Symbols>
         <Symbol id="Standard">
@@ -39,6 +39,9 @@
         </Parameter>
         <Parameter name="type" unit="" default_value="npn" show="false">
             <Description>Device type</Description>
+        </Parameter>
+        <Parameter name="mm_ok" unit="" default_value="0" show="false">
+            <Description>[0,1]</Description>
         </Parameter>
     </Parameters>
 </Component>

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/npn13g2l.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/npn13g2l.xml
@@ -15,9 +15,9 @@
     <Netlists>
         <NgspiceNetlist value=
             "{{{Letter}}}::schematic_id='nequal'Q{PartCounter} {nets} {bulk} {{{model}}}::model='nonempty'
-            {{Nx={Nx}}}::Nx='nonempty' {{El={El}}}::El='nonempty'">
+            {{Nx={Nx}}}::Nx='nonempty' {{El={El}}}::El='nonempty' mm_ok={mm_ok}">
         </NgspiceNetlist>
-        <CDLNetlist value="{NgspiceNetlist}"></CDLNetlist>
+        <CDLNetlist value="{{{Letter}}}::schematic_id='nequal'Q{PartCounter} {nets} {bulk} {{{model}}}::model='nonempty' {{Nx={Nx}}}::Nx='nonempty' {{El={El}}}::El='nonempty'"></CDLNetlist>
     </Netlists>
     <Symbols>
         <Symbol id="Standard">
@@ -42,6 +42,9 @@
         </Parameter>
         <Parameter name="type" unit="" default_value="npn" show="false">
             <Description>Device type</Description>
+        </Parameter>
+        <Parameter name="mm_ok" unit="" default_value="0" show="false">
+            <Description>[0,1]</Description>
         </Parameter>
     </Parameters>
 </Component>

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/npn13g2l.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/npn13g2l.xml
@@ -43,7 +43,7 @@
         <Parameter name="type" unit="" default_value="npn" show="false">
             <Description>Device type</Description>
         </Parameter>
-        <Parameter name="mm_ok" unit="" default_value="0" show="false">
+        <Parameter name="mm_ok" unit="" default_value="1" show="false">
             <Description>[0,1]</Description>
         </Parameter>
     </Parameters>

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/npn13g2v.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/npn13g2v.xml
@@ -40,7 +40,7 @@
         <Parameter name="type" unit="" default_value="npn" show="false">
             <Description>Device type</Description>
         </Parameter>
-        <Parameter name="mm_ok" unit="" default_value="0" show="false">
+        <Parameter name="mm_ok" unit="" default_value="1" show="false">
             <Description>[0,1]</Description>
         </Parameter>
     </Parameters>

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/npn13g2v.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/npn13g2v.xml
@@ -15,9 +15,9 @@
     <Netlists>
         <NgspiceNetlist value=
             "{{{Letter}}}::schematic_id='nequal'Q{PartCounter} {nets} {bulk} {{{model}}}::model='nonempty'
-            {{Nx={Nx}}}::Nx='nonempty' ">
+            {{Nx={Nx}}}::Nx='nonempty' mm_ok={mm_ok}">
         </NgspiceNetlist>
-        <CDLNetlist value="{NgspiceNetlist}"></CDLNetlist>
+        <CDLNetlist value="{{{Letter}}}::schematic_id='nequal'Q{PartCounter} {nets} {bulk} {{{model}}}::model='nonempty' {{Nx={Nx}}}::Nx='nonempty'"></CDLNetlist>
     </Netlists>
     <Symbols>
         <Symbol id="Standard">
@@ -39,6 +39,9 @@
         </Parameter>
         <Parameter name="type" unit="" default_value="npn" show="false">
             <Description>Device type</Description>
+        </Parameter>
+        <Parameter name="mm_ok" unit="" default_value="0" show="false">
+            <Description>[0,1]</Description>
         </Parameter>
     </Parameters>
 </Component>

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/pmos.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/pmos.xml
@@ -48,7 +48,7 @@
         <Parameter name="m" unit="" default_value="1" show="false">
             <Description>Multiplier</Description>
         </Parameter>
-        <Parameter name="mm_ok" unit="" default_value="0" show="false">
+        <Parameter name="mm_ok" unit="" default_value="1" show="false">
             <Description>[0,1]</Description>
         </Parameter>
     </Parameters>

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/pmos.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/pmos.xml
@@ -15,9 +15,11 @@
     <Netlists>
         <NgspiceNetlist value=
             "{{{Letter}}}::schematic_id='nequal'M{PartCounter} {nets} {{{model}}}::model='nonempty'
-            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{m={m}}}::m='nonempty'">
+            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{m={m}}}::m='nonempty' mm_ok={mm_ok}">
         </NgspiceNetlist>
-        <CDLNetlist value="{NgspiceNetlist}"> </CDLNetlist>
+        <CDLNetlist value=
+            "{{{Letter}}}::schematic_id='nequal'M{PartCounter} {nets} {{{model}}}::model='nonempty'
+            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{m={m}}}::m='nonempty'"> </CDLNetlist>
     </Netlists>
     <Symbols>
         <Symbol id="Standard">
@@ -45,6 +47,9 @@
         </Parameter>
         <Parameter name="m" unit="" default_value="1" show="false">
             <Description>Multiplier</Description>
+        </Parameter>
+        <Parameter name="mm_ok" unit="" default_value="0" show="false">
+            <Description>[0,1]</Description>
         </Parameter>
     </Parameters>
 </Component>

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/pmosHV.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/pmosHV.xml
@@ -48,7 +48,7 @@
         <Parameter name="m" unit="" default_value="1" show="false">
             <Description>Multiplier</Description>
         </Parameter>
-        <Parameter name="mm_ok" unit="" default_value="0" show="false">
+        <Parameter name="mm_ok" unit="" default_value="1" show="false">
             <Description>[0,1]</Description>
         </Parameter>
     </Parameters>

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/pmosHV.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/pmosHV.xml
@@ -15,9 +15,11 @@
     <Netlists>
         <NgspiceNetlist value=
             "{{{Letter}}}::schematic_id='nequal'M{PartCounter} {nets} {{{model}}}::model='nonempty'
-            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{m={m}}}::m='nonempty'">
+            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{m={m}}}::m='nonempty' mm_ok={mm_ok}">
         </NgspiceNetlist>
-        <CDLNetlist value="{NgspiceNetlist}"> </CDLNetlist>
+        <CDLNetlist value=
+            "{{{Letter}}}::schematic_id='nequal'M{PartCounter} {nets} {{{model}}}::model='nonempty'
+            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{m={m}}}::m='nonempty'"> </CDLNetlist>
     </Netlists>
     <Symbols>
         <Symbol id="Standard">
@@ -45,6 +47,9 @@
         </Parameter>
         <Parameter name="m" unit="" default_value="1" show="false">
             <Description>Multiplier</Description>
+        </Parameter>
+        <Parameter name="mm_ok" unit="" default_value="0" show="false">
+            <Description>[0,1]</Description>
         </Parameter>
     </Parameters>
 </Component>

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/rfnmos.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/rfnmos.xml
@@ -51,7 +51,7 @@
         <Parameter name="rfmode" unit="" default_value="1" show="false">
             <Description>RF mode switch</Description>
         </Parameter>
-        <Parameter name="mm_ok" unit="" default_value="0" show="false">
+        <Parameter name="mm_ok" unit="" default_value="1" show="false">
             <Description>[0,1]</Description>
         </Parameter>
     </Parameters>

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/rfnmos.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/rfnmos.xml
@@ -15,9 +15,11 @@
     <Netlists>
         <NgspiceNetlist value=
             "{{{Letter}}}::schematic_id='nequal'M{PartCounter} {nets} {{{model}}}::model='nonempty'
-            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty'  {{rfmode={rfmode}}}::rfmode='nonempty' {{m={m}}}::m='nonempty'">
+            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty'  {{rfmode={rfmode}}}::rfmode='nonempty' {{m={m}}}::m='nonempty' mm_ok={mm_ok}">
         </NgspiceNetlist>
-        <CDLNetlist value="{NgspiceNetlist}"> </CDLNetlist>
+        <CDLNetlist value=
+            "{{{Letter}}}::schematic_id='nequal'M{PartCounter} {nets} {{{model}}}::model='nonempty'
+            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{rfmode={rfmode}}}::rfmode='nonempty' {{m={m}}}::m='nonempty'"> </CDLNetlist>
     </Netlists>
     <Symbols>
         <Symbol id="Standard">
@@ -48,6 +50,9 @@
         </Parameter>
         <Parameter name="rfmode" unit="" default_value="1" show="false">
             <Description>RF mode switch</Description>
+        </Parameter>
+        <Parameter name="mm_ok" unit="" default_value="0" show="false">
+            <Description>[0,1]</Description>
         </Parameter>
     </Parameters>
 </Component>

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/rfnmosHV.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/rfnmosHV.xml
@@ -51,7 +51,7 @@
         <Parameter name="rfmode" unit="" default_value="1" show="false">
             <Description>RF mode switch</Description>
         </Parameter>
-        <Parameter name="mm_ok" unit="" default_value="0" show="false">
+        <Parameter name="mm_ok" unit="" default_value="1" show="false">
             <Description>[0,1]</Description>
         </Parameter>
     </Parameters>

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/rfnmosHV.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/rfnmosHV.xml
@@ -15,9 +15,11 @@
     <Netlists>
         <NgspiceNetlist value=
             "{{{Letter}}}::schematic_id='nequal'M{PartCounter} {nets} {{{model}}}::model='nonempty'
-            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{rfmode={rfmode}}}::rfmode='nonempty' {{m={m}}}::m='nonempty'">
+            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{rfmode={rfmode}}}::rfmode='nonempty' {{m={m}}}::m='nonempty' mm_ok={mm_ok}">
         </NgspiceNetlist>
-        <CDLNetlist value="{NgspiceNetlist}"> </CDLNetlist>
+        <CDLNetlist value=
+            "{{{Letter}}}::schematic_id='nequal'M{PartCounter} {nets} {{{model}}}::model='nonempty'
+            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{rfmode={rfmode}}}::rfmode='nonempty' {{m={m}}}::m='nonempty'"> </CDLNetlist>
     </Netlists>
     <Symbols>
         <Symbol id="Standard">
@@ -48,6 +50,9 @@
         </Parameter>
         <Parameter name="rfmode" unit="" default_value="1" show="false">
             <Description>RF mode switch</Description>
+        </Parameter>
+        <Parameter name="mm_ok" unit="" default_value="0" show="false">
+            <Description>[0,1]</Description>
         </Parameter>
     </Parameters>
 </Component>

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/rfpmos.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/rfpmos.xml
@@ -51,7 +51,7 @@
         <Parameter name="rfmode" unit="" default_value="1" show="false">
             <Description>RF mode switch</Description>
         </Parameter>
-        <Parameter name="mm_ok" unit="" default_value="0" show="false">
+        <Parameter name="mm_ok" unit="" default_value="1" show="false">
             <Description>[0,1]</Description>
         </Parameter>
     </Parameters>

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/rfpmos.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/rfpmos.xml
@@ -15,9 +15,11 @@
     <Netlists>
         <NgspiceNetlist value=
             "{{{Letter}}}::schematic_id='nequal'M{PartCounter} {nets} {{{model}}}::model='nonempty'
-            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{rfmode={rfmode}}}::rfmode='nonempty' {{m={m}}}::m='nonempty'">
+            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{rfmode={rfmode}}}::rfmode='nonempty' {{m={m}}}::m='nonempty' mm_ok={mm_ok}">
         </NgspiceNetlist>
-        <CDLNetlist value="{NgspiceNetlist}"> </CDLNetlist>
+        <CDLNetlist value=
+            "{{{Letter}}}::schematic_id='nequal'M{PartCounter} {nets} {{{model}}}::model='nonempty'
+            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{rfmode={rfmode}}}::rfmode='nonempty' {{m={m}}}::m='nonempty'"> </CDLNetlist>
     </Netlists>
     <Symbols>
         <Symbol id="Standard">
@@ -48,6 +50,9 @@
         </Parameter>
         <Parameter name="rfmode" unit="" default_value="1" show="false">
             <Description>RF mode switch</Description>
+        </Parameter>
+        <Parameter name="mm_ok" unit="" default_value="0" show="false">
+            <Description>[0,1]</Description>
         </Parameter>
     </Parameters>
 </Component>

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/rfpmosHV.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/rfpmosHV.xml
@@ -51,7 +51,7 @@
         <Parameter name="rfmode" unit="" default_value="1" show="false">
             <Description>RF mode switch</Description>
         </Parameter>
-        <Parameter name="mm_ok" unit="" default_value="0" show="false">
+        <Parameter name="mm_ok" unit="" default_value="1" show="false">
             <Description>[0,1]</Description>
         </Parameter>
     </Parameters>

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/rfpmosHV.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/rfpmosHV.xml
@@ -15,9 +15,11 @@
     <Netlists>
         <NgspiceNetlist value=
             "{{{Letter}}}::schematic_id='nequal'M{PartCounter} {nets} {{{model}}}::model='nonempty'
-            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{rfmode={rfmode}}}::rfmode='nonempty' {{m={m}}}::m='nonempty'">
+            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{rfmode={rfmode}}}::rfmode='nonempty' {{m={m}}}::m='nonempty' mm_ok={mm_ok}">
         </NgspiceNetlist>
-        <CDLNetlist value="{NgspiceNetlist}"> </CDLNetlist>
+        <CDLNetlist value=
+            "{{{Letter}}}::schematic_id='nequal'M{PartCounter} {nets} {{{model}}}::model='nonempty'
+            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{rfmode={rfmode}}}::rfmode='nonempty' {{m={m}}}::m='nonempty'"> </CDLNetlist>
     </Netlists>
     <Symbols>
         <Symbol id="Standard">
@@ -48,6 +50,9 @@
         </Parameter>
         <Parameter name="rfmode" unit="" default_value="1" show="false">
             <Description>RF mode switch</Description>
+        </Parameter>
+        <Parameter name="mm_ok" unit="" default_value="0" show="false">
+            <Description>[0,1]</Description>
         </Parameter>
     </Parameters>
 </Component>

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/rhigh.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/rhigh.xml
@@ -49,7 +49,7 @@
             show="true">
             <Description>Resistance value</Description>
         </Parameter>
-        <Parameter name="mm_ok" unit="" default_value="0" show="false">
+        <Parameter name="mm_ok" unit="" default_value="1" show="false">
             <Description>[0,1]</Description>
         </Parameter>
     </Parameters>

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/rhigh.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/rhigh.xml
@@ -13,9 +13,9 @@
         </SpiceModel>
     </Models>
     <Netlists>
-        <NgspiceNetlist value = "{{{Letter}}}::schematic_id='nequal'R{PartCounter} {nets} {bulk} {model} {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' b={b} {{m={m}}}::m='nonempty'"> </NgspiceNetlist>
-        <CDLNetlist value = "{NgspiceNetlist}"> </CDLNetlist>
-        <XyceNetlist value = "{{{Letter}}}::schematic_id='nequal'R{PartCounter} {nets} {bulk} {model} {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' b={b} {{m={m}}}::m='nonempty'"> </XyceNetlist>
+        <NgspiceNetlist value = "{{{Letter}}}::schematic_id='nequal'R{PartCounter} {nets} {bulk} {model} {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' b={b} {{m={m}}}::m='nonempty' mm_ok={mm_ok}"> </NgspiceNetlist>
+        <CDLNetlist value = "{{{Letter}}}::schematic_id='nequal'R{PartCounter} {nets} {bulk} {model} {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' b={b} {{m={m}}}::m='nonempty'"> </CDLNetlist>
+        <XyceNetlist value = "{{{Letter}}}::schematic_id='nequal'R{PartCounter} {nets} {bulk} {model} {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' b={b} {{m={m}}}::m='nonempty' mm_ok={mm_ok}"> </XyceNetlist>
     </Netlists>
     <Symbols>
         <Symbol id="Standard">
@@ -48,6 +48,9 @@
             equation="(1.6e-4 / w + 1360.0*((b + 1)*l + (1.081*(w - 0.04e-6) + 0.18e-6)*b) / (w - 0.04e-6)) / m"
             show="true">
             <Description>Resistance value</Description>
+        </Parameter>
+        <Parameter name="mm_ok" unit="" default_value="0" show="false">
+            <Description>[0,1]</Description>
         </Parameter>
     </Parameters>
 </Component>

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/rppd.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/rppd.xml
@@ -49,7 +49,7 @@
             show="true">
             <Description>Resistance value</Description>
         </Parameter>
-        <Parameter name="mm_ok" unit="" default_value="0" show="false">
+        <Parameter name="mm_ok" unit="" default_value="1" show="false">
             <Description>[0,1]</Description>
         </Parameter>
     </Parameters>

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/rppd.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/rppd.xml
@@ -13,9 +13,9 @@
         </SpiceModel>
     </Models>
     <Netlists>
-        <NgspiceNetlist value = "{{{Letter}}}::schematic_id='nequal'R{PartCounter} {nets} {bulk} {model} {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' b={b} {{m={m}}}::m='nonempty'"> </NgspiceNetlist>
-        <CDLNetlist value = "{NgspiceNetlist}"> </CDLNetlist>
-        <XyceNetlist value = "{{{Letter}}}::schematic_id='nequal'R{PartCounter} {nets} {bulk} {model} {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' b={b} {{m={m}}}::m='nonempty'"> </XyceNetlist>
+        <NgspiceNetlist value = "{{{Letter}}}::schematic_id='nequal'R{PartCounter} {nets} {bulk} {model} {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' b={b} {{m={m}}}::m='nonempty' mm_ok={mm_ok}"> </NgspiceNetlist>
+        <CDLNetlist value = "{{{Letter}}}::schematic_id='nequal'R{PartCounter} {nets} {bulk} {model} {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' b={b} {{m={m}}}::m='nonempty'"> </CDLNetlist>
+        <XyceNetlist value = "{{{Letter}}}::schematic_id='nequal'R{PartCounter} {nets} {bulk} {model} {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' b={b} {{m={m}}}::m='nonempty' mm_ok={mm_ok}"> </XyceNetlist>
     </Netlists>
     <Symbols>
         <Symbol id="Standard">
@@ -48,6 +48,9 @@
             equation="(70.0e-6 / w + 260.0 * ((b + 1)*l + (1.081*(w + 6.0e-9) + 0.18e-6)*b) / (w + 6.0e-9)) / m"
             show="true">
             <Description>Resistance value</Description>
+        </Parameter>
+        <Parameter name="mm_ok" unit="" default_value="0" show="false">
+            <Description>[0,1]</Description>
         </Parameter>
     </Parameters>
 </Component>

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/rsil.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/rsil.xml
@@ -46,7 +46,7 @@
             show="true">
             <Description>Resistance value</Description>
         </Parameter>
-        <Parameter name="mm_ok" unit="" default_value="0" show="false">
+        <Parameter name="mm_ok" unit="" default_value="1" show="false">
             <Description>[0,1]</Description>
         </Parameter>
     </Parameters>

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/rsil.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/rsil.xml
@@ -13,9 +13,9 @@
         </SpiceModel>
     </Models>
     <Netlists>
-        <NgspiceNetlist value = "{{{Letter}}}::schematic_id='nequal'R{PartCounter} {nets} {bulk} {model} {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{m={m}}}::m='nonempty'"> </NgspiceNetlist>
-        <CDLNetlist value = "{NgspiceNetlist}"> </CDLNetlist>
-        <XyceNetlist value = "{{{Letter}}}::schematic_id='nequal'R{PartCounter} {nets} {bulk} {model} {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{m={m}}}::m='nonempty'"> </XyceNetlist>
+        <NgspiceNetlist value = "{{{Letter}}}::schematic_id='nequal'R{PartCounter} {nets} {bulk} {model} {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{m={m}}}::m='nonempty' mm_ok={mm_ok}"> </NgspiceNetlist>
+        <CDLNetlist value = "{{{Letter}}}::schematic_id='nequal'R{PartCounter} {nets} {bulk} {model} {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{m={m}}}::m='nonempty'"> </CDLNetlist>
+        <XyceNetlist value = "{{{Letter}}}::schematic_id='nequal'R{PartCounter} {nets} {bulk} {model} {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{m={m}}}::m='nonempty' mm_ok={mm_ok}"> </XyceNetlist>
     </Netlists>
     <Symbols>
         <Symbol id="Standard">
@@ -45,6 +45,9 @@
             equation="(9.0e-6 / w + 7.0 * (l) / (w + 1.0e-8)) / m"
             show="true">
             <Description>Resistance value</Description>
+        </Parameter>
+        <Parameter name="mm_ok" unit="" default_value="0" show="false">
+            <Description>[0,1]</Description>
         </Parameter>
     </Parameters>
 </Component>

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/svaricap.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/svaricap.xml
@@ -43,7 +43,7 @@
         <Parameter name="Nx" unit="" default_value="1" show="true">
             <Description>Multiplier</Description>
         </Parameter>
-        <Parameter name="mm_ok" unit="" default_value="0" show="false">
+        <Parameter name="mm_ok" unit="" default_value="1" show="false">
             <Description>[0,1]</Description>
         </Parameter>
     </Parameters>

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/svaricap.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/svaricap.xml
@@ -15,9 +15,9 @@
     <Netlists>
         <NgspiceNetlist value=
             "{{{Letter}}}::schematic_id='nequal'D{PartCounter} {nets} {bulk} {{{model}}}::model='nonempty'
-            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{Nx={Nx}}}::Nx='nonempty'">
+            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{Nx={Nx}}}::Nx='nonempty' mm_ok={mm_ok}">
         </NgspiceNetlist>
-        <CDLNetlist value="{NgspiceNetlist}"></CDLNetlist>
+        <CDLNetlist value="{{{Letter}}}::schematic_id='nequal'D{PartCounter} {nets} {bulk} {{{model}}}::model='nonempty' {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{Nx={Nx}}}::Nx='nonempty'"></CDLNetlist>
     </Netlists>
     <Symbols>
         <Symbol id="Standard">
@@ -42,6 +42,9 @@
         </Parameter>
         <Parameter name="Nx" unit="" default_value="1" show="true">
             <Description>Multiplier</Description>
+        </Parameter>
+        <Parameter name="mm_ok" unit="" default_value="0" show="false">
+            <Description>[0,1]</Description>
         </Parameter>
     </Parameters>
 </Component>


### PR DESCRIPTION
- Added mm_ok param. 
- Default is set to 0. 
- SPICE netlist includes mm_ok, 
- mm_ok is excluded in CDL



-  [x] Existing testcases in the PDK (with xml symbols) runs as expected. Has separate issue with rfcmim regarding pins: Fixed is in separate PR.

