### PR TITLE
requirements: remove tkinter (not a pip package)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ pyyaml
 gdstk
 tqdm
 termcolor
-tkinter


### PR DESCRIPTION
Drops the `tkinter` line from `requirements.txt`. `tkinter` is a stdlib module that ships with cpython, not a PyPI package, so `pip install -r requirements.txt` fails on that line and breaks `make env`. No script in the repo imports `tkinter` either, so removing the line is enough.

Closes #1014.
