### PR TITLE
cmomi: exclude density fill from the device

### DIFF
--- a/ihp-sg13g2/libs.tech/klayout/python/sg13g2_pycell_lib/ihp/cmomi_code.py
+++ b/ihp-sg13g2/libs.tech/klayout/python/sg13g2_pycell_lib/ihp/cmomi_code.py
@@ -406,15 +406,27 @@ class cmomi(DloGen):
             y_hi = max(y_hi, pad_y_hi)
         self._paint(recog_layer, x_lo, y_lo, x_hi, y_hi)
 
-        # 5) Substrate isolation block
+        # 5) Filler keep-out over the full device.
+        # The cap_cmomi value is defined by the metal geometry. Automatic dummy
+        # metal fill (density fill) landing on or beside the fingers, or over the
+        # device on the upper metals the cap does not draw, perturbs the real
+        # capacitance. LVS matches this device topologically and does not compare
+        # its value, and DRC leaves rule-compliant fill untouched, so neither
+        # catches the perturbation. NoMetFiller (160/0) over the device bbox is
+        # honoured by every metal and topmetal filler and excludes all metal
+        # fill in one marker.
+        nofiller_layer = Layer('NoMetFiller', 'drawing')
+        self._paint(nofiller_layer, x_lo, y_lo, x_hi, y_hi)
+
+        # 6) Substrate isolation block
         if self.subblock:
             pwb_layer = Layer('PWell', 'block')
             self._paint(pwb_layer, x_lo, y_lo, x_hi, y_hi)
 
-        # 6) Pins
+        # 7) Pins
         self._place_pins(m_top, dev_w, ny, feed_pad_yrange, metal_layers)
 
-        # 7) Capacitance label (must match the simulation model, contract).
+        # 8) Capacitance label (must match the simulation model, contract).
         n_clamped = min(self.METAL_MAX, max(2, n_layers))
         areacap = self.AREACAP[n_clamped]
         active_area = nx_active * self.UC_X * ny_active * self.UC_Y


### PR DESCRIPTION
The cap_cmomi capacitance is defined by its metal geometry, but the automatic density filler drops dummy metal on or beside the fingers and, more importantly, over the device on the upper metals the cap does not draw. That dummy metal changes the real capacitance. LVS matches cap_cmomi topologically and does not compare its value (the extractor reads only L and W from the recognition marker and checks for exactly two pins), and DRC leaves rule-compliant fill in place, so neither flags the perturbation.

The device previously painted the recognition marker, the optional substrate block and the pins, but no fill keep-out, so the filler was free to fill over it. The metal and topmetal fillers already subtract NoMetFiller (160/0) on every layer, so painting NoMetFiller over the full device bounding box (the same extent as the recognition marker) excludes all metal fill from the device in a single marker. The marker carries no DRC rule of its own and is exempt from the offgrid and angle checks, so it adds no violations.

Verified with the KLayout filler on a flattened mmax=2 cmomi placed inside an EdgeSeal frame: without the marker the filler drops dummy metal on Metal3, Metal4 and Metal5 over the device; with the marker there is none, on any metal layer, across the double, same and none feeds. Generation was also checked for the double, same and none feeds and for N from 2 to 5: the NoMetFiller shape matches the recognition marker bounding box exactly.

The same fix is being applied to ihp-sg13cmos5l, whose cap_cmomi PCell has the same gap.
