### PR TITLE
Fix SG13_dev PCell coerce failure on tech params containing spaces

### DIFF
--- a/ihp-sg13g2/libs.tech/klayout/python/sg13g2_pycell_lib/callbacks/parameters.tcl
+++ b/ihp-sg13g2/libs.tech/klayout/python/sg13g2_pycell_lib/callbacks/parameters.tcl
@@ -85,11 +85,24 @@ proc setTechParameters {techParams} {
 
     set techParameters [dict create]
 
-    dict for {key value} $techParams {
-        # remove decoration from key/value
-        regexp {'?([^',]+)'?:?} $key match undecoratedKey
-        regexp {'?([^',]+)'?,?} $value match undecoratedValue
-        dict append techParameters $undecoratedKey $undecoratedValue
+    # techParams arrives as a Python dict repr, e.g.
+    #   'key': 'value', 'key': 0.001, 'key': 'value with spaces', ...
+    # A plain "dict for" over this string breaks whenever a value contains a
+    # space (e.g. 'No value'), because the whitespace split then yields an odd
+    # number of tokens and Tcl raises "missing value to go with key". Parse
+    # with a regex that respects the quoting so that space-containing values
+    # keep their key/value pairing intact.
+    set pattern {'([^']+)'\s*:\s*(?:'([^']*)'|([^,]+))}
+    foreach {match key quotedValue bareValue} [regexp -all -inline $pattern $techParams] {
+        if {$match eq ""} {
+            continue
+        }
+        if {$bareValue ne ""} {
+            set value [string trim $bareValue]
+        } else {
+            set value $quotedValue
+        }
+        dict set techParameters $key $value
     }
 }
 


### PR DESCRIPTION
Fixes #1065.

`setTechParameters` in `sg13g2_pycell_lib/callbacks/parameters.tcl` parsed the
tech-param dict repr with `dict for {key value}`, which splits on whitespace. Several
shipped tech params carry spaces (`vendorName`, `authorName`, `LBE_h = 'No value'`), so
the token count goes odd and Tcl raises `missing value to go with key`. That aborts
`_initializeCallbacks` one line before `setCniPythonPath`, leaving `cniPythonPath` empty,
which later surfaces on callback devices as `ModuleNotFoundError: No module named 'numeric'`.
The net effect is that every `SG13_dev` PCell fails at its first coerce.

This replaces the parser with a quote-respecting regex so space-bearing values keep their
key/value pairing. Behavior is unchanged for the values that already parsed; it only adds
correct handling for values with spaces.

Validation: a standalone `tclsh` run over the full shipped tech-param set (numbers, unit
strings, empty strings, and space-bearing values) parses every pair correctly, and
`sg13g2_tests/pycell_test.py` then instantiates the `SG13_dev` devices without the coerce
crash.

Note on CI: the DRC/LVS regressions run against committed static GDS and never exercise
the PCell coerce path, so this change is invisible to those checks (which is also why the
bug went unnoticed). Adding a gating PCell smoke test would close that gap and could be a
separate follow-up.

Scope: a single file, `parameters.tcl`. The two unrelated basic-lib failures noted in
#1065 (cmim `abs()` arity, nmos float-param typing) are out of scope here.
