### PR TITLE
ihp-sg13g2: klayout: drc: offgrid: Remove irrelevant checks

### DIFF
--- a/ihp-sg13g2/libs.tech/klayout/tech/drc/rule_decks/geometry/3_1_offgrid.drc
+++ b/ihp-sg13g2/libs.tech/klayout/tech/drc/rule_decks/geometry/3_1_offgrid.drc
@@ -58,13 +58,10 @@ if TABLES.include?('offgrid') || (TABLES.include?('main') && OFFGRID)
     OFFGRID_LAYERS = {
         # ACTIV
         "activ_drw"    => activ_drw,
-        "activ_pin"    => activ_pin,
         "activ_mask"   => activ_mask,
         "activ_filler" => activ_filler,
-        "activ_nofill" => activ_nofill,
         "activ_opc"    => activ_opc,
         "activ_iopc"   => activ_iopc,
-        "activ_noqrc"  => activ_noqrc,
 
         # BIWIND / PEMWIND
         "biwind_drw"  => biwind_drw,
@@ -73,9 +70,7 @@ if TABLES.include?('offgrid') || (TABLES.include?('main') && OFFGRID)
 
         # GATPOLY
         "gatpoly_drw"    => gatpoly_drw,
-        "gatpoly_pin"    => gatpoly_pin,
         "gatpoly_filler" => gatpoly_filler,
-        "gatpoly_nofill" => gatpoly_nofill,
         "gatpoly_opc"    => gatpoly_opc,
         "gatpoly_iopc"   => gatpoly_iopc,
         "gatpoly_noqrc"  => gatpoly_noqrc,
@@ -88,10 +83,8 @@ if TABLES.include?('offgrid') || (TABLES.include?('main') && OFFGRID)
 
         # METAL1
         "metal1_drw"     => metal1_drw,
-        "metal1_pin"     => metal1_pin,
         "metal1_mask"    => metal1_mask,
         "metal1_filler"  => metal1_filler,
-        "metal1_nofill"  => metal1_nofill,
         "metal1_slit"    => metal1_slit,
         "metal1_opc"     => metal1_opc,
         "metal1_noqrc"   => metal1_noqrc,
@@ -101,17 +94,14 @@ if TABLES.include?('offgrid') || (TABLES.include?('main') && OFFGRID)
 
         # PASSIV
         "passiv_drw"    => passiv_drw,
-        "passiv_pin"    => passiv_pin,
         "passiv_pillar" => passiv_pillar,
         "passiv_sbump"  => passiv_sbump,
         "passiv_pdl"    => passiv_pdl,
 
         # METAL2
         "metal2_drw"     => metal2_drw,
-        "metal2_pin"     => metal2_pin,
         "metal2_mask"    => metal2_mask,
         "metal2_filler"  => metal2_filler,
-        "metal2_nofill"  => metal2_nofill,
         "metal2_slit"    => metal2_slit,
         "metal2_opc"     => metal2_opc,
         "metal2_noqrc"   => metal2_noqrc,
@@ -121,17 +111,14 @@ if TABLES.include?('offgrid') || (TABLES.include?('main') && OFFGRID)
 
         # BASPOLY / PSD / NLDB / VIA1
         "baspoly_drw" => baspoly_drw,
-        "baspoly_pin" => baspoly_pin,
         "psd_drw"     => psd_drw,
         "nldb_drw"    => nldb_drw,
         "via1_drw"    => via1_drw,
 
         # BACKMETAL1 / BACKPASSIV
         "backmetal1_drw"     => backmetal1_drw,
-        "backmetal1_pin"     => backmetal1_pin,
         "backmetal1_mask"    => backmetal1_mask,
         "backmetal1_filler"  => backmetal1_filler,
-        "backmetal1_nofill"  => backmetal1_nofill,
         "backmetal1_slit"    => backmetal1_slit,
         "backmetal1_opc"     => backmetal1_opc,
         "backmetal1_noqrc"   => backmetal1_noqrc,
@@ -146,10 +133,8 @@ if TABLES.include?('offgrid') || (TABLES.include?('main') && OFFGRID)
 
         # METAL3
         "metal3_drw"     => metal3_drw,
-        "metal3_pin"     => metal3_pin,
         "metal3_mask"    => metal3_mask,
         "metal3_filler"  => metal3_filler,
-        "metal3_nofill"  => metal3_nofill,
         "metal3_slit"    => metal3_slit,
         "metal3_opc"     => metal3_opc,
         "metal3_noqrc"   => metal3_noqrc,
@@ -159,12 +144,9 @@ if TABLES.include?('offgrid') || (TABLES.include?('main') && OFFGRID)
 
         # WELLS / BULAY
         "nwell_drw"     => nwell_drw,
-        "nwell_pin"     => nwell_pin,
         "nbulay_drw"    => nbulay_drw,
-        "nbulay_pin"    => nbulay_pin,
         "nbulay_block"  => nbulay_block,
         "pwell_drw"     => pwell_drw,
-        "pwell_pin"     => pwell_pin,
         "pwell_block"   => pwell_block,
 
         # EMWIND / DEEPCO / MIM
@@ -183,10 +165,8 @@ if TABLES.include?('offgrid') || (TABLES.include?('main') && OFFGRID)
 
         # METAL4
         "metal4_drw"     => metal4_drw,
-        "metal4_pin"     => metal4_pin,
         "metal4_mask"    => metal4_mask,
         "metal4_filler"  => metal4_filler,
-        "metal4_nofill"  => metal4_nofill,
         "metal4_slit"    => metal4_slit,
         "metal4_opc"     => metal4_opc,
         "metal4_noqrc"   => metal4_noqrc,
@@ -197,10 +177,8 @@ if TABLES.include?('offgrid') || (TABLES.include?('main') && OFFGRID)
         # VIA4 / METAL5
         "via4_drw" => via4_drw,
         "metal5_drw"     => metal5_drw,
-        "metal5_pin"     => metal5_pin,
         "metal5_mask"    => metal5_mask,
         "metal5_filler"  => metal5_filler,
-        "metal5_nofill"  => metal5_nofill,
         "metal5_slit"    => metal5_slit,
         "metal5_opc"     => metal5_opc,
         "metal5_noqrc"   => metal5_noqrc,
@@ -212,15 +190,10 @@ if TABLES.include?('offgrid') || (TABLES.include?('main') && OFFGRID)
         "prboundary_drw" => prboundary_drw,
 
         "exchange0_drw" => exchange0_drw,
-        "exchange0_pin" => exchange0_pin,
         "exchange1_drw" => exchange1_drw,
-        "exchange1_pin" => exchange1_pin,
         "exchange2_drw" => exchange2_drw,
-        "exchange2_pin" => exchange2_pin,
         "exchange3_drw" => exchange3_drw,
-        "exchange3_pin" => exchange3_pin,
         "exchange4_drw" => exchange4_drw,
-        "exchange4_pin" => exchange4_pin,
 
         "isonwell_drw" => isonwell_drw,
 
@@ -243,10 +216,8 @@ if TABLES.include?('offgrid') || (TABLES.include?('main') && OFFGRID)
         "mempad_drw"      => mempad_drw,
         "topvia1_drw"     => topvia1_drw,
         "topmetal1_drw"   => topmetal1_drw,
-        "topmetal1_pin"   => topmetal1_pin,
         "topmetal1_mask"  => topmetal1_mask,
         "topmetal1_filler" => topmetal1_filler,
-        "topmetal1_nofill" => topmetal1_nofill,
         "topmetal1_slit"   => topmetal1_slit,
         "topmetal1_noqrc"  => topmetal1_noqrc,
         "topmetal1_res"    => topmetal1_res,
@@ -254,16 +225,13 @@ if TABLES.include?('offgrid') || (TABLES.include?('main') && OFFGRID)
         "topmetal1_diffprb" => topmetal1_diffprb,
         "inldpwl_drw"     => inldpwl_drw,
         "polyres_drw"     => polyres_drw,
-        "polyres_pin"     => polyres_pin,
         "vmim_drw"        => vmim_drw,
         "nbulaycut_drw"   => nbulaycut_drw,
         "antmetal1_drw"   => antmetal1_drw,
         "topvia2_drw"     => topvia2_drw,
         "topmetal2_drw"   => topmetal2_drw,
-        "topmetal2_pin"   => topmetal2_pin,
         "topmetal2_mask"  => topmetal2_mask,
         "topmetal2_filler" => topmetal2_filler,
-        "topmetal2_nofill" => topmetal2_nofill,
         "topmetal2_slit"   => topmetal2_slit,
         "topmetal2_noqrc"  => topmetal2_noqrc,
         "topmetal2_res"    => topmetal2_res,

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ pyyaml
 gdstk
 tqdm
 termcolor
-tkinter


### PR DESCRIPTION
The offgrid table included many layers that carry no manufactured geometry - `.pin`, `_nofill` and `_noqrc` datatypes. These exist only for tooling (connectivity, fill exclusion, RC extraction) and are allowed to sit off grid, so checking them produced spurious offgrid errors.

Drop these layers from the offgrid check.

Fixes #1023
