### PR TITLE
removed leading space in `format=` line

### DIFF
--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/cap_cmim.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/cap_cmim.sym
@@ -15,7 +15,7 @@ v {xschem version=3.4.8RC file_version=1.3
 }
 G {}
 K {type=capacitor
- format="@spiceprefix@name @pinlist @model w=@w l=@l m=@m mm_ok=@mm_ok"
+format="@spiceprefix@name @pinlist @model w=@w l=@l m=@m mm_ok=@mm_ok"
 lvs_format="C@name @pinlist @model w=@w l=@l m=@m"
 template="name=C1
 model=cap_cmim

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/cap_rfcmim.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/cap_rfcmim.sym
@@ -15,7 +15,7 @@ v {xschem version=3.4.8RC file_version=1.3
 }
 G {}
 K {type=capacitor
- format="@spiceprefix@name @pinlist @model w=@w l=@l wfeed=@wfeed m=@m mm_ok=@mm_ok"
+format="@spiceprefix@name @pinlist @model w=@w l=@l wfeed=@wfeed m=@m mm_ok=@mm_ok"
 lvs_format="C@name @pinlist @lvs_model w=@w l=@l wfeed=@wfeed m=@m"
 template="name=C1 
 model=cap_rfcmim

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2.sym
@@ -17,7 +17,7 @@ v {xschem version=3.4.8RC file_version=1.3
 G {}
 K {type=vertical_npn
 lvs_format="Q@name @pinlist @model le=900e-9 we=70.0n Nx=@Nx"
- format="@spiceprefix@name @pinlist @model Nx=@Nx mm_ok=@mm_ok"
+format="@spiceprefix@name @pinlist @model Nx=@Nx mm_ok=@mm_ok"
 template="name=Q1
 model=npn13G2
  spiceprefix=X

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2_5t.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2_5t.sym
@@ -17,7 +17,7 @@ v {xschem version=3.4.8RC file_version=1.3
 G {}
 K {type=vertical_npn
 lvs_format="Q@name @pinlist @model le=900e-9 we=70.0n Nx=@Nx"
- format="@spiceprefix@name @pinlist @model Nx=@Nx mm_ok=@mm_ok"
+format="@spiceprefix@name @pinlist @model Nx=@Nx mm_ok=@mm_ok"
 template="name=Q1
 model=npn13G2_5t
  spiceprefix=X

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2l.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2l.sym
@@ -17,7 +17,7 @@ v {xschem version=3.4.8RC file_version=1.3
 G {}
 K {type=vertical_npn
 lvs_format="tcleval(Q@name @pinlist @model le=[ev \{ @El * 1.0e-6 \} ] we=70.0n Nx=@Nx )"
- format="@spiceprefix@name @pinlist @model Nx=@Nx El=@El mm_ok=@mm_ok"
+format="@spiceprefix@name @pinlist @model Nx=@Nx El=@El mm_ok=@mm_ok"
 template="name=Q1
 model=npn13G2l
 spiceprefix=X

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2l_5t.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2l_5t.sym
@@ -17,7 +17,7 @@ v {xschem version=3.4.8RC file_version=1.3
 G {}
 K {type=vertical_npn
 lvs_format="tcleval(Q@name @pinlist @model le=[ev \{ @El * 1.0e-6 \} ] we=70.0n Nx=@Nx )"
- format="@spiceprefix@name @pinlist @model Nx=@Nx El=@El mm_ok=@mm_ok"
+format="@spiceprefix@name @pinlist @model Nx=@Nx El=@El mm_ok=@mm_ok"
 template="name=Q1
 model=npn13G2l_5t
 spiceprefix=X

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2v.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2v.sym
@@ -17,7 +17,7 @@ v {xschem version=3.4.8RC file_version=1.3
 G {}
 K {type=vertical_npn
 lvs_format="tcleval(Q@name @pinlist @model le=[ev \{ @El * 1.0e-6 \} ] we=120.0n Nx=@Nx )"
- format="@spiceprefix@name @pinlist @model Nx=@Nx El=@El mm_ok=@mm_ok"
+format="@spiceprefix@name @pinlist @model Nx=@Nx El=@El mm_ok=@mm_ok"
 template="name=Q1
 model=npn13G2v
 spiceprefix=X

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2v_5t.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/npn13G2v_5t.sym
@@ -17,7 +17,7 @@ v {xschem version=3.4.8RC file_version=1.3
 G {}
 K {type=vertical_npn
 lvs_format="tcleval(Q@name @pinlist @model le=[ev \{ @El * 1.0e-6 \} ] we=120.0n Nx=@Nx )"
- format="@spiceprefix@name @pinlist @model Nx=@Nx El=@El mm_ok=@mm_ok"
+format="@spiceprefix@name @pinlist @model Nx=@Nx El=@El mm_ok=@mm_ok"
 template="name=Q1
 model=npn13G2v_5t
  spiceprefix=X

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/rhigh.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/rhigh.sym
@@ -17,7 +17,7 @@ v {xschem version=3.4.8RC file_version=1.3
 G {}
 K {type=res
 lvs_format="R@name @pinlist @value \\$SUB=@body \\$[@model\\\\] w=@w l=@l b=@b m=@m"
- format="@spiceprefix@name @pinlist @body @model w=@w l=@l m=@m b=@b mm_ok=@mm_ok"
+format="@spiceprefix@name @pinlist @body @model w=@w l=@l m=@m b=@b mm_ok=@mm_ok"
 template="name=R1
 w=0.5e-6
 l=0.96e-6

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/rppd.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/rppd.sym
@@ -17,7 +17,7 @@ v {xschem version=3.4.8RC file_version=1.3
 G {}
 K {type=res
 lvs_format="R@name @pinlist @value \\$SUB=@body \\$[@model\\\\] w=@w l=@l b=@b m=@m"
- format="@spiceprefix@name @pinlist @body @model w=@w l=@l m=@m b=@b mm_ok=@mm_ok"
+format="@spiceprefix@name @pinlist @body @model w=@w l=@l m=@m b=@b mm_ok=@mm_ok"
 template="name=R1
 w=0.5e-6
 l=0.5e-6

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/rsil.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/rsil.sym
@@ -17,7 +17,7 @@ v {xschem version=3.4.8RC file_version=1.3
 G {}
 K {type=res
 lvs_format="R@name @pinlist @value \\$SUB=@body \\$[@model\\\\] w=@w l=@l m=@m"
- format="@spiceprefix@name @pinlist @body @model w=@w l=@l m=@m mm_ok=@mm_ok"
+format="@spiceprefix@name @pinlist @body @model w=@w l=@l m=@m mm_ok=@mm_ok"
 template="name=R1
 w=0.5e-6
 l=0.5e-6

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/sg13_hv_nmos.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/sg13_hv_nmos.sym
@@ -17,7 +17,7 @@ v {xschem version=3.4.8RC file_version=1.3
 G {}
 K {type=nmos
 lvs_format="M@name @pinlist @model w=@w l=@l ng=@ng m=@m"
- format="@spiceprefix@name @pinlist @model w=@w  l=@l ng=@ng m=@m mm_ok=@mm_ok"
+format="@spiceprefix@name @pinlist @model w=@w  l=@l ng=@ng m=@m mm_ok=@mm_ok"
 template="name=M1
 l=0.45u
 w=0.3u

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/sg13_hv_pmos.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/sg13_hv_pmos.sym
@@ -17,7 +17,7 @@ v {xschem version=3.4.8RC file_version=1.3
 G {}
 K {type=pmos
 lvs_format="M@name @pinlist @model w=@w l=@l ng=@ng m=@m"
- format="@spiceprefix@name @pinlist @model w=@w l=@l ng=@ng m=@m mm_ok=@mm_ok"
+format="@spiceprefix@name @pinlist @model w=@w l=@l ng=@ng m=@m mm_ok=@mm_ok"
 template="name=M1
 l=0.4u
 w=0.3u

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/sg13_hv_rf_nmos.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/sg13_hv_rf_nmos.sym
@@ -17,7 +17,7 @@ v {xschem version=3.4.8RC file_version=1.3
 G {}
 K {type=nmos
 lvs_format="M@name @pinlist @lvs_model w=@w l=@l ng=@ng m=@m"
- format="@spiceprefix@name @pinlist @model w=@w l=@l ng=@ng m=@m rfmode=@rfmode mm_ok=@mm_ok"
+format="@spiceprefix@name @pinlist @model w=@w l=@l ng=@ng m=@m rfmode=@rfmode mm_ok=@mm_ok"
 template="name=M1
 l=0.72u
 w=1.0u

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/sg13_hv_rf_pmos.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/sg13_hv_rf_pmos.sym
@@ -17,7 +17,7 @@ v {xschem version=3.4.8RC file_version=1.3
 G {}
 K {type=pmos
 lvs_format="M@name @pinlist @lvs_model w=@w l=@l ng=@ng m=@m"
- format="@spiceprefix@name @pinlist @model w=@w l=@l ng=@ng m=@m rfmode=@rfmode mm_ok=@mm_ok"
+format="@spiceprefix@name @pinlist @model w=@w l=@l ng=@ng m=@m rfmode=@rfmode mm_ok=@mm_ok"
 template="name=M1
 l=0.72u
 w=1.0u

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/sg13_lv_rf_nmos.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/sg13_lv_rf_nmos.sym
@@ -17,7 +17,7 @@ v {xschem version=3.4.8RC file_version=1.3
 G {}
 K {type=nmos
 lvs_format="M@name @pinlist @lvs_model w=@w l=@l ng=@ng m=@m"
- format="@spiceprefix@name @pinlist @model w=@w l=@l ng=@ng m=@m rfmode=@rfmode mm_ok=@mm_ok"
+format="@spiceprefix@name @pinlist @model w=@w l=@l ng=@ng m=@m rfmode=@rfmode mm_ok=@mm_ok"
 template="name=M1
 l=0.72u
 w=1.0u

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/sg13_lv_rf_pmos.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/sg13_lv_rf_pmos.sym
@@ -17,7 +17,7 @@ v {xschem version=3.4.8RC file_version=1.3
 G {}
 K {type=pmos
 lvs_format="M@name @pinlist @lvs_model w=@w l=@l ng=@ng m=@m"
- format="@spiceprefix@name @pinlist @model w=@w l=@l ng=@ng m=@m rfmode=@rfmode mm_ok=@mm_ok"
+format="@spiceprefix@name @pinlist @model w=@w l=@l ng=@ng m=@m rfmode=@rfmode mm_ok=@mm_ok"
 template="name=M1
 l=0.72u
 w=1.0u

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/sg13_svaricap.sym
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_pr/sg13_svaricap.sym
@@ -15,7 +15,7 @@ v {xschem version=3.4.8RC file_version=1.3
 }
 G {}
 K {type=capacitor
- format="@spiceprefix@name @pinlist @body @model w=@w l=@l Nx=@Nx mm_ok=@mm_ok"
+format="@spiceprefix@name @pinlist @body @model w=@w l=@l Nx=@Nx mm_ok=@mm_ok"
 lvs_format="C@name @pinlist @body @model w=@w l=@l Nx=@Nx"
 template="name=C1 
 model=sg13_hv_svaricap 


### PR DESCRIPTION
For VACASK, leading spaces can be problematic. See issue: https://codeberg.org/arpadbuermen/VACASK/issues/75