### PR TITLE
Add ihp-sg13cmos5l

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "ihp-sg13g2/libs.tech/palace"]
 	path = ihp-sg13g2/libs.tech/palace
 	url = https://github.com/VolkerMuehlhaus/gds2palace_ihp_sg13g2.git
+[submodule "ihp-sg13cmos5l"]
+	path = ihp-sg13cmos5l
+	url = git@github.com:IHP-GmbH/ihp-sg13cmos5l.git


### PR DESCRIPTION
Add IHP's CMOS5L PDK as sub-module.

This is a requirement to add CMOS5L to CIEL. Additionally, it makes access to this PDK easier.