### PR TITLE
remove additional sub pin for rfcmim symbol in Qucs-S

### DIFF
--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/rfcmim.sym
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/rfcmim.sym
@@ -8,4 +8,7 @@
 <Line x1="-25" y1="12" x2="-15" y2="12" color="#000080" width="2" style="1" />
 <PortSym x="30" y="0" type="1" angle="0"/>
 <PortSym x="-30" y="0" type="1" angle="0" />
-<PortSym x="-20" y="20" type="1" angle="0" /> 
+<!-- PortSym x="-20" y="20" type="1" angle="0" --> 
+<Line x1="-25" y1="20" x2="-15" y2="20" color="#000080" width="2" style="1" />
+<Line x1="-24" y1="21" x2="-20" y2="26" color="#000080" width="2" style="1" />
+<Line x1="-16" y1="21" x2="-20" y2="26" color="#000080" width="2" style="1" />


### PR DESCRIPTION
Since the body is tied to sub through parameter, additional pin for body creates `too many parameters in subcircuit` error. Replaced pin with a GND symbol.

- [x] Existing ac_capacitor testcase runs without error and return expected results.  

