### PR TITLE
[KLayout DRC] Fix `Sdiod.d`/`Sdiod.e` false positives: scope `schottky_contbar` to the recognition region, not `ptap.holes`

### DIFF
--- a/ihp-sg13g2/libs.tech/klayout/tech/drc/rule_decks/feol/6_7_schottkydiode.drc
+++ b/ihp-sg13g2/libs.tech/klayout/tech/drc/rule_decks/feol/6_7_schottkydiode.drc
@@ -25,7 +25,7 @@ if TABLES.include?('schottkydiode') || FEOL
 
   unless PRECHECK_DRC
     # Schottky diode derivations
-    schottky_contbar = contbar.and(schottky_nbl1)
+    schottky_contbar = contbar.and(schottky_nbl_rec)
     schottky_nsd_block = nsd_block.and(schottky_nbl1)
     schottky_salblock = salblock_drw.and(schottky_nbl1)
 


### PR DESCRIPTION
## What

Scope the Schottky-diode ContBar check in `rule_decks/feol/6_7_schottkydiode.drc` to the nBuLay-based recognition region (`schottky_nbl_rec`) instead of `schottky_nbl1`:

```diff
-    schottky_contbar = contbar.and(schottky_nbl1)
+    schottky_contbar = contbar.and(schottky_nbl_rec)
```

Fixes #1048.

## Why

`schottky_nbl1` is derived as `ptap.holes.covering(schottky_nbl_rec)` (`ihp-sg13g2.drc:351`). On any chip whose substrate ties / sealring form a ring around the die, `ptap.holes` becomes a single polygon spanning the **entire die interior**. `6_7_schottkydiode.drc` then takes `contbar.and(schottky_nbl1)`, so **every** non-square contact on the chip is classified as a Schottky anode bar and measured against the SBD anode dimensions by `Sdiod.d` (width 0.30 µm) and `Sdiod.e` (length 1.00 µm). Ordinary poly-resistor contact bars (`rsil`, `rppd`, `rhigh`) can never satisfy those and are reported as violations, even hundreds of µm away from any diode.

This is the DRC-side twin of the LVS problem discussed in #498, where the same `ptap.holes` over-captures shorted the substrate. The **LVS deck already carries the fix**. `general_derivations.lvs:95` uses `ptap_all.not(edgeseal_drw).holes`, but the DRC deck still used the bare `ptap.holes`. It also underlies the reports in #684 and #779.

`schottky_nbl_rec = nbulay_drw.not(nwell_drw).not_outside(schottky_nbl_mk)` is the actual nBuLay footprint of the diode (already derived immediately above `schottky_nbl1` in `ihp-sg13g2.drc`, same guard/scope), so restricting `schottky_contbar` to it selects only real diode anode bars.

## Scope of the change

- Only `schottky_contbar` is re-scoped. `Sdiod.b` and `Sdiod.c` are left untouched and stay correct because they consume `schottky_contbar` via `.enclosed(...)` / `.interacting(schottky_contbar)`, so they are implicitly restricted to real diode bars once `schottky_contbar` is correct. `schottky_nsd_block` / `schottky_salblock` are intentionally **not** re-scoped, to avoid clipping their enclosure regions and introducing new `Sdiod.b`/`Sdiod.c` false positives.
- `schottky_nbl1` itself is unchanged, so its other uses in the deck (e.g. `schottky_nbl1.join(schottky_nw1)`) are unaffected.
- Alternative considered: mirror the LVS fix with `ptap.not(edgeseal_drw).holes`. That also clears this case, but keeps the `holes` operation, which still over-captures for a legitimate inner p-tap guard ring around non-diode contacts (see @klayoutmatthias's note in #498). Scoping to the recognition region drops `holes` entirely and is the more robust fix.

## Verification

Reproduced with the real `run_drc.py` on the public test case [iic-jku/SG13CMOS_SPARX](https://github.com/iic-jku/SG13CMOS_SPARX) (`layout/sparx160_top.gds`, `--table=schottkydiode --run_mode=deep`, IHP PDK from IIC-OSIC-TOOLS 2026.07, KLayout 0.30.9), identical GDS/table/run-mode, only the deck differing:

| Deck | Result |
| --- | --- |
| before (`contbar.and(schottky_nbl1)`) | ❌ 20 items — `Sdiod.d`, `Sdiod.e` |
| after (`contbar.and(schottky_nbl_rec)`) | ✅ 0 items |

The 8 legitimate SBD anode bars still pass and are still checked, so the fix does not loosen the rule — a malformed anode bar would still be caught.

## Not affected

- **Maximal deck** (`rule_decks/sg13g2_maximal.drc`): uses a different `NWell.holes`/`isoPWell`-based derivation and has no `without_bbox` `Sdiod.d`/`Sdiod.e` rules --> not impacted.
- **ihp-sg13cmos5l**: independent DRC deck. Its modular deck removes the Schottky file (`# REMOVED: rule_decks/feol/6_7_schottkydiode.drc`), and its maximal deck uses the same `NWell.holes` derivation. No change needed there.