### PR TITLE
KLayout Tech File: add comprehensive list of grid values

### DIFF
--- a/ihp-sg13g2/libs.tech/klayout/tech/sg13g2.lyt
+++ b/ihp-sg13g2/libs.tech/klayout/tech/sg13g2.lyt
@@ -20,7 +20,7 @@
  <original-base-path></original-base-path>
  <layer-properties_file>sg13g2.lyp</layer-properties_file>
  <add-other-layers>true</add-other-layers>
- <default-grids>0.01,0.005!</default-grids>
+ <default-grids>10.0,5.0,1.0,0.5,0.1,0.05,0.01,0.005!</default-grids>
  <reader-options>
   <gds2>
    <box-mode>1</box-mode>


### PR DESCRIPTION
Fixes #1042 

Add grid values, list is now: `10µm, 5µm, 1µm, 500nm, 100nm, 50nm, 10nm, 5nm`
