### PR TITLE
lvs: make the inductor metal stack configurable per PDK

### DIFF
--- a/ihp-sg13g2/libs.tech/klayout/tech/lvs/rule_decks/custom_extractor.lvs
+++ b/ihp-sg13g2/libs.tech/klayout/tech/lvs/rule_decks/custom_extractor.lvs
@@ -224,12 +224,9 @@ class GeneralNTerminalExtractor < RBA::GenericDeviceExtractor
     space = get_space_val(meas_sel, max_mk_len)
 
     # Turns
-    # Calc steps used for no. of turns:
-    # step1: Get count of inductor metal (catch if we have more 1)
-    # Step2: For more than 1 turns, get number of holes
-    # Step3: Turns = 1 + (holes - 1)/2 
-    no_turns_init = meas_mk.merged.count
-    no_turns = no_turns_init
+    # The crossings cut the winding metal into one arc per turn, so the number
+    # of turns is the number of winding polygons inside this device's marker.
+    no_turns = meas_sel.count
 
     ## Old implementation
     # if no_turns_init == 1
@@ -239,6 +236,18 @@ class GeneralNTerminalExtractor < RBA::GenericDeviceExtractor
     #   no_turns_pre2 = (no_turns_pre1 - 1) / 2
     #   no_turns = 1 + no_turns_pre2.ceil
     # end
+
+    # Default values. These must be applied before the diameter arithmetic
+    # below: get_width_val / get_space_val return nil on an empty region, and
+    # nil would raise a TypeError there rather than fall back to a default.
+    if meas_sel.is_empty?
+      $logger.error("No winding metal found for #{@name}: w, s and nr_r " \
+                    'cannot be measured. Check that the winding is on the ' \
+                    "metal this PDK's ind_wind points at.")
+    end
+    width ||= 0
+    space ||= 0
+    no_turns = 1 if no_turns < 1
 
     # Diameter
     # Calc steps used for diameter:
@@ -252,12 +261,6 @@ class GeneralNTerminalExtractor < RBA::GenericDeviceExtractor
     diameter = diam_edge.length
     diameter = diameter - (2 * (no_turns - 1) * space) - (2 * no_turns * width)
     diameter = diameter.negative? ? 0 : diameter
-
-    # Default values
-    width ||= 0
-    space ||= 0
-    diameter ||= 0
-    no_turns ||= 1
 
     [width, space, diameter, no_turns]
   end

--- a/ihp-sg13g2/libs.tech/klayout/tech/lvs/rule_decks/general_derivations.lvs
+++ b/ihp-sg13g2/libs.tech/klayout/tech/lvs/rule_decks/general_derivations.lvs
@@ -62,6 +62,20 @@ metal5_con    = metal5.not(metal5_res)
 topmetal1_con = topmetal1.not(topmetal1_res).not(ind_drw)
 topmetal2_con = topmetal2.not(topmetal2_res).not(ind_drw)
 
+# Inductor metal stack.
+# ind_wind is the winding metal: w, s and nr_r are all measured on it, and
+# nr_r is the number of winding arcs the crossings cut it into.
+# ind_cross is the metal carrying the underpass crossings that join the turns;
+# it is part of the core so that the coil merges into a single polygon.
+# The *_con lists are the connectivity layers the IND pins bond to. They are
+# lists because KLayout connectivity is defined per layer object: joining two
+# derived layers would create a third one that is connected to neither.
+# A PDK with a different metal stack overrides these after including this deck.
+ind_wind      = topmetal2
+ind_cross     = topmetal1
+ind_wind_con  = [topmetal2_con]
+ind_cross_con = [topmetal1_con]
+
 # Gate FETs
 tgate   = gatpoly.and(activ).not(res_mk)
 ngate   = nactiv.and(tgate)

--- a/ihp-sg13g2/libs.tech/klayout/tech/lvs/rule_decks/ind_connections.lvs
+++ b/ihp-sg13g2/libs.tech/klayout/tech/lvs/rule_decks/ind_connections.lvs
@@ -26,12 +26,14 @@ logger.info('Starting Inductor CONNECTIONS')
 # ind2
 connect(ind2_ports, ind_pin)
 connect(ind_pin, ind_text)
-connect(ind_pin, topmetal2_con)
+# One connect per layer: connectivity is defined between layer objects, so a
+# joined layer would be a third object connected to neither of its operands.
+ind_wind_con.each { |ind_wind_layer| connect(ind_pin, ind_wind_layer) }
 connect(ind2_sub, pwell)
 connect(ind2_sub, nwell_drw)
 
 # ind3
 connect(ind3_ports, ind_pin)
-connect(ind_pin, topmetal1_con)
+ind_cross_con.each { |ind_cross_layer| connect(ind_pin, ind_cross_layer) }
 connect(ind3_sub, pwell)
 connect(ind3_sub, nwell_drw)

--- a/ihp-sg13g2/libs.tech/klayout/tech/lvs/rule_decks/ind_derivations.lvs
+++ b/ihp-sg13g2/libs.tech/klayout/tech/lvs/rule_decks/ind_derivations.lvs
@@ -37,14 +37,16 @@ ind2_patt = glob_to_case_insensitive_glob("inductor2*")
 ind3_patt = glob_to_case_insensitive_glob("inductor3*")
 
 ind_edges = ind_drw.edges
-ind_core_ = topmetal2.join(topmetal1).and(ind_drw).merged.not(ind_exc)
+# ind_wind / ind_cross come from general_derivations.lvs and describe which
+# metals a coil is built from. Joining them here is a geometric union only.
+ind_core_ = ind_wind.join(ind_cross).and(ind_drw).merged.not(ind_exc)
 ind_ports_ = ind_pin.and(ind_core_).interacting(ind_edges)
 ind_port_la = ind_ports_.interacting(ind_text.texts(la_patt))
-ind_la_tm1 = ind_port_la.and(topmetal1)
+ind_la_cross = ind_port_la.and(ind_cross)
 ind_port_lb = ind_ports_.interacting(ind_text.texts(lb_patt))
-ind_lb_tm1 = ind_port_lb.and(topmetal1)
+ind_lb_cross = ind_port_lb.and(ind_cross)
 ind_port_lc = ind_ports_.interacting(ind_text.texts(lc_patt))
-ind_lc_tm2 = ind_port_lc.and(topmetal2)
+ind_lc_wind = ind_port_lc.and(ind_wind)
 
 # inductor2
 ind2_ports = ind_port_la.join(ind_port_lb)
@@ -56,11 +58,24 @@ ind2_sub2 = pwell_block.and(ind_drw).interacting(ind2_core).sized(1.nm)
 ind2_well = nwell_drw.and(ind_drw).interacting(ind2_core).sized(-1.nm)
 ind2_sub = ind2_sub1.join(ind2_sub2).join(ind2_well)
 # inductor3
-ind3_ports = ind_la_tm1.join(ind_lb_tm1).join(ind_lc_tm2)
-ind3_core = ind_core_.interacting(ind_lb_tm1, 1).interacting(ind_lb_tm1, 1).interacting(ind_lc_tm2, 1)
+ind3_ports = ind_la_cross.join(ind_lb_cross).join(ind_lc_wind)
+ind3_core = ind_core_.interacting(ind_la_cross, 1).interacting(ind_lb_cross, 1).interacting(ind_lc_wind, 1)
 ind3_mk_ = ind_drw.interacting(text_drw.texts(ind3_patt))
 ind3_mk = ind3_mk_.interacting(ind3_core).interacting(ind3_ports)
 ind3_sub1 = pwell.and(ind_drw).interacting(ind3_core)
 ind3_sub2 = pwell_block.and(ind_drw).interacting(ind3_core).sized(1.nm)
 ind3_well = nwell_drw.and(ind_drw).interacting(ind3_core).sized(-1.nm)
 ind3_sub = ind3_sub1.join(ind3_sub2).join(ind3_well)
+
+# A marker that names a device but fails the core/port predicates is dropped
+# before extraction, so the extractor's own diagnostics never fire. Say so,
+# otherwise the whole inductor silently disappears from the netlist.
+if !ind2_mk_.is_empty? && ind2_mk.is_empty?
+  logger.error('inductor2 marker found but no device recognised: check that ' \
+               'the IND:pin rectangles sit on the winding metal, touch the ' \
+               'IND edge, and carry LA/LB labels on IND:text')
+end
+if !ind3_mk_.is_empty? && ind3_mk.is_empty?
+  logger.error('inductor3 marker found but no device recognised: check that ' \
+               'LA/LB land on the crossing metal and LC on the winding metal')
+end

--- a/ihp-sg13g2/libs.tech/klayout/tech/lvs/rule_decks/ind_extraction.lvs
+++ b/ihp-sg13g2/libs.tech/klayout/tech/lvs/rule_decks/ind_extraction.lvs
@@ -28,7 +28,7 @@ logger.info('Extracting Inductor2 device')
 extract_devices(GeneralNTerminalExtractor.new('inductor', 2), {
                   'core' => ind2_core,
                   'ports' => ind2_ports,
-                  'meas_mk' => topmetal2.and(ind2_core),
+                  'meas_mk' => ind_wind.and(ind2_core),
                   'dev_mk' => ind2_mk,
                   'sub_mk' => ind2_sub
                 })
@@ -38,7 +38,7 @@ logger.info('Extracting Inductor3 device')
 extract_devices(GeneralNTerminalExtractor.new('inductor3', 3), {
                   'core' => ind3_core,
                   'ports' => ind3_ports,
-                  'meas_mk' => topmetal2.and(ind3_core),
+                  'meas_mk' => ind_wind.and(ind3_core),
                   'dev_mk' => ind3_mk,
                   'sub_mk' => ind3_sub
                 })


### PR DESCRIPTION
Fixes #1067

Related: IHP-GmbH/ihp-sg13cmos5l#57

The inductor decks hardcoded TopMetal2 as the winding metal and TopMetal1 as the crossing metal. That is right for SG13G2, but it is baked into decks that derived PDKs consume verbatim, so a process without TopMetal2 cannot recognise an inductor at all: `meas_mk` comes out empty, `w`/`s`/`nr_r` cannot be measured, and the coil never merges into a single core polygon.

The two metals move into `ind_wind` / `ind_cross`, defaulted to the current pair in `general_derivations.lvs`:

```ruby
ind_wind      = topmetal2
ind_cross     = topmetal1
ind_wind_con  = [topmetal2_con]
ind_cross_con = [topmetal1_con]
```

A PDK with a different stack overrides them after including that deck. Defaults live there rather than in the top deck so that an unmodified downstream deck keeps working, and because Ruby parses a name with no textually earlier assignment as a method call.

The `*_con` values are lists on purpose. KLayout connectivity is defined between layer objects, so `metal4_con.join(metal3_con)` would create a third layer connected to neither operand and the pins would end up on a floating net. `ind_connections.lvs` iterates instead. The plain `.join()` inside `ind_cross` is fine, that one is geometry only.

Three defects surfaced while doing this, all described in #1067:

- `ind3_core` tested `ind_lb_tm1` twice, so the LA port was never required.
- `calc_ind_params` applied its `||= 0` defaults after using `width` and `space`, so an empty `meas_mk` raised `TypeError: nil can't be coerced into Integer` instead of falling back. Reachable today with a TopMetal1-only coil.
- `no_turns ||= 1` never fired, because `0` is truthy in Ruby. It is now clamped, and measured on the region-clipped selection like `width` and `space` rather than on the whole cluster.

A marker that names an inductor but fails the core or port predicates is dropped before `extract_devices` runs, so the extractor's own "terminals don't touch device marker correctly" diagnostic never appears and the device vanishes from the netlist with no explanation. That case is now logged.

### Verification

`nr_r` is not part of `equal_ind_parameters` in `custom_devices.lvs`, so LVS never compares it and pass/fail alone would not catch a turn-count regression. Verified by diffing extracted netlists instead:

```
$ diff ind_before/inductor/inductor_extracted.cir ind_after/inductor/inductor_extracted.cir
```

Both `inductor.gds` and `inductor3.gds` come out byte-identical apart from the timestamp comment, across all 26 devices and `nr_r` values 1 to 5.

- `make test-LVS-IND`: 2/2 passed
- full LVS regression: 49/49 passed

- [x] Tests pass
- [x] Appropriate changes to README are included in PR

No README change applies: this is behaviour-preserving for SG13G2 and adds no user-facing feature here. The downstream PDK documents its own override.
