### PR TITLE
PyCell for Klayout

### DIFF
--- a/ihp-sg13g2/libs.tech/klayout/python/sg13g2_pycell_lib/callbacks/callbacks.json
+++ b/ihp-sg13g2/libs.tech/klayout/python/sg13g2_pycell_lib/callbacks/callbacks.json
@@ -28,20 +28,12 @@
     "callbackDefinition": {
         "callbackList": [
             {
-                "devices": ["cmim"],
+                "devices": ["cmim", "rfcmim"],
                 "callbacks": [
                     {
                         "callback": "CbCap",
-                        "pcellParameters": ["C", "w", "l"]
-                    }
-                ]
-            },
-            {
-                "devices": ["rfcmim"],
-                "callbacks": [
-                    {
-                        "callback": "CbCap",
-                        "pcellParameters": ["C", "w", "l"]
+                        "pcellParameters": ["C", "w", "l", "Calculate"],
+                        "usePcellParameterAsArgument": "true"
                     }
                 ]
             },
@@ -50,16 +42,18 @@
                 "callbacks": [
                     {
                         "callback": "CbSVaricap_wl",
-                        "pcellParameters": ["w", "l"]
+                        "pcellParameters": ["w", "l"],
+                        "usePcellParameterAsArgument": "true"
                     }
                 ]
             },
             {
-                "devices": ["dantenna"],
+                "devices": ["dantenna", "dpantenna"],
                 "callbacks": [
                     {
                         "callback": "CbDiode",
-                        "pcellParameters": ["w", "l", "a"]
+                        "pcellParameters": ["w", "l", "a", "p", "Calculate"],
+                        "usePcellParameterAsArgument": "true"
                     }
                 ]
             },
@@ -68,11 +62,63 @@
                 "callbacks": [
                     {
                         "callback": "CbBondpad",
-                        "pcellParameters": ["topMetal", "bottomMetal"]
+                        "pcellParameters": ["topMetal", "bottomMetal"],
+                        "usePcellParameterAsArgument": "true"
                     },
                     {
                         "callback": "bondpad_cb",
-                        "pcellParameters": ["hwquota", "diameter", "padType", "passEncl", "FlipChip"]
+                        "pcellParameters": ["hwquota", "diameter", "padType", "passEncl", "FlipChip"],
+                        "usePcellParameterAsArgument": "true"
+                    }
+                ]
+            },
+            {
+                "devices": ["inductor2", "inductor3"],
+                "callbacks": [
+                    {
+                        "callback": "inductor_w",
+                        "pcellParameters": ["w"],
+                        "usePcellParameterAsArgument": "false"
+                    },
+                    {
+                        "callback": "inductor_s",
+                        "pcellParameters": ["s"],
+                        "usePcellParameterAsArgument": "false"
+                    },
+                    {
+                        "callback": "inductor_nr",
+                        "pcellParameters": ["nr_r"],
+                        "usePcellParameterAsArgument": "false"
+                    },
+                    {
+                        "callback": "inductor_d",
+                        "pcellParameters": ["d"],
+                        "usePcellParameterAsArgument": "false"
+                    }
+                ]
+            },
+            {
+                "devices": ["isolbox"],
+                "callbacks": [
+                    {
+                        "callback": "isol_l",
+                        "pcellParameters": ["l"],
+                        "usePcellParameterAsArgument": "false"
+                    },
+                    {
+                        "callback": "isol_w",
+                        "pcellParameters": ["w"],
+                        "usePcellParameterAsArgument": "false"
+                    },
+                    {
+                        "callback": "isol_well",
+                        "pcellParameters": ["wellwidth"],
+                        "usePcellParameterAsArgument": "false"
+                    },
+                    {
+                        "callback": "isolbox_cb",
+                        "pcellParameters": ["Bv", "calculate", "pwell_w"],
+                        "usePcellParameterAsArgument": "true"
                     }
                 ]
             }

--- a/ihp-sg13g2/libs.tech/klayout/python/sg13g2_pycell_lib/callbacks/callbacks.json
+++ b/ihp-sg13g2/libs.tech/klayout/python/sg13g2_pycell_lib/callbacks/callbacks.json
@@ -19,11 +19,13 @@
     "moduleList": [
         "parameters.tcl",
         "util.tcl",
+        "tech.tcl",
         "cap_cb.tcl",
         "diode_cb.tcl",
         "bondpad_cb.tcl",
         "inductor_cb.tcl",
-        "isolbox_cb.tcl"
+        "isolbox_cb.tcl",
+        "res_cb.tcl"
     ],
     "callbackDefinition": {
         "callbackList": [
@@ -118,6 +120,27 @@
                     {
                         "callback": "isolbox_cb",
                         "pcellParameters": ["Bv", "calculate", "pwell_w"],
+                        "usePcellParameterAsArgument": "true"
+                    }
+                ]
+            },
+            {
+                "devices": ["rsil"],
+                "callbacks": [
+                    {
+                        "callback": "CbRes",
+                        "pcellParameters": ["R", "w", "l", "ps", "Calculate"],
+                        "usePcellParameterAsArgument": "true"
+                    }
+                ]
+            },
+            {
+                "devices": ["rhigh", "rppd"],
+                "callbacks": [
+                    {
+                        "callback": "CbRes",
+                        "pcellParameters": ["R", "w", "l", "b", "ps", "Calculate", "Recommendation"],
+                        "parameterMappings": ["Recommendation➜Calculate"],
                         "usePcellParameterAsArgument": "true"
                     }
                 ]

--- a/ihp-sg13g2/libs.tech/klayout/python/sg13g2_pycell_lib/callbacks/callbacks.json
+++ b/ihp-sg13g2/libs.tech/klayout/python/sg13g2_pycell_lib/callbacks/callbacks.json
@@ -25,7 +25,8 @@
         "bondpad_cb.tcl",
         "inductor_cb.tcl",
         "isolbox_cb.tcl",
-        "res_cb.tcl"
+        "res_cb.tcl",
+        "mos_cb.tcl"
     ],
     "callbackDefinition": {
         "callbackList": [
@@ -142,6 +143,61 @@
                         "pcellParameters": ["R", "w", "l", "b", "ps", "Calculate", "Recommendation"],
                         "parameterMappings": ["Recommendation➜Calculate"],
                         "usePcellParameterAsArgument": "true"
+                    }
+                ]
+            },
+            {
+                "devices": ["nmos", "pmos", "nmosHV"],
+                "callbacks": [
+                    {
+                        "callback": "NLCB_mos_w",
+                        "pcellParameters": ["w"],
+                        "usePcellParameterAsArgument": "no"
+                    },
+                    {
+                        "callback": "NLCB_mos_ng",
+                        "pcellParameters": ["ws", "ng"],
+                        "usePcellParameterAsArgument": "no"
+                    },
+                    {
+                        "callback": "NLCB_mos_l",
+                        "pcellParameters": ["l"],
+                        "usePcellParameterAsArgument": "no"
+                    }
+                ]
+            },
+            {
+                "devices": ["pmosHV"],
+                "callbacks": [
+                    {
+                        "callback": "NLCB_mos_w",
+                        "pcellParameters": ["w"],
+                        "usePcellParameterAsArgument": "no"
+                    },
+                    {
+                        "callback": "NLCB_mos_ng",
+                        "pcellParameters": ["ng"],
+                        "usePcellParameterAsArgument": "no"
+                    },
+                    {
+                        "callback": "NLCB_mos_l",
+                        "pcellParameters": ["l"],
+                        "usePcellParameterAsArgument": "no"
+                    }
+                ]
+            },
+            {
+                "devices": ["sealring"],
+                "callbacks": [
+                    {
+                        "callback": "NLCB_w",
+                        "pcellParameters": ["w"],
+                        "usePcellParameterAsArgument": "no"
+                    },
+                    {
+                        "callback": "NLCB_l",
+                        "pcellParameters": ["l"],
+                        "usePcellParameterAsArgument": "no"
                     }
                 ]
             }

--- a/ihp-sg13g2/libs.tech/klayout/python/sg13g2_pycell_lib/callbacks/inductor_cb.tcl
+++ b/ihp-sg13g2/libs.tech/klayout/python/sg13g2_pycell_lib/callbacks/inductor_cb.tcl
@@ -127,7 +127,7 @@ proc inductor_s {} {
 proc inductor_nr {} {
 
     set cellId [iPDK_getCurrentInst]
-    set cell   [iPDK_getInstCellName $cellId]
+    set cell [iPDK_getInstCellName $cellId]_
 
     set tmpnr [expr int([iPDK_getParamValue nr_r $cellId])]
 
@@ -155,7 +155,7 @@ proc inductor_nr {} {
     if {$tmpnr != "" && $tmpNrmax!="" && $tmpNrmax<$tmpnr} {
         hiGetAttention
         hiGetAttention
-        CbMessage "WARNING: wrong number of turns: using maximum number ${tmpNrmax}%L!!"
+        CbMessage "WARNING: wrong number of turns: using maximum number ${tmpNrmax}!!"
         iPDK_setParamValue nr_r $tmpNrmax $cellId
         set tmpnr $tmpNrmax
     }
@@ -216,7 +216,7 @@ proc inductor_d {} {
         hiGetAttention
         CbMessage "WARNING: wrong distance in the center of inductor: using the minimum distance ${tmpDminS}!!"
         iPDK_setParamValue d $tmpDminS $cellId
-        set tmpd $tmpDminS
+        set tmpd [Stof $tmpDminS]
     }
 
     if {$tmpd!="" && $tmpDmax!="" && $tmpDmax<$tmpd} {

--- a/ihp-sg13g2/libs.tech/klayout/python/sg13g2_pycell_lib/callbacks/isolbox_cb.tcl
+++ b/ihp-sg13g2/libs.tech/klayout/python/sg13g2_pycell_lib/callbacks/isolbox_cb.tcl
@@ -144,7 +144,7 @@ proc isolbox_cb {arg} {
     set b 68.59
     set c 0.56491
 
-    switch arg {
+    switch $arg {
         Bv {
             set bv [Stof [iPDK_getParamValue Bv $cellId]]
             if {$bv <= 10.8} {
@@ -170,7 +170,7 @@ proc isolbox_cb {arg} {
                     set w 10
                     set bv [expr $a-$b*pow($c,$w)]
                     CbMessage "WARNING: Bv reset according to maximum PWellBlock width 10u"
-                    hiGetAttention(
+                    hiGetAttention
                     hiGetAttention
                     iPDK_setParamValue Bv [Ftos $bv 2] $cellId
                 }
@@ -179,8 +179,8 @@ proc isolbox_cb {arg} {
             iPDK_setParamValue pwell_w ${w}u $cellId
         }
         calculate {
-            set comp [iPDK_getParamValue compute $cellId]
-            if {$comp == "Bv"} {
+            set calc [iPDK_getParamValue calculate $cellId]
+            if {$calc == "Bv"} {
                 isolbox_cb pwell_w
             } else {
                 isolbox_cb Bv

--- a/ihp-sg13g2/libs.tech/klayout/python/sg13g2_pycell_lib/callbacks/mos_cb.tcl
+++ b/ihp-sg13g2/libs.tech/klayout/python/sg13g2_pycell_lib/callbacks/mos_cb.tcl
@@ -1,0 +1,181 @@
+########################################################################
+#
+# Copyright 2026 IHP PDK Authors
+#
+# Licensed under the GNU General Public License, Version 3.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.gnu.org/licenses/gpl-3.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+########################################################################
+
+#*******************************************************************************
+#* Callback functions for MOS transistors
+#*******************************************************************************
+
+#******************************************************************************************************
+proc NLCB_mos_w {} {
+    
+    set cellId [iPDK_getCurrentInst]
+    set cell   [iPDK_getInstCellName $cellId]
+    
+    set tmpw     [Stof [iPDK_getParamValue w $cellId]]
+    set tmpng    [expr int([iPDK_getParamValue ng $cellId])]
+    set tmpWminS [iPDK_getParamValue Wmin $cellId]
+    set tmpWmax  [Stof [techGetParam ${cell}_maxW]]
+    
+    if {$tmpWminS == ""} {
+        set tmpWminS [techGetParam ${cell}_minW]
+    }
+    set tmpWmin [Stof $tmpWminS]
+    
+    if {$tmpw != "" && $tmpw>$tmpWmax*$tmpng} {
+        hiGetAttention
+        hiGetAttention
+        CbMessage "WARNING: wrong width: using minimum width ${tmpWminS}!!"
+        iPDK_setParamValue w $tmpWminS $cellId
+        set tmpw $tmpWmin
+    }
+    
+    if {$tmpw != "" && $tmpWmin!="" && $tmpWmin>$tmpw} {
+        hiGetAttention
+        hiGetAttention
+        CbMessage "WARNING: wrong width: using minimum width ${tmpWminS}!!"
+        iPDK_setParamValue w $tmpWminS $cellId
+        set tmpw $tmpWmin
+    }
+    
+    if {$tmpw != "" && $tmpWmin!="" && $tmpng!="" && $tmpWmin*$tmpng>$tmpw} {
+        hiGetAttention
+        hiGetAttention
+        CbMessage "WARNING: wrong width: using ng times minimum width ${tmpWminS}!!"
+        iPDK_setParamValue w [Ftos [expr $tmpWmin*$tmpng*1e6] 3]u $cellId 
+        set tmpw  [Stof [iPDK_getParamValue w $cellId]]
+    }
+    
+    set tmpw [Stof [iPDK_getParamValue w $cellId]]
+    set tmpw [GridFix [expr ($tmpw/$tmpng*1.0e6)*$tmpng]]
+    
+    iPDK_setParamValue w  [Ftos $tmpw 3]u $cellId
+    iPDK_setParamValue ws [Ftos [expr $tmpw/$tmpng] 3]u $cellId
+}
+
+#******************************************************************************************************
+proc NLCB_mos_ng {} {
+
+    set cellId [iPDK_getCurrentInst]
+    set cell   [iPDK_getInstCellName $cellId]
+
+    set tmpng    [expr round([Stof [iPDK_getParamValue ng $cellId]])]
+    set tmpMaxNg [expr round([Stof [techGetParam ${cell}_maxNG]])]
+    
+    if {$tmpng < 1} {
+        set tmpng 1
+    }
+    if {$tmpng > $tmpMaxNg} {
+        set tmpng $tmpMaxNg 
+    }
+
+    iPDK_setParamValue ng [expr int($tmpng)] $cellId
+
+    set tmpw [Stof [iPDK_getParamValue w $cellId]]
+    iPDK_setParamValue ws [Ftos [expr 1e6*$tmpw/$tmpng] 3]u $cellId
+
+    NLCB_mos_w
+}
+   
+#******************************************************************************************************
+proc NLCB_mos_l {} {
+    
+    set cellId [iPDK_getCurrentInst]
+    set cell   [iPDK_getInstCellName $cellId]
+    
+    set tmpl    [Stof [iPDK_getParamValue l $cellId]]
+    set tmpLmax [Stof [techGetParam ${cell}_maxL]] 
+    
+    if {$tmpl != "" && $tmpl>$tmpLmax} {
+        hiGetAttention
+        hiGetAttention
+        CbMessage "WARNING: wrong length: using maximum length 10u!!"
+        iPDK_setParamValue l [Ftos [expr $tmpLmax*1e6] 3]u $cellId
+        #set tmpl [Stof [iPDK_getParamValue l $cellId]]
+    }
+    
+    NLCB_l
+}
+
+#******************************************************************************************************
+proc NLCB_l {} {
+    # Callback function for a "l"-parameter.
+    
+    set cellId [iPDK_getCurrentInst]
+    set cell   [iPDK_getInstCellName $cellId]
+    
+    set tmpl     [Stof [iPDK_getParamValue l $cellId]]
+    set tmpLminS [iPDK_getParamValue Lmin $cellId]
+    
+    if {$tmpLminS == ""} {
+        set tmpLminS [techGetParam ${cell}_minL]
+    }
+    set tmpLmin [Stof $tmpLminS]
+    
+    if {$tmpl != "" && $tmpl>15e-3} {
+        hiGetAttention
+        hiGetAttention
+        CbMessage "WARNING: wrong length: using minimum length ${tmpLminS}!!"
+        iPDK_setParamValue l $tmpLminS $cellId
+    }
+    
+    if { $tmpl != "" && $tmpLmin!="" && $tmpLmin>$tmpl} {
+        hiGetAttention
+        hiGetAttention
+        CbMessage "WARNING: wrong length: using minimum length ${tmpLminS}!!"
+        iPDK_setParamValue l $tmpLminS $cellId
+    }
+    
+    set tmpl [Stof [iPDK_getParamValue l $cellId]]
+    set tmpl [GridFix [expr $tmpl*1.0e6]]
+    iPDK_setParamValue l [Ftos $tmpl 3]u $cellId
+}
+
+#******************************************************************************************************
+proc NLCB_w {} {
+    # Callback function for a "w"-parameter.
+    
+    set cellId [iPDK_getCurrentInst]
+    set cell   [iPDK_getInstCellName $cellId]
+    
+    set tmpw     [Stof [iPDK_getParamValue w $cellId]]
+    set tmpWminS [iPDK_getParamValue Wmin $cellId]
+    
+    if {$tmpWminS == ""} {
+        set tmpWminS [techGetParam ${cell}_minW]
+    }
+    set tmpWmin [Stof $tmpWminS]
+    
+    if {$tmpw > 15e-3} {
+        hiGetAttention
+        hiGetAttention
+        CbMessage "Warning: wrong width: using minimum width ${tmpWminS}!!"
+        iPDK_setParamValue w $tmpWminS $cellId
+    }
+
+    if {$tmpWmin > $tmpw} {
+        hiGetAttention
+        hiGetAttention
+        CbMessage "Warning: wrong width: using minimum width ${tmpWminS}!!"
+        iPDK_setParamValue w $tmpWminS $cellId
+    }
+    
+    set tmpw [Stof [iPDK_getParamValue w $cellId]]
+    set tmpw [GridFix [expr $tmpw*1.0e6]]
+    iPDK_setParamValue w [Ftos $tmpw 3]u $cellId
+}
+

--- a/ihp-sg13g2/libs.tech/klayout/python/sg13g2_pycell_lib/callbacks/parameters.tcl
+++ b/ihp-sg13g2/libs.tech/klayout/python/sg13g2_pycell_lib/callbacks/parameters.tcl
@@ -49,6 +49,9 @@ proc setCurrentCellParameters {parameters} {
         } else {
             # map space pattern to space
             set value [string map {"\u2709" " "} $value]
+            # map square brackets pattern to square brackets
+            set value [string map {"\u2772" "\["} $value]
+            set value [string map {"\u2773" "\]"} $value]
 
             # remove decoration from value
             regexp {'?([^',]+)'?,?} $value match undecoratedValue
@@ -68,6 +71,8 @@ proc getCurrentCellParameters {} {
             set value "\u2717"
         } else {
             set value [string map {" " "\u2709"} $value]
+            set value [string map {"\[" "\u2772"} $value]
+            set value [string map {"\]" "\u2773"} $value]
         }
         dict append coercedCellParameters $key $value
     }

--- a/ihp-sg13g2/libs.tech/klayout/python/sg13g2_pycell_lib/callbacks/res_cb.tcl
+++ b/ihp-sg13g2/libs.tech/klayout/python/sg13g2_pycell_lib/callbacks/res_cb.tcl
@@ -1,0 +1,490 @@
+
+#***********************************************************************************************************************
+# CbResCalc
+#***********************************************************************************************************************
+proc CbResCalc {calc r l w b ps cell} {
+    
+    global SG13_LIBRARY
+    global SG13_EPSILON
+    global SG13_TECHNOLOGY
+    
+    set suffix ""
+    if {$SG13_TECHNOLOGY == "SG13G2"} {
+        set suffix "G2"
+    }
+    if {$SG13_TECHNOLOGY == "SG13D7"} {
+        set suffix "D7"
+    }
+    
+    set rspec  [Stof [techGetParam ${cell}_rspec ]]                       ;# specific body res. per sq. (float)
+    set rkspec [Stof [techGetParam ${cell}_rkspec]]                       ;# res. per single contact (float)
+    set rzspec [expr {[Stof [techGetParam ${cell}_rzspec]] * 1.0e6}]      ;# transition res. per um width between contact area and body (float)
+    set lwd    [expr {[Stof [techGetParam ${cell}_lwd   ]] * 1.0e6}]      ;# line width delta [um] (both edges, positiv value adds to w)
+    set kappa  [Stof [techGetParam ${cell}_kappa ]]
+    
+    set poly_over_cont [Stof [techGetParam "Cnt_d" ]]
+    set cont_size      [Stof [techGetParam "Cnt_a"]]
+    set cont_space     [Stof [techGetParam "Cnt_b"]]
+    set cont_dist      [expr {$cont_space+$cont_size}]
+    
+    set minW  [Stof [techGetParam ${cell}_minW]]
+
+    set r  [Stof $r ]
+    set l  [Stof $l ]
+    set w  [Stof $w ]
+    set b  [Stof $b ]
+    set ps [Stof $ps]
+
+    if {[Less $w $minW 1u} {
+         set w $minW ;# avoid divide by zero errors in case of problems
+    }
+     
+    set w  [expr {$w  * 1.0e6}] ;# um (needed for contact calculation)
+    set l  [expr {$l  * 1.0e6}]
+    set ps [expr {$ps * 1.0e6}]
+    
+    set result 0
+    switch $calc {
+        R {
+            set weff [expr {$w+$lwd}]
+            set result [expr {$l/$weff*($b+1)*$rspec + (2.0/$kappa*$weff+$ps)*$b/$weff*$rspec + 2.0/$w*$rzspec}]
+        }
+        l {
+            set weff [expr {w+lwd}]
+            set result [expr {($weff*$r - $b*(2.0/$kappa*$weff+$ps)*$rspec - 2.0*$weff/$w*$rzspec )/($rspec*($b+1))*1e-6}] ;# in [um]
+        }
+        w {
+            set tmp    [expr {$r-2*$b*$rspec/$kappa}]
+            set p      [expr {($r*$lwd-$l*($b+1)*$rspec-(2*$lwd/$kappa+$ps)*$b*$rspec-2*$rzspec)/$tmp}]
+            set q      [expr {-2*$lwd*$rzspec/$tmp}]
+            set w      [expr {-$p/2+sqrt($p*$p/4-$q}]
+            set result [expr {[Snap $w] * 1.0e-6}] ;# -> [m]
+        }
+    }
+    
+    return $result
+}
+
+#******************************************************************************************************
+# calculate max. current through resistor
+
+proc CbResCurrent {w cell} { ;# w must be float in [m], i is given as a string
+
+    global SG13_LIBRARY
+    global SG13_EPSILON
+    
+    set ikspec [Stof [techGetParam  ${cell}_ikspec]]
+    set ipspec [Stof [techGetParam  ${cell}_ipspec]]
+
+    set poly_over_cont [techGetParam  "Cnt_d"]   
+    set cont_size      [techGetParam  "Cnt_a"] 
+    set cont_space     [techGetParam  "Cnt_b"] 
+    set cont_dist      [expr $cont_space+$cont_size]
+
+    set ncont [expr int( ($w*1.0e6-2.0*$poly_over_cont+$cont_space+$SG13_EPSILON)/$cont_dist )] ;# max. nr. of contacts across resistor width
+    if {$ncont < 1} {
+        set ncont 1
+    }
+
+    set ilim_cont [expr $ikspec*$ncont]
+    set ilim_poly [expr $w*$ipspec]
+
+    set ilim $ilim_poly
+    
+    return [format "%1.2gm" [expr $ilim*1000]]
+}
+
+#******************************************************************************************************
+# res callback function, used in CDF forms and in automated parameter update
+# returns RC value. t = success, nil=failed, CbMsg may hold info text
+#******************************************************************************************************
+
+proc CbRes {param} {
+    
+    global SG13_EPSILON2
+    global SG13_GRID
+    
+    set RC 1
+    
+    set cellId [iPDK_getCurrentInst]
+    set cell   [iPDK_getInstCellName $cellId] 
+    
+    set minL   [Stof [techGetParam  ${cell}_minL]]
+    set minW  0.0
+    set minPS 0.0
+    set minW  [Stof [techGetParam  ${cell}_minW]]
+    set minPS [Stof [techGetParam  ${cell}_minPS]]
+
+    set minB  [expr int([techGetParam  ${cell}_minB])]
+    set maxL  [Stof [techGetParam  ${cell}_maxL]]
+    set maxW  [Stof [techGetParam  ${cell}_maxW]]
+    set maxPS [Stof [techGetParam  ${cell}_maxPS]]
+    set maxB  [expr int([techGetParam  ${cell}_maxB])]
+    set minR  [CbResCalc R 0.0 $minL $maxW $minB $maxPS $cell]
+    set maxR  [CbResCalc R 0.0 $maxL $minW $maxB $maxPS $cell]
+
+    set r  [IsNumberString [iPDK_getParamValue R  $cellId]]
+    set w  [IsNumberString [iPDK_getParamValue w  $cellId]]
+    set l  [IsNumberString [iPDK_getParamValue l  $cellId]]
+    set ps [IsNumberString [iPDK_getParamValue ps $cellId]]
+    set b  [expr int([IsNumberString [iPDK_getParamValue b  $cellId]])]
+    
+    set rold  $r
+    set wold  $w
+    set lold  $l
+    set bold  $b
+    set psold $ps
+    
+    # check the entered parameters
+    switch $param {
+        R {
+            if {$r != 0} {
+                if {$r < [expr [CbResCalc "R" $r $minL $maxW $minB $minPS $cell]-$SG13_EPSILON2]} {
+                    CbMessage "r too small"
+                    set r [CbResCalc "R" $r $minL $w $b $ps $cell]
+                }
+                if { $r > [expr [CbResCalc "R" $r $maxL $minW $maxB $maxPS $cell] + $SG13_EPSILON2]} {
+                    set r [CbResCalc "R" $r $maxL $maxW $b $ps $cell]
+                    CbMessage "r too large, changed to r = $r"
+               }
+               iPDK_setParamValue R [Ftos $r 3] $cellId
+            } else {
+                CbMessage "INFO: R contains an expression and/or design variable. Parameter check not executed!"
+            } 
+        }
+        l {
+            if {$l != 0} {
+                set l [CbRoundm $l $SG13_GRID]
+                if { [Less $l $minL 1u]} {
+                    CbMessage "l too small"
+                    set l $minL
+                }
+
+                if {[Greater $l $maxL 1u]} {
+                    CbMessage "l too large"}
+                    set l $maxL
+                }
+                iPDK_setParamValue l [Ftos $l 3] $cellId
+            } else {
+                CbMessage "INFO: l contains an expression and/or design variable. Parameter check not executed!\n"
+        }
+        w {
+            if {$w != 0} {
+                set w [CbRoundm $w $SG13_GRID]
+                if {[Less $w $minW 1u]} {
+                    CbMessage "w too small"
+                    set $w $minW
+               }
+               if {[Greater $w $maxW 1u]} {
+                   CbMessage "w too large"
+                   set w $maxW
+               }
+               iPDK_setParamValue w [Ftos $w 3] $cellId
+            } else {
+                CbMessage "INFO: w contains an expression and/or design variable. Parameter check not executed!\n"
+            }
+        }
+        ps {
+            if {$ps != 0} {
+               set ps [CbRoundm $ps $SG13_GRID]
+               if {[Less $ps $minPS 1u]} {
+                   CbMessage "ps too small"
+                   set $ps $minPS
+               }
+               if {[Greater $ps $maxPS 1u]} {
+                   CbMessage "ps too large"
+                   set ps $maxPS
+               }
+               iPDK_setParamValue ps [Ftos $ps 3] $cellId
+           } else {
+               CbMessage "INFO: ps contains an expression and/or design variable. Parameter check not executed!\n"
+           }
+        }
+        b {
+            if {$b != 0} {
+                if {[Less $b $minB 1]} {
+                    CbMessage "b too small"
+                    set b $minB
+                }
+                if {[Greater $b $maxB 1]} {
+                    CbMessage "b too large"
+                    set b $maxB
+                }
+                iPDK_setParamValue b $b $cellId
+            } else {
+                CbMessage "INFO: b contains an expression and/or design variable. Parameter check not executed!\n"
+            }
+        }
+    } ; # end switch
+    
+    set calc [iPDK_getParamValue Calculate $cellId]
+    
+    #puts $r
+    #puts $w
+    #puts $l
+    #puts $ps
+    #puts $b
+    
+    if {$r!=0 && $w!=0 && $l!=0 && $ps!=0 && $b!=0} {
+        # now recalculate other params
+        switch $calc {
+            R {
+                if { $w != 0 && $l != 0 } {
+                    set r [CbResCalc R $r $l $w $b $ps $cell]
+                    iPDK_setParamValue R [Ftos $r 3] $cellId
+                }
+            }
+            w {
+                if { $l!=0 && $r!=0} {
+                    set w [CbResCalc w $r $l $w $b $ps $cell]
+                    if {[Less $w $minW 1e-6]} {
+                        set w $minW
+                    }
+                    set w [CbRoundm $w $SG13_GRID]
+                    iPDK_setParamValue w [Ftos $w 3] $cellId
+                }
+            }
+            l {
+                if {$w!=0 && $r!=0} {
+                    set l [CbResCalc l $r $l $w $b $ps $cell]
+                    set l [CbRoundm $l $SG13_GRID]
+                    iPDK_setParamValue l [Ftos $l 3] $cellId
+                }
+            }
+        }
+        
+        # recalculate r value (may have changed due to grid rounding)
+        
+        set r [CbResCalc R 0 $l $w $b $ps $cell]
+        
+        #check for error condition, restore old data in that case
+        if {[Less $l $minL 1e-6] || [Greater $l $maxL 1e-6] || [Less $w $minW 1e-6] || [Greater $w $maxW 1e-6] || [Less $ps $minPS 1e-6] || [Greater $ps $maxPS 1e-6] || [Less $b $minB 1] || [Greater $b $maxB 1] || [Less $r $minR 1] || [Greater $r $maxR 1]} {
+            if {[Less $l $minL 1e-6] || [Greater $l $maxL 1e-6]} {
+                CbMessage [format "%s < l = %s < %s" $minL $l $maxL]
+            }
+            if {[Less $w $minW 1e-6] || [Greater $w $maxW 1e-6]} {
+                CbMessage [format "%s < w = %s < %s" $minW $w $maxW]
+            }
+            if {[Less $ps $minPS 1e-6] || [Greater $ps $maxPS 1e-6]} {
+                CbMessage [format "%s < ps = %s < %s" $minPS $ps $maxPS]
+            }
+            if {[Less $b $minB 1] || [Greater $b $maxB 1]} {
+                CbMessage [format "%s < b = %s < %s" $minB $b $maxB]
+            }
+            if {[Less $r $minR 1] || [Greater $r $maxR 1]} {
+                CbMessage [format "%s < r = %s < %s" $minR $r $maxR]
+            }
+
+            set RC 0
+            CbMessage "parameter value out of range - restoring last value"
+
+            # Note: bold and b are equal because call comes too late. Need to store backup values in CbResInit
+            if {$l > $maxL && $b==$bold} {
+                set r $rold
+                set l $lold
+                set w $wold
+                set ps $psold
+                set bold 0
+            }
+            if {$w < 0 && $b==$bold} {
+                set r $rold
+                set l $lold
+                set w $wold
+                set ps $psold
+                set bold 0
+            }
+            if {$l < $minL && $param=="b"} {
+                CbMessage "uups! I apologize, you found a bug! Can't restore b - will set it to 0"
+                set r $rold
+                set l $lold
+                set w $wold 
+                set ps $psold
+                set b 0
+                if {[Less $r $minR 1]} {
+                    set r $minR
+                }
+                if {[Greater $r $maxR 1]} {
+                    set r $maxR
+                }
+                if {[Less $l $minL 1e-6]} {
+                    set l $minL
+                }
+                if {[Greater $l $maxL 1e-6]} {
+                    set l $maxL
+                }
+                if {[Less $w $minW 1e-6]} {
+                    set w $minW
+                }
+                if {[Greater $w $maxW 1e-6]} {
+                    set w $maxW
+                }
+                if {[Less $ps $minPS 1e-6]} {
+                    set ps $minPS
+                }
+                if {[Greater $ps $maxPS 1e-6]} {
+                    set ps $maxPS
+                }
+                if {[Less $b $minB 1]} {
+                    set b $minB
+                }
+                if {[Greater $b $maxB 1]} {
+                    set b $maxB
+                }
+            } else {
+                set r $rold
+                set l $lold
+                set w $wold 
+                set ps $psold
+                set b $bold
+                if {[Less $r $minR 1]} {
+                    set r $minR
+                }
+                if {[Greater $r $maxR 1]} {
+                    set r $maxR
+                }
+                if {[Less $l $minL 1e-6]} {
+                    set l $minL
+                }
+                if {[Greater $l $maxL 1e-6]} {
+                    set l $maxL
+                }
+                if {[Less $w $minW 1e-6]} {
+                    set w $minW
+                }
+                if {[Greater $w $maxW 1e-6]} {
+                    set w $maxW
+                }
+                if {[Less $ps $minPS 1e-6]} {
+                    set ps $minPS
+                }
+                if {[Greater $ps $maxPS 1e-6]} {
+                    set ps $maxPS
+                }
+                if {[Less $b $minB 1]} {
+                    set b $minB
+                }
+                if {[Greater $b $maxB 1]} {
+                    set b $maxB
+                }
+            }
+            
+            switch $param {
+                R {
+                    if { $wold!=0 && $lold!=0} {
+                        if {[Less $l $minL 1e-6]} {
+                            set l $minL
+                        }
+                        if {[Greater $l $maxL 1e-6]} {
+                            set l $maxL
+                        }
+                        if {[Less $w $minW 1e-6]} {
+                            set w $minW
+                        }
+                        if {[Greater $w $maxW 1e-6]} {
+                            set w $maxW
+                        }
+                        if {[Less $ps $minPS 1e-6]} {
+                            set ps $minPS
+                        }
+                        if {[Greater $ps $maxPS 1e-6]} {
+                            set ps $maxPS
+                        }
+                        if {[Less $b $minB 1]} {
+                            set b $minB
+                        }
+                        if {[Greater $b $maxB 1]} {
+                            set b $maxB
+                        }
+                        set r [CbResCalc R $r $l $w $b $ps $cell]
+                    }
+                 }
+
+               w {
+                   if { $lold!=0 && $rold!=0} {
+                       if {[Less $r $minR 1]} {
+                            set r $minR
+                        }
+                        if {[Greater $r $maxR 1]} {
+                            set r $maxR
+                        }
+                        if {[Less $l $minL 1e-6]} {
+                            set l $minL
+                        }
+                        if {[Greater $l $maxL 1e-6]} {
+                            set l $maxL
+                        }
+                        if {[Less $ps $minPS 1e-6]} {
+                            set ps $minPS
+                        }
+                        if {[Greater $ps $maxPS 1e-6]} {
+                            set ps $maxPS
+                        }
+                        if {[Less $b $minB 1]} {
+                            set b $minB
+                        }
+                        if {[Greater $b $maxB 1]} {
+                            set b $maxB
+                        }
+                        set w [CbResCalc w $r $l $w $b $ps $cell]
+                        set w [CbRoundm $w $SG13_GRID]
+                    }
+                }
+
+               l {
+                   if { $wold!=0 && $rold!=0} {
+                       if {[Less $r $minR 1]} {
+                            set r $minR
+                        }
+                        if {[Greater $r $maxR 1]} {
+                            set r $maxR
+                        }
+                        if {[Less $l $minL 1e-6]} {
+                            set l $minL
+                        }
+                        if {[Greater $l $maxL 1e-6]} {
+                            set l $maxL
+                        }
+                        if {[Less $w $minW 1e-6]} {
+                            set w $minW
+                        }
+                        if {[Greater $w $maxW 1e-6]} {
+                            set w $maxW
+                        }
+                        if {[Less $ps $minPS 1e-6]} {
+                            set ps $minPS
+                        }
+                        if {[Greater $ps $maxPS 1e-6]} {
+                            set ps $maxPS
+                        }
+                        if {[Less $b $minB 1]} {
+                            set b $minB
+                        }
+                        if {[Greater $b $maxB 1]} {
+                            set b $maxB
+                        }
+                        set l [CbResCalc l $r $l $w $b $ps $cell]
+                        set l [CbRoundm $l $SG13_GRID]
+                    }
+                }
+            }
+        }
+        
+        #puts $r
+        #puts $w
+        #puts $l
+        #puts $ps
+        #puts $b
+        
+        #update component CDF:
+        iPDK_setParamValue R  [Ftos $r  3] $cellId
+        iPDK_setParamValue w  [Ftos $w  3] $cellId
+        iPDK_setParamValue l  [Ftos $l  3] $cellId
+        iPDK_setParamValue ps [Ftos $ps 3] $cellId
+        iPDK_setParamValue b $b $cellId
+        iPDK_setParamValue Imax [CbResCurrent $w $cell] $cellId ;# give the user a feedback for the maximum device current 
+    } else {
+        CbMessage "INFO: Callback function not completely executed due to an expression/variable in the parameters!"
+    } 
+    
+    return $RC
+}

--- a/ihp-sg13g2/libs.tech/klayout/python/sg13g2_pycell_lib/callbacks/res_cb.tcl
+++ b/ihp-sg13g2/libs.tech/klayout/python/sg13g2_pycell_lib/callbacks/res_cb.tcl
@@ -1,3 +1,20 @@
+########################################################################
+#
+# Copyright 2026 IHP PDK Authors
+#
+# Licensed under the GNU General Public License, Version 3.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.gnu.org/licenses/gpl-3.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+########################################################################
 
 #***********************************************************************************************************************
 # CbResCalc
@@ -8,13 +25,6 @@ proc CbResCalc {calc r l w b ps cell} {
     global SG13_EPSILON
     global SG13_TECHNOLOGY
     
-    set suffix ""
-    if {$SG13_TECHNOLOGY == "SG13G2"} {
-        set suffix "G2"
-    }
-    if {$SG13_TECHNOLOGY == "SG13D7"} {
-        set suffix "D7"
-    }
     
     set rspec  [Stof [techGetParam ${cell}_rspec ]]                       ;# specific body res. per sq. (float)
     set rkspec [Stof [techGetParam ${cell}_rkspec]]                       ;# res. per single contact (float)
@@ -35,7 +45,7 @@ proc CbResCalc {calc r l w b ps cell} {
     set b  [Stof $b ]
     set ps [Stof $ps]
 
-    if {[Less $w $minW 1u} {
+    if {[Less $w $minW 1u]} {
          set w $minW ;# avoid divide by zero errors in case of problems
     }
      
@@ -50,14 +60,14 @@ proc CbResCalc {calc r l w b ps cell} {
             set result [expr {$l/$weff*($b+1)*$rspec + (2.0/$kappa*$weff+$ps)*$b/$weff*$rspec + 2.0/$w*$rzspec}]
         }
         l {
-            set weff [expr {w+lwd}]
+            set weff [expr {$w+$lwd}]
             set result [expr {($weff*$r - $b*(2.0/$kappa*$weff+$ps)*$rspec - 2.0*$weff/$w*$rzspec )/($rspec*($b+1))*1e-6}] ;# in [um]
         }
         w {
             set tmp    [expr {$r-2*$b*$rspec/$kappa}]
             set p      [expr {($r*$lwd-$l*($b+1)*$rspec-(2*$lwd/$kappa+$ps)*$b*$rspec-2*$rzspec)/$tmp}]
             set q      [expr {-2*$lwd*$rzspec/$tmp}]
-            set w      [expr {-$p/2+sqrt($p*$p/4-$q}]
+            set w      [expr {-$p/2+sqrt($p*$p/4-$q)}]
             set result [expr {[Snap $w] * 1.0e-6}] ;# -> [m]
         }
     }
@@ -72,9 +82,19 @@ proc CbResCurrent {w cell} { ;# w must be float in [m], i is given as a string
 
     global SG13_LIBRARY
     global SG13_EPSILON
+    global SG13_TECHNOLOGY
+
+    set suffix ""
+    if {$SG13_TECHNOLOGY == "SG13G2"} {
+        set suffix "G2"
+    }
+    if {$SG13_TECHNOLOGY == "SG13D7"} {
+        set suffix "D7"
+    }
+
     
-    set ikspec [Stof [techGetParam  ${cell}_ikspec]]
-    set ipspec [Stof [techGetParam  ${cell}_ipspec]]
+    set ikspec [Stof [techGetParam  ${cell}${suffix}_ikspec]]
+    set ipspec [Stof [techGetParam  ${cell}${suffix}_ipspec]]
 
     set poly_over_cont [techGetParam  "Cnt_d"]   
     set cont_size      [techGetParam  "Cnt_a"] 
@@ -127,7 +147,10 @@ proc CbRes {param} {
     set w  [IsNumberString [iPDK_getParamValue w  $cellId]]
     set l  [IsNumberString [iPDK_getParamValue l  $cellId]]
     set ps [IsNumberString [iPDK_getParamValue ps $cellId]]
-    set b  [expr int([IsNumberString [iPDK_getParamValue b  $cellId]])]
+    set b  [IsNumberString [iPDK_getParamValue b $cellId]]
+    if {$b != ""} {
+        set b [expr int($b)]
+    }
     
     set rold  $r
     set wold  $w
@@ -161,12 +184,13 @@ proc CbRes {param} {
                 }
 
                 if {[Greater $l $maxL 1u]} {
-                    CbMessage "l too large"}
+                    CbMessage "l too large"
                     set l $maxL
                 }
                 iPDK_setParamValue l [Ftos $l 3] $cellId
             } else {
                 CbMessage "INFO: l contains an expression and/or design variable. Parameter check not executed!\n"
+            }
         }
         w {
             if {$w != 0} {
@@ -219,13 +243,7 @@ proc CbRes {param} {
     
     set calc [iPDK_getParamValue Calculate $cellId]
     
-    #puts $r
-    #puts $w
-    #puts $l
-    #puts $ps
-    #puts $b
-    
-    if {$r!=0 && $w!=0 && $l!=0 && $ps!=0 && $b!=0} {
+    if {$r!=0 && $w!=0 && $l!=0 && $ps!=0 && $b!=""} {
         # now recalculate other params
         switch $calc {
             R {

--- a/ihp-sg13g2/libs.tech/klayout/python/sg13g2_pycell_lib/callbacks/tech.tcl
+++ b/ihp-sg13g2/libs.tech/klayout/python/sg13g2_pycell_lib/callbacks/tech.tcl
@@ -1,0 +1,42 @@
+global env
+global SG13_LIBRARY
+set    SG13_LIBRARY SG13_dev
+global SG13_TECHNOLOGY
+set    SG13_TECHNOLOGY SG13G2
+global IHP_iPDK_CbMsg
+set    IHP_iPDK_CbMsg ""
+
+global TechParams
+dict set TechParams "" ""
+
+puts "Technology $SG13_LIBRARY is loaded."
+
+global SG13_GRID
+set    SG13_GRID [techGetParam grid]
+
+if {$SG13_GRID == ""} {
+    set SG13_GRID 0.01
+}
+puts  "GRID : $SG13_GRID"
+
+global SG13_IGRID
+set    SG13_IGRID [expr {1.0/$SG13_GRID}] ;# inverse grid
+puts  "GRID inverse : $SG13_IGRID"
+
+global SG13_EPSILON
+global SG13_EPSILON2
+
+set    SG13_EPSILON  [techGetParam epsilon1]
+if {$SG13_EPSILON == ""} {
+    set SG13_EPSILON 0.001
+}
+set    SG13_EPSILON2 [techGetParam epsilon2]
+if {$SG13_EPSILON2 == ""} {
+    set SG13_EPSILON2 1e-9
+}
+
+puts "EPSILON1  : $SG13_EPSILON"
+puts "EPSILON2  : $SG13_EPSILON2"
+
+puts "Success."
+

--- a/ihp-sg13g2/libs.tech/klayout/python/sg13g2_pycell_lib/callbacks/util.tcl
+++ b/ihp-sg13g2/libs.tech/klayout/python/sg13g2_pycell_lib/callbacks/util.tcl
@@ -240,7 +240,7 @@ proc Greater {var1 var2 var3} {
 
 proc IsNumberString {str} {
 
-    set x 0
+    set x ""
     set str1 $str
     set str_end [string range $str1 end end]
 


### PR DESCRIPTION
-updated pycell4klayout-api submodule reference
-introduced explicit configuration of parameter usage as
 callback argument
-added rfcmim, dpantenna, inductor2, inductor3 and isolbox to
 callback configuration
-fixed Python/Tcl parameter mapping containing square brackets issue
-fixed inductor- and isolbox-callback
