### PR TITLE
add Xyce netlists for Qucs-S symbols

### DIFF
--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/bondpad.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/bondpad.xml
@@ -16,6 +16,8 @@
         <NgspiceNetlist value = 'XR{PartCounter} {nets} bondpad '>
         </NgspiceNetlist>
         <CDLNetlist value = 'X{PartCounter} {nets} bondpad '> </CDLNetlist>
+        <XyceNetlist value = 'XR{PartCounter} {nets} bondpad '>
+        </XyceNetlist>
     </Netlists>
     <Symbols>
         <Symbol id="Standard">

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/cap_cmim.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/cap_cmim.xml
@@ -21,6 +21,10 @@
             "{{{Letter}}}::schematic_id='nequal'C{PartCounter} {nets} {{{model}}}::model='nonempty'
             {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' m={m}">
         </CDLNetlist>
+        <XyceNetlist value=
+            "{{{Letter}}}::schematic_id='nequal'C{PartCounter} {nets} {{{model}}}::model='nonempty'
+            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' m={m} mm_ok={mm_ok}">
+        </XyceNetlist>
    </Netlists>
     <Symbols>
         <Symbol id="Standard">

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/cap_cmim.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/cap_cmim.xml
@@ -23,7 +23,7 @@
         </CDLNetlist>
         <XyceNetlist value=
             "{{{Letter}}}::schematic_id='nequal'C{PartCounter} {nets} {{{model}}}::model='nonempty'
-            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' m={m} mm_ok={mm_ok}">
+            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' m={m}">
         </XyceNetlist>
    </Netlists>
     <Symbols>

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/cap_rfcmim.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/cap_rfcmim.xml
@@ -23,7 +23,7 @@
         </CDLNetlist>
         <XyceNetlist value=
             "{{{Letter}}}::schematic_id='nequal'C{PartCounter} {nets} {bulk} {{{model}}}::model='nonempty'
-            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty'  {{wfeed={wfeed}}}::wfeed='nonempty'  {{m={m}}}::m='nonempty' mm_ok={mm_ok}">
+            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty'  {{wfeed={wfeed}}}::wfeed='nonempty'  {{m={m}}}::m='nonempty'">
         </XyceNetlist>
     </Netlists>
     <Symbols>

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/cap_rfcmim.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/cap_rfcmim.xml
@@ -21,6 +21,10 @@
             "{{{Letter}}}::schematic_id='nequal'C{PartCounter} {nets} {bulk} {{{model}}}::model='nonempty'
             {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty'  {{wfeed={wfeed}}}::wfeed='nonempty'  {{m={m}}}::m='nonempty' ">
         </CDLNetlist>
+        <XyceNetlist value=
+            "{{{Letter}}}::schematic_id='nequal'C{PartCounter} {nets} {bulk} {{{model}}}::model='nonempty'
+            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty'  {{wfeed={wfeed}}}::wfeed='nonempty'  {{m={m}}}::m='nonempty' mm_ok={mm_ok}">
+        </XyceNetlist>
     </Netlists>
     <Symbols>
         <Symbol id="Standard">

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/dantenna.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/dantenna.xml
@@ -15,6 +15,7 @@
     <Netlists>
         <NgspiceNetlist value = "{{{Letter}}}::schematic_id='nequal'D{PartCounter} {nets} {model} {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{m={m}}}::m='nonempty'"> </NgspiceNetlist>
         <CDLNetlist value = "{NgspiceNetlist}"> </CDLNetlist>
+        <XyceNetlist value = "{{{Letter}}}::schematic_id='nequal'D{PartCounter} {nets} {model} {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{m={m}}}::m='nonempty'"> </XyceNetlist>
     </Netlists>
     <Symbols>
         <Symbol id="Standard">

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/diodevdd_2kv.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/diodevdd_2kv.xml
@@ -15,6 +15,7 @@
     <Netlists>
         <NgspiceNetlist value = "{{{Letter}}}::schematic_id='nequal'D{PartCounter} {nets} {model} {{m={m}}}::m='nonempty'"> </NgspiceNetlist>
         <CDLNetlist value = "{NgspiceNetlist}"> </CDLNetlist>
+        <XyceNetlist value = "{{{Letter}}}::schematic_id='nequal'D{PartCounter} {nets} {model} {{m={m}}}::m='nonempty'"> </XyceNetlist>
     </Netlists>
     <Symbols>
         <Symbol id="Standard">

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/diodevdd_4kv.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/diodevdd_4kv.xml
@@ -15,6 +15,7 @@
     <Netlists>
         <NgspiceNetlist value = "{{{Letter}}}::schematic_id='nequal'D{PartCounter} {nets} {model} {{m={m}}}::m='nonempty'"> </NgspiceNetlist>
         <CDLNetlist value = "{NgspiceNetlist}"> </CDLNetlist>
+        <XyceNetlist value = "{{{Letter}}}::schematic_id='nequal'D{PartCounter} {nets} {model} {{m={m}}}::m='nonempty'"> </XyceNetlist>
     </Netlists>
     <Symbols>
         <Symbol id="Standard">

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/diodevss_2kv.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/diodevss_2kv.xml
@@ -15,6 +15,7 @@
     <Netlists>
         <NgspiceNetlist value = "{{{Letter}}}::schematic_id='nequal'D{PartCounter} {nets} {model} {{m={m}}}::m='nonempty'"> </NgspiceNetlist>
         <CDLNetlist value = "{NgspiceNetlist}"> </CDLNetlist>
+        <XyceNetlist value = "{{{Letter}}}::schematic_id='nequal'D{PartCounter} {nets} {model} {{m={m}}}::m='nonempty'"> </XyceNetlist>
     </Netlists>
     <Symbols>
         <Symbol id="Standard">

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/diodevss_4kv.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/diodevss_4kv.xml
@@ -15,6 +15,7 @@
     <Netlists>
         <NgspiceNetlist value = "{{{Letter}}}::schematic_id='nequal'D{PartCounter} {nets} {model} {{m={m}}}::m='nonempty'"> </NgspiceNetlist>
         <CDLNetlist value = "{NgspiceNetlist}"> </CDLNetlist>
+        <XyceNetlist value = "{{{Letter}}}::schematic_id='nequal'D{PartCounter} {nets} {model} {{m={m}}}::m='nonempty'"> </XyceNetlist>
     </Netlists>
     <Symbols>
         <Symbol id="Standard">

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/dpantenna.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/dpantenna.xml
@@ -15,6 +15,7 @@
     <Netlists>
         <NgspiceNetlist value = "{{{Letter}}}::schematic_id='nequal'D{PartCounter} {nets} {model} {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{m={m}}}::m='nonempty'"> </NgspiceNetlist>
         <CDLNetlist value = "{NgspiceNetlist}"> </CDLNetlist>
+        <XyceNetlist value = "{{{Letter}}}::schematic_id='nequal'D{PartCounter} {nets} {model} {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{m={m}}}::m='nonempty'"> </XyceNetlist>
     </Netlists>
     <Symbols>
         <Symbol id="Standard">

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/isolbox.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/isolbox.xml
@@ -15,6 +15,7 @@
     <Netlists>
         <NgspiceNetlist value = "{{{Letter}}}::schematic_id='nequal'D{PartCounter} {nets} {model} {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty'"> </NgspiceNetlist>
         <CDLNetlist value = "{NgspiceNetlist}"> </CDLNetlist>
+        <XyceNetlist value = "{{{Letter}}}::schematic_id='nequal'D{PartCounter} {nets} {model} {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty'"> </XyceNetlist>
     </Netlists>
     <Symbols>
         <Symbol id="Standard">

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/nmos.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/nmos.xml
@@ -22,7 +22,7 @@
             {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{m={m}}}::m='nonempty'"> </CDLNetlist>
         <XyceNetlist value=
             "{{{Letter}}}::schematic_id='nequal'M{PartCounter} {nets} {{{model}}}::model='nonempty'
-            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{m={m}}}::m='nonempty' mm_ok={mm_ok}">
+            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{m={m}}}::m='nonempty'">
         </XyceNetlist>
     </Netlists>
     <Symbols>

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/nmos.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/nmos.xml
@@ -20,6 +20,10 @@
         <CDLNetlist value=
             "{{{Letter}}}::schematic_id='nequal'M{PartCounter} {nets} {{{model}}}::model='nonempty'
             {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{m={m}}}::m='nonempty'"> </CDLNetlist>
+        <XyceNetlist value=
+            "{{{Letter}}}::schematic_id='nequal'M{PartCounter} {nets} {{{model}}}::model='nonempty'
+            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{m={m}}}::m='nonempty' mm_ok={mm_ok}">
+        </XyceNetlist>
     </Netlists>
     <Symbols>
         <Symbol id="Standard">

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/nmosHV.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/nmosHV.xml
@@ -22,7 +22,7 @@
             {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{m={m}}}::m='nonempty'"> </CDLNetlist>
         <XyceNetlist value=
             "{{{Letter}}}::schematic_id='nequal'M{PartCounter} {nets} {{{model}}}::model='nonempty'
-            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{m={m}}}::m='nonempty' mm_ok={mm_ok}">
+            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{m={m}}}::m='nonempty'">
         </XyceNetlist>
     </Netlists>
     <Symbols>

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/nmosHV.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/nmosHV.xml
@@ -20,6 +20,10 @@
         <CDLNetlist value=
             "{{{Letter}}}::schematic_id='nequal'M{PartCounter} {nets} {{{model}}}::model='nonempty'
             {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{m={m}}}::m='nonempty'"> </CDLNetlist>
+        <XyceNetlist value=
+            "{{{Letter}}}::schematic_id='nequal'M{PartCounter} {nets} {{{model}}}::model='nonempty'
+            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{m={m}}}::m='nonempty' mm_ok={mm_ok}">
+        </XyceNetlist>
     </Netlists>
     <Symbols>
         <Symbol id="Standard">

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/nmoscl_2.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/nmoscl_2.xml
@@ -17,6 +17,9 @@
             "{{{Letter}}}::schematic_id='nequal'D{PartCounter} {nets} {{{model}}}::model='nonempty' {{m={m}}}::m='nonempty'">
         </NgspiceNetlist>
         <CDLNetlist value="{NgspiceNetlist}"> </CDLNetlist>
+        <XyceNetlist value=
+            "{{{Letter}}}::schematic_id='nequal'D{PartCounter} {nets} {{{model}}}::model='nonempty' {{m={m}}}::m='nonempty'">
+        </XyceNetlist>
     </Netlists>
     <Symbols>
         <Symbol id="Standard">

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/nmoscl_4.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/nmoscl_4.xml
@@ -17,6 +17,9 @@
             "{{{Letter}}}::schematic_id='nequal'D{PartCounter} {nets} {{{model}}}::model='nonempty' {{m={m}}}::m='nonempty'">
         </NgspiceNetlist>
         <CDLNetlist value="{NgspiceNetlist}"> </CDLNetlist>
+        <XyceNetlist value=
+            "{{{Letter}}}::schematic_id='nequal'D{PartCounter} {nets} {{{model}}}::model='nonempty' {{m={m}}}::m='nonempty'">
+        </XyceNetlist>
     </Netlists>
     <Symbols>
         <Symbol id="Standard">

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/npn13g2.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/npn13g2.xml
@@ -20,7 +20,7 @@
         <CDLNetlist value="{{{Letter}}}::schematic_id='nequal'Q{PartCounter} {nets} {bulk} {{{model}}}::model='nonempty' {{Nx={Nx}}}::Nx='nonempty'"></CDLNetlist>
         <XyceNetlist value=
             "{{{Letter}}}::schematic_id='nequal'Q{PartCounter} {nets} {bulk} {{{model}}}::model='nonempty'
-            {{Nx={Nx}}}::Nx='nonempty' mm_ok={mm_ok}">
+            {{Nx={Nx}}}::Nx='nonempty'">
         </XyceNetlist>
     </Netlists>
     <Symbols>

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/npn13g2.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/npn13g2.xml
@@ -18,6 +18,10 @@
             {{Nx={Nx}}}::Nx='nonempty' mm_ok={mm_ok}">
         </NgspiceNetlist>
         <CDLNetlist value="{{{Letter}}}::schematic_id='nequal'Q{PartCounter} {nets} {bulk} {{{model}}}::model='nonempty' {{Nx={Nx}}}::Nx='nonempty'"></CDLNetlist>
+        <XyceNetlist value=
+            "{{{Letter}}}::schematic_id='nequal'Q{PartCounter} {nets} {bulk} {{{model}}}::model='nonempty'
+            {{Nx={Nx}}}::Nx='nonempty' mm_ok={mm_ok}">
+        </XyceNetlist>
     </Netlists>
     <Symbols>
         <Symbol id="Standard">

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/npn13g2l.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/npn13g2l.xml
@@ -18,6 +18,10 @@
             {{Nx={Nx}}}::Nx='nonempty' {{El={El}}}::El='nonempty' mm_ok={mm_ok}">
         </NgspiceNetlist>
         <CDLNetlist value="{{{Letter}}}::schematic_id='nequal'Q{PartCounter} {nets} {bulk} {{{model}}}::model='nonempty' {{Nx={Nx}}}::Nx='nonempty' {{El={El}}}::El='nonempty'"></CDLNetlist>
+        <XyceNetlist value=
+            "{{{Letter}}}::schematic_id='nequal'Q{PartCounter} {nets} {bulk} {{{model}}}::model='nonempty'
+            {{Nx={Nx}}}::Nx='nonempty' {{El={El}}}::El='nonempty' mm_ok={mm_ok}">
+        </XyceNetlist>
     </Netlists>
     <Symbols>
         <Symbol id="Standard">

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/npn13g2l.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/npn13g2l.xml
@@ -20,7 +20,7 @@
         <CDLNetlist value="{{{Letter}}}::schematic_id='nequal'Q{PartCounter} {nets} {bulk} {{{model}}}::model='nonempty' {{Nx={Nx}}}::Nx='nonempty' {{El={El}}}::El='nonempty'"></CDLNetlist>
         <XyceNetlist value=
             "{{{Letter}}}::schematic_id='nequal'Q{PartCounter} {nets} {bulk} {{{model}}}::model='nonempty'
-            {{Nx={Nx}}}::Nx='nonempty' {{El={El}}}::El='nonempty' mm_ok={mm_ok}">
+            {{Nx={Nx}}}::Nx='nonempty' {{El={El}}}::El='nonempty'">
         </XyceNetlist>
     </Netlists>
     <Symbols>

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/npn13g2v.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/npn13g2v.xml
@@ -20,7 +20,7 @@
         <CDLNetlist value="{{{Letter}}}::schematic_id='nequal'Q{PartCounter} {nets} {bulk} {{{model}}}::model='nonempty' {{Nx={Nx}}}::Nx='nonempty'"></CDLNetlist>
         <XyceNetlist value=
             "{{{Letter}}}::schematic_id='nequal'Q{PartCounter} {nets} {bulk} {{{model}}}::model='nonempty'
-            {{Nx={Nx}}}::Nx='nonempty' mm_ok={mm_ok}">
+            {{Nx={Nx}}}::Nx='nonempty'">
         </XyceNetlist>
     </Netlists>
     <Symbols>

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/npn13g2v.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/npn13g2v.xml
@@ -18,6 +18,10 @@
             {{Nx={Nx}}}::Nx='nonempty' mm_ok={mm_ok}">
         </NgspiceNetlist>
         <CDLNetlist value="{{{Letter}}}::schematic_id='nequal'Q{PartCounter} {nets} {bulk} {{{model}}}::model='nonempty' {{Nx={Nx}}}::Nx='nonempty'"></CDLNetlist>
+        <XyceNetlist value=
+            "{{{Letter}}}::schematic_id='nequal'Q{PartCounter} {nets} {bulk} {{{model}}}::model='nonempty'
+            {{Nx={Nx}}}::Nx='nonempty' mm_ok={mm_ok}">
+        </XyceNetlist>
     </Netlists>
     <Symbols>
         <Symbol id="Standard">

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/ntap1.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/ntap1.xml
@@ -15,6 +15,7 @@
     <Netlists>
         <NgspiceNetlist value = "{{{Letter}}}::schematic_id='nequal'R{PartCounter} {nets} {model} {{R={R}}}::R='nonempty' {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty'"> </NgspiceNetlist>
         <CDLNetlist value = "{NgspiceNetlist}"> </CDLNetlist>
+        <XyceNetlist value = "{{{Letter}}}::schematic_id='nequal'R{PartCounter} {nets} {model} {{R={R}}}::R='nonempty' {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty'"> </XyceNetlist>
     </Netlists>
     <Symbols>
         <Symbol id="Standard">

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/pmos.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/pmos.xml
@@ -22,7 +22,7 @@
             {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{m={m}}}::m='nonempty'"> </CDLNetlist>
         <XyceNetlist value=
             "{{{Letter}}}::schematic_id='nequal'M{PartCounter} {nets} {{{model}}}::model='nonempty'
-            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{m={m}}}::m='nonempty' mm_ok={mm_ok}">
+            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{m={m}}}::m='nonempty'">
         </XyceNetlist>
     </Netlists>
     <Symbols>

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/pmos.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/pmos.xml
@@ -20,6 +20,10 @@
         <CDLNetlist value=
             "{{{Letter}}}::schematic_id='nequal'M{PartCounter} {nets} {{{model}}}::model='nonempty'
             {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{m={m}}}::m='nonempty'"> </CDLNetlist>
+        <XyceNetlist value=
+            "{{{Letter}}}::schematic_id='nequal'M{PartCounter} {nets} {{{model}}}::model='nonempty'
+            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{m={m}}}::m='nonempty' mm_ok={mm_ok}">
+        </XyceNetlist>
     </Netlists>
     <Symbols>
         <Symbol id="Standard">

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/pmosHV.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/pmosHV.xml
@@ -22,7 +22,7 @@
             {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{m={m}}}::m='nonempty'"> </CDLNetlist>
         <XyceNetlist value=
             "{{{Letter}}}::schematic_id='nequal'M{PartCounter} {nets} {{{model}}}::model='nonempty'
-            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{m={m}}}::m='nonempty' mm_ok={mm_ok}">
+            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{m={m}}}::m='nonempty'">
         </XyceNetlist>
     </Netlists>
     <Symbols>

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/pmosHV.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/pmosHV.xml
@@ -20,6 +20,10 @@
         <CDLNetlist value=
             "{{{Letter}}}::schematic_id='nequal'M{PartCounter} {nets} {{{model}}}::model='nonempty'
             {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{m={m}}}::m='nonempty'"> </CDLNetlist>
+        <XyceNetlist value=
+            "{{{Letter}}}::schematic_id='nequal'M{PartCounter} {nets} {{{model}}}::model='nonempty'
+            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{m={m}}}::m='nonempty' mm_ok={mm_ok}">
+        </XyceNetlist>
     </Netlists>
     <Symbols>
         <Symbol id="Standard">

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/pnpMPA.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/pnpMPA.xml
@@ -18,6 +18,10 @@
             {{a={A}}}::A='nonempty' {{p={P}}}::P='nonempty' {{m={m}}}::m='nonempty'">
         </NgspiceNetlist>
         <CDLNetlist value="{NgspiceNetlist}"></CDLNetlist>
+        <XyceNetlist value=
+            "{{{Letter}}}::schematic_id='nequal'Q{PartCounter} {nets} {{{model}}}::model='nonempty'
+            {{a={A}}}::A='nonempty' {{p={P}}}::P='nonempty' {{m={m}}}::m='nonempty'">
+        </XyceNetlist>
     </Netlists>
     <Symbols>
         <Symbol id="Standard">

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/ptap1.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/ptap1.xml
@@ -15,6 +15,7 @@
     <Netlists>
         <NgspiceNetlist value = "{{{Letter}}}::schematic_id='nequal'R{PartCounter} {nets} {model} {{R={R}}}::R='nonempty' {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty'"> </NgspiceNetlist>
         <CDLNetlist value = "{NgspiceNetlist}"> </CDLNetlist>
+        <XyceNetlist value = "{{{Letter}}}::schematic_id='nequal'R{PartCounter} {nets} {model} {{R={R}}}::R='nonempty' {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty'"> </XyceNetlist>
     </Netlists>
     <Symbols>
         <Symbol id="Standard">

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/rfnmos.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/rfnmos.xml
@@ -22,7 +22,7 @@
             {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{rfmode={rfmode}}}::rfmode='nonempty' {{m={m}}}::m='nonempty'"> </CDLNetlist>
         <XyceNetlist value=
             "{{{Letter}}}::schematic_id='nequal'M{PartCounter} {nets} {{{model}}}::model='nonempty'
-            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty'  {{rfmode={rfmode}}}::rfmode='nonempty' {{m={m}}}::m='nonempty' mm_ok={mm_ok}">
+            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty'  {{rfmode={rfmode}}}::rfmode='nonempty' {{m={m}}}::m='nonempty'">
         </XyceNetlist>
     </Netlists>
     <Symbols>

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/rfnmos.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/rfnmos.xml
@@ -20,6 +20,10 @@
         <CDLNetlist value=
             "{{{Letter}}}::schematic_id='nequal'M{PartCounter} {nets} {{{model}}}::model='nonempty'
             {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{rfmode={rfmode}}}::rfmode='nonempty' {{m={m}}}::m='nonempty'"> </CDLNetlist>
+        <XyceNetlist value=
+            "{{{Letter}}}::schematic_id='nequal'M{PartCounter} {nets} {{{model}}}::model='nonempty'
+            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty'  {{rfmode={rfmode}}}::rfmode='nonempty' {{m={m}}}::m='nonempty' mm_ok={mm_ok}">
+        </XyceNetlist>
     </Netlists>
     <Symbols>
         <Symbol id="Standard">

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/rfnmosHV.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/rfnmosHV.xml
@@ -22,7 +22,7 @@
             {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{rfmode={rfmode}}}::rfmode='nonempty' {{m={m}}}::m='nonempty'"> </CDLNetlist>
         <XyceNetlist value=
             "{{{Letter}}}::schematic_id='nequal'M{PartCounter} {nets} {{{model}}}::model='nonempty'
-            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{rfmode={rfmode}}}::rfmode='nonempty' {{m={m}}}::m='nonempty' mm_ok={mm_ok}">
+            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{rfmode={rfmode}}}::rfmode='nonempty' {{m={m}}}::m='nonempty'">
         </XyceNetlist>
     </Netlists>
     <Symbols>

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/rfnmosHV.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/rfnmosHV.xml
@@ -20,6 +20,10 @@
         <CDLNetlist value=
             "{{{Letter}}}::schematic_id='nequal'M{PartCounter} {nets} {{{model}}}::model='nonempty'
             {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{rfmode={rfmode}}}::rfmode='nonempty' {{m={m}}}::m='nonempty'"> </CDLNetlist>
+        <XyceNetlist value=
+            "{{{Letter}}}::schematic_id='nequal'M{PartCounter} {nets} {{{model}}}::model='nonempty'
+            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{rfmode={rfmode}}}::rfmode='nonempty' {{m={m}}}::m='nonempty' mm_ok={mm_ok}">
+        </XyceNetlist>
     </Netlists>
     <Symbols>
         <Symbol id="Standard">

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/rfpmos.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/rfpmos.xml
@@ -22,7 +22,7 @@
             {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{rfmode={rfmode}}}::rfmode='nonempty' {{m={m}}}::m='nonempty'"> </CDLNetlist>
         <XyceNetlist value=
             "{{{Letter}}}::schematic_id='nequal'M{PartCounter} {nets} {{{model}}}::model='nonempty'
-            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{rfmode={rfmode}}}::rfmode='nonempty' {{m={m}}}::m='nonempty' mm_ok={mm_ok}">
+            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{rfmode={rfmode}}}::rfmode='nonempty' {{m={m}}}::m='nonempty'">
         </XyceNetlist>
     </Netlists>
     <Symbols>

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/rfpmos.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/rfpmos.xml
@@ -20,6 +20,10 @@
         <CDLNetlist value=
             "{{{Letter}}}::schematic_id='nequal'M{PartCounter} {nets} {{{model}}}::model='nonempty'
             {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{rfmode={rfmode}}}::rfmode='nonempty' {{m={m}}}::m='nonempty'"> </CDLNetlist>
+        <XyceNetlist value=
+            "{{{Letter}}}::schematic_id='nequal'M{PartCounter} {nets} {{{model}}}::model='nonempty'
+            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{rfmode={rfmode}}}::rfmode='nonempty' {{m={m}}}::m='nonempty' mm_ok={mm_ok}">
+        </XyceNetlist>
     </Netlists>
     <Symbols>
         <Symbol id="Standard">

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/rfpmosHV.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/rfpmosHV.xml
@@ -22,7 +22,7 @@
             {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{rfmode={rfmode}}}::rfmode='nonempty' {{m={m}}}::m='nonempty'"> </CDLNetlist>
         <XyceNetlist value=
             "{{{Letter}}}::schematic_id='nequal'M{PartCounter} {nets} {{{model}}}::model='nonempty'
-            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{rfmode={rfmode}}}::rfmode='nonempty' {{m={m}}}::m='nonempty' mm_ok={mm_ok}">
+            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{rfmode={rfmode}}}::rfmode='nonempty' {{m={m}}}::m='nonempty'">
         </XyceNetlist>
     </Netlists>
     <Symbols>

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/rfpmosHV.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/rfpmosHV.xml
@@ -20,6 +20,10 @@
         <CDLNetlist value=
             "{{{Letter}}}::schematic_id='nequal'M{PartCounter} {nets} {{{model}}}::model='nonempty'
             {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{rfmode={rfmode}}}::rfmode='nonempty' {{m={m}}}::m='nonempty'"> </CDLNetlist>
+        <XyceNetlist value=
+            "{{{Letter}}}::schematic_id='nequal'M{PartCounter} {nets} {{{model}}}::model='nonempty'
+            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{ng={ng}}}::ng='nonempty' {{rfmode={rfmode}}}::rfmode='nonempty' {{m={m}}}::m='nonempty' mm_ok={mm_ok}">
+        </XyceNetlist>
     </Netlists>
     <Symbols>
         <Symbol id="Standard">

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/rhigh.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/rhigh.xml
@@ -15,7 +15,7 @@
     <Netlists>
         <NgspiceNetlist value = "{{{Letter}}}::schematic_id='nequal'R{PartCounter} {nets} {bulk} {model} {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' b={b} {{m={m}}}::m='nonempty' mm_ok={mm_ok}"> </NgspiceNetlist>
         <CDLNetlist value = "{{{Letter}}}::schematic_id='nequal'R{PartCounter} {nets} {bulk} {model} {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' b={b} {{m={m}}}::m='nonempty'"> </CDLNetlist>
-        <XyceNetlist value = "{{{Letter}}}::schematic_id='nequal'R{PartCounter} {nets} {bulk} {model} {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' b={b} {{m={m}}}::m='nonempty' mm_ok={mm_ok}"> </XyceNetlist>
+        <XyceNetlist value = "{{{Letter}}}::schematic_id='nequal'R{PartCounter} {nets} {bulk} {model} {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' b={b} {{m={m}}}::m='nonempty'"> </XyceNetlist>
     </Netlists>
     <Symbols>
         <Symbol id="Standard">

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/rppd.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/rppd.xml
@@ -15,7 +15,7 @@
     <Netlists>
         <NgspiceNetlist value = "{{{Letter}}}::schematic_id='nequal'R{PartCounter} {nets} {bulk} {model} {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' b={b} {{m={m}}}::m='nonempty' mm_ok={mm_ok}"> </NgspiceNetlist>
         <CDLNetlist value = "{{{Letter}}}::schematic_id='nequal'R{PartCounter} {nets} {bulk} {model} {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' b={b} {{m={m}}}::m='nonempty'"> </CDLNetlist>
-        <XyceNetlist value = "{{{Letter}}}::schematic_id='nequal'R{PartCounter} {nets} {bulk} {model} {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' b={b} {{m={m}}}::m='nonempty' mm_ok={mm_ok}"> </XyceNetlist>
+        <XyceNetlist value = "{{{Letter}}}::schematic_id='nequal'R{PartCounter} {nets} {bulk} {model} {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' b={b} {{m={m}}}::m='nonempty'"> </XyceNetlist>
     </Netlists>
     <Symbols>
         <Symbol id="Standard">

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/rsil.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/rsil.xml
@@ -15,7 +15,7 @@
     <Netlists>
         <NgspiceNetlist value = "{{{Letter}}}::schematic_id='nequal'R{PartCounter} {nets} {bulk} {model} {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{m={m}}}::m='nonempty' mm_ok={mm_ok}"> </NgspiceNetlist>
         <CDLNetlist value = "{{{Letter}}}::schematic_id='nequal'R{PartCounter} {nets} {bulk} {model} {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{m={m}}}::m='nonempty'"> </CDLNetlist>
-        <XyceNetlist value = "{{{Letter}}}::schematic_id='nequal'R{PartCounter} {nets} {bulk} {model} {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{m={m}}}::m='nonempty' mm_ok={mm_ok}"> </XyceNetlist>
+        <XyceNetlist value = "{{{Letter}}}::schematic_id='nequal'R{PartCounter} {nets} {bulk} {model} {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{m={m}}}::m='nonempty'"> </XyceNetlist>
     </Netlists>
     <Symbols>
         <Symbol id="Standard">

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/schottky.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/schottky.xml
@@ -16,6 +16,8 @@
         <NgspiceNetlist value = "{{{Letter}}}::schematic_id='nequal'D{PartCounter} {nets} {model} {{Nx={Nx}}}::Nx='nonempty' {{Ny={Ny}}}::Ny='nonempty'
              {{m={m}}}::m='nonempty'"> </NgspiceNetlist>
         <CDLNetlist value = "{NgspiceNetlist}"> </CDLNetlist>
+        <XyceNetlist value = "{{{Letter}}}::schematic_id='nequal'D{PartCounter} {nets} {model} {{Nx={Nx}}}::Nx='nonempty' {{Ny={Ny}}}::Ny='nonempty'
+             {{m={m}}}::m='nonempty'"> </XyceNetlist>
     </Netlists>
     <Symbols>
         <Symbol id="Standard">

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/sub.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/sub.xml
@@ -15,6 +15,7 @@
     <Netlists>
         <NgspiceNetlist value = ".GLOBAL {net} "> </NgspiceNetlist>
         <CDLNetlist value = "{NgspiceNetlist}"> </CDLNetlist>
+        <XyceNetlist value = ".GLOBAL {net} "> </XyceNetlist>
     </Netlists>
     <Symbols>
         <Symbol id="Standard">

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/svaricap.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/svaricap.xml
@@ -20,7 +20,7 @@
         <CDLNetlist value="{{{Letter}}}::schematic_id='nequal'D{PartCounter} {nets} {bulk} {{{model}}}::model='nonempty' {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{Nx={Nx}}}::Nx='nonempty'"></CDLNetlist>
         <XyceNetlist value=
             "{{{Letter}}}::schematic_id='nequal'D{PartCounter} {nets} {bulk} {{{model}}}::model='nonempty'
-            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{Nx={Nx}}}::Nx='nonempty' mm_ok={mm_ok}">
+            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{Nx={Nx}}}::Nx='nonempty'">
         </XyceNetlist>
     </Netlists>
     <Symbols>

--- a/ihp-sg13g2/libs.tech/qucs-s/symbols/svaricap.xml
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols/svaricap.xml
@@ -18,6 +18,10 @@
             {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{Nx={Nx}}}::Nx='nonempty' mm_ok={mm_ok}">
         </NgspiceNetlist>
         <CDLNetlist value="{{{Letter}}}::schematic_id='nequal'D{PartCounter} {nets} {bulk} {{{model}}}::model='nonempty' {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{Nx={Nx}}}::Nx='nonempty'"></CDLNetlist>
+        <XyceNetlist value=
+            "{{{Letter}}}::schematic_id='nequal'D{PartCounter} {nets} {bulk} {{{model}}}::model='nonempty'
+            {{w={w}}}::w='nonempty' {{l={l}}}::l='nonempty' {{Nx={Nx}}}::Nx='nonempty' mm_ok={mm_ok}">
+        </XyceNetlist>
     </Netlists>
     <Symbols>
         <Symbol id="Standard">


### PR DESCRIPTION
This commit adds explicit XyceNetlist entries across the updated Qucs-S symbol set

Worked:
- Added XyceNetlist definitions for bondpad, diodes, taps, substrate, MOS, RF MOS, BJTs, and MIM capacitor symbols.
- Preserved the existing Ngspice and CDL netlist definitions while mirroring Xyce-specific parameters such as mm_ok where the symbols already carried them.


Did not verify:
- No Qucs-S netlisting smoke test was run in this commit.
- Xyce simulation run was executed for rhigh, rppd, npn13G2, MiM, ptap1 devices.
- No broader library regression or integration validation was run as part of this commit.


