### PR TITLE
ci: waive tkinter pip failure in make env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,9 +34,17 @@ REQUIREMENTS_FILE := requirements.txt
 $(TOP_DIR)/actions_venv:
 	@python3 -m venv $(TOP_DIR)/actions_venv
 
-# Install requirements	
+# Install requirements
+# tkinter is listed in requirements.txt but is not a PyPI package (it ships as the
+# system package python3-tk), so pip aborts the whole install. Temporary waiver:
+# if the install fails, warn and retry without tkinter so CI proceeds. A real
+# dependency failure still aborts because the retry keeps every other package.
 env: $(TOP_DIR)/actions_venv
-	@. $(VENV_RUN_COMMAND); pip install -r $(REQUIREMENTS_FILE)
+	@. $(VENV_RUN_COMMAND); \
+	pip install -r $(REQUIREMENTS_FILE) || { \
+		echo "::warning::pip install failed on tkinter (not a PyPI package; install python3-tk via the system package manager). Continuing without it so CI can proceed."; \
+		grep -vx 'tkinter' $(REQUIREMENTS_FILE) | pip install -r /dev/stdin; \
+	}
 
 # ========================
 # ----- LINTING TEST -----


### PR DESCRIPTION
tkinter was re-added to `requirements.txt` in 288cd9db, but it is not a PyPI package (it ships as the system package `python3-tk`). With pip's resolver the install is atomic, so pip aborts before installing anything and every CI job that runs `make env` (linting, DRC, LVS) fails.

This is a temporary CI waiver, it does not remove tkinter. The `env` target still runs the normal `pip install -r requirements.txt`, and only if that fails it emits a `::warning::` and retries with the `tkinter` line filtered out, so the remaining dependencies install and CI proceeds. A genuine dependency failure (for example an unavailable klayout pin) still aborts, because the retry keeps every other package.

Verified locally: `make env` and `make lint_python` both exit 0, the warning is shown, and all deps (klayout 0.30.5, flake8, pandas, ...) install.

Proper fix for later: install `python3-tk` via the system package manager in CI and either drop tkinter or replace it with a never-resolving PEP 508 marker.
