### PR TITLE
gnucap: make `check` build what it runs, and let the suite fail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,3 +193,12 @@ cliff*toml
 
 # OpneVAF compiled models dir
 */*/ngspice/osdi
+# Gnucap build and test outputs (now that `make check` builds, these land in the
+# tree on every run; *.so is already covered above)
+*/*/gnucap/plugins/
+*/*/gnucap/figures/
+*/*/gnucap/models/*.dump.va
+*/*/gnucap/tests/**/check/
+*/*/gnucap/tests/**/*.diff
+*/*/gnucap/tests/**/.check-failures.*
+*/*/gnucap/tests/**/.check-ran.*

--- a/ihp-sg13g2/libs.tech/gnucap/Makefile
+++ b/ihp-sg13g2/libs.tech/gnucap/Makefile
@@ -11,8 +11,13 @@ models-plugins:
 gnucap-plugins:
 	@$(MAKE) -C cpp
 
-# Run all tests
-check: models plugins
+# Run all tests, after building what they load.
+#
+# The prerequisites used to read `models plugins`. Neither has a rule with a
+# recipe, and they resolved only because .PHONY declared them, which makes them
+# silent no-ops: check ran the suite without building anything, even though the
+# README describes it as building the required plugins first.
+check: all
 	@$(MAKE) -C tests
 
 # Clean everything
@@ -20,17 +25,19 @@ clean:
 	@$(MAKE) -C models clean
 	@$(MAKE) -C cpp clean
 	@$(MAKE) -C tests clean
-	@rm -rf plugins/*.so
+	@# The sub-makes remove their own .so from plugins/models and plugins/gnucap;
+	@# nothing is ever written to plugins/ itself, so only the empty dirs remain.
+	@rmdir plugins/models plugins/gnucap plugins/osdi plugins 2>/dev/null || true
 
 # Help
 help:
 	@echo "Build Gnucap Verilog-AMS Model and Simulator Plugins"
 	@echo ""
 	@echo "Targets:"
-	@echo "  all      - Build all plugins"
+	@echo "  all             - Build all plugins"
 	@echo "  models-plugins  - Build Verilog-AMS model plugins only"
 	@echo "  gnucap-plugins  - Build Gnucap simulator plugins only"
-	@echo "  tests    - Run test suite"
-	@echo "  clean    - Remove all build artifacts"
+	@echo "  check           - Build the plugins, then run the test suite"
+	@echo "  clean           - Remove all build artifacts"
 
-.PHONY: all clean models plugins tests
+.PHONY: all models-plugins gnucap-plugins check clean help

--- a/ihp-sg13g2/libs.tech/gnucap/README.md
+++ b/ihp-sg13g2/libs.tech/gnucap/README.md
@@ -47,11 +47,13 @@ Install:
 - [Gnucap](https://codeberg.org/gnucap/gnucap)
 - [gnucap-modelgen-verilog](https://codeberg.org/gnucap/gnucap-modelgen-verilog)
 - [Ngspice](https://sourceforge.net/projects/ngspice/files/ng-spice-rework/46/)
+- [OpenVAF](https://openvaf.semimod.de), for the OSDI step below
 
 Tested with:
-- Gnucap: `sckt 2026.05.12`
-- gnucap-modelgen-verilog: `sckt 2026.05.12`
-- Ngspice: `ngspice-46` 
+- Gnucap: `resolve 2026.06.10`
+- gnucap-modelgen-verilog: `gnucap-mg-vams`, same release
+- Ngspice: `ngspice-46`
+- OpenVAF: `openvaf 23.5.0` (`openvaf-r`)
 
 To run Ngspice testbench, add the following environment variables to your  
 `~/.bashrc`: 
@@ -65,6 +67,15 @@ export PDK=ihp-sg13g2
 
 Replace `/path/to/IHP-Open-PDK` with the path to your local IHP-Open-PDK 
 repository.
+
+The Ngspice testbenches also need the OSDI objects that the model cards
+reference. Those are a build product rather than a tracked file, so on a fresh
+checkout `libs.tech/ngspice/osdi/` does not exist yet and the Ngspice half of the
+suite stops on its first test. Build them once with [OpenVAF](https://openvaf.semimod.de):
+
+```bash
+cd $PDK_ROOT/$PDK/libs.tech/verilog-a && ./openvaf-compile-va.sh
+```
 
 To plot and compare test results between Gnucap and Ngspice, install the 
 required Python dependencies. From the top-level `gnucap/` directory, create a 
@@ -93,7 +104,7 @@ make
 Build only Verilog-A model plugins:
 
 ```bash
-make model-plugins
+make models-plugins
 ```
 
 Build only Gnucap simulator plugins:
@@ -228,7 +239,7 @@ make -C tests/ngspice resistor/check/tb_res_basic_typ.sp.out
 Generate all figures from the reference test data:
 
 ```bash
-python python/plot_tests.py
+python python/plot_all.py
 
 ```
 

--- a/ihp-sg13g2/libs.tech/gnucap/models/Makefile
+++ b/ihp-sg13g2/libs.tech/gnucap/models/Makefile
@@ -22,16 +22,52 @@ PLUGINS = $(TARGETS:%=$(TARGET_DIR)/%.so)
 # Default target
 all: $(PLUGINS)
 
-# Create target directory if it doesn't exist
+# Create target directories if they don't exist
 $(TARGET_DIR):
 	mkdir -p $(TARGET_DIR)
+
+$(OSDI_DIR):
+	mkdir -p $(OSDI_DIR)
 
 # Auto-generate convenience targets for each item in TARGETS
 $(TARGETS): %: $(TARGET_DIR)/%.so
 # Auto-generate convenience targets to dump each item in TARGETS
 $(TARGETS:%=dump-%): dump-%: %.dump.va
 # Auto-generate convenience targets to build OSDI for each item in TARGETS
-$(TARGETS:%=osdi-%): osdi-%: $(TARGET_DIR)/%.osdi
+$(TARGETS:%=osdi-%): osdi-%: $(OSDI_DIR)/%.osdi
+
+# Sources reached through `include, listed by hand because gnucap-mg-vams has no
+# dependency-output mode. Without them make compares only the paramset file
+# itself, so editing r3_cmc.va, psp103.va, cap_cmomi.va or discipline.h leaves a
+# stale .so in place and `make check` then validates the previous build instead
+# of the current one. The external model trees are taken wholesale: any of their
+# .include files feeds the compile, and they are third-party sources that change
+# rarely enough that over-triggering costs nothing.
+va_sources  = $(wildcard $(1)/*.va $(1)/*.vams $(1)/*.include $(1)/*.h)
+R3CMC_SRC  := $(call va_sources,$(IHP_VERILOG_DIR)/r3_cmc)
+PSP103_SRC := $(call va_sources,$(IHP_VERILOG_DIR)/psp103)
+CMOMI_SRC  := $(call va_sources,$(IHP_VERILOG_DIR)/cap_cmomi)
+
+$(TARGET_DIR)/resistor_paramset.cc:        resistor.va discipline.h $(R3CMC_SRC)
+$(TARGET_DIR)/capacitor_paramset.cc:       capacitor.va $(CMOMI_SRC)
+$(TARGET_DIR)/sg13g2_moslv_paramset.cc:    discipline.h $(PSP103_SRC)
+$(TARGET_DIR)/sg13g2_moslv_rf_paramset.cc: discipline.h $(PSP103_SRC)
+$(TARGET_DIR)/sg13g2_moshv_paramset.cc:    discipline.h $(PSP103_SRC)
+$(TARGET_DIR)/sg13g2_moshv_rf_paramset.cc: discipline.h $(PSP103_SRC)
+
+resistor_paramset.dump.va:        resistor.va discipline.h $(R3CMC_SRC)
+capacitor_paramset.dump.va:       capacitor.va $(CMOMI_SRC)
+sg13g2_moslv_paramset.dump.va:    discipline.h $(PSP103_SRC)
+sg13g2_moslv_rf_paramset.dump.va: discipline.h $(PSP103_SRC)
+sg13g2_moshv_paramset.dump.va:    discipline.h $(PSP103_SRC)
+sg13g2_moshv_rf_paramset.dump.va: discipline.h $(PSP103_SRC)
+
+# Naming the generated C++ as explicit targets above would make it permanent:
+# GNU make only treats a file as intermediate, and deletes it after the build,
+# when it is never mentioned as a target or prerequisite. These are hundreds of
+# MB, so keep them intermediate; the dependencies above still decide when the
+# chain has to be rebuilt.
+.INTERMEDIATE: $(TARGETS:%=$(TARGET_DIR)/%.cc)
 
 # Generate C++ from Verilog-A
 $(TARGET_DIR)/%.cc: %.va | $(TARGET_DIR)
@@ -54,7 +90,8 @@ $(TARGET_DIR)/%.so: $(TARGET_DIR)/%.o
 	${MODELGEN_VERILOG} ${MGFLAGS} -o $@ --dump $<
 
 # Generate OSDI from dumped paramset Verilog-A module
-$(TARGET_DIR)/%.osdi: %.dump.va
+# (into OSDI_DIR, which is where clean looks for it)
+$(OSDI_DIR)/%.osdi: %.dump.va | $(OSDI_DIR)
 	${OPENVAF} $< -o $@
 
 # Clean plugins

--- a/ihp-sg13g2/libs.tech/gnucap/tests/Makefile
+++ b/ihp-sg13g2/libs.tech/gnucap/tests/Makefile
@@ -6,8 +6,19 @@
 # Default: run all tests
 all: check
 
-# Run both gnucap and ngspice tests
-check: check-gnucap check-ngspice
+# Run both gnucap and ngspice tests.
+#
+# Not a plain prerequisite list: each half now exits nonzero when a test
+# mismatches, and stopping at the first failure would hide whether the other
+# simulator failed too. That distinction is the useful one here, since a failure
+# on both sides points at the model or the reference data while a failure on one
+# side points at that simulator's plumbing. So both halves always run and the
+# status is reported afterwards.
+check:
+	@rc=0; \
+	$(MAKE) -C gnucap check || rc=1; \
+	$(MAKE) -C ngspice check || rc=1; \
+	exit $$rc
 
 # Run gnucap tests
 check-gnucap:
@@ -34,8 +45,12 @@ help:
 	@echo "  check-ngspice   - Run ngspice tests only"
 	@echo "  clean           - Remove all test outputs"
 	@echo ""
-	@echo "To run individual test directories (resistor, capacitor, moslv, moshv):"
-	@echo "  make -C gnucap <testdir>"
-	@echo "  make -C ngspice <testdir>"
+	@echo "To run one test directory:"
+	@echo "  make -C gnucap check-<testdir>"
+	@echo "  make -C ngspice check-<testdir>"
+	@echo ""
+	@echo "For the test directories this PDK has, and the test counts:"
+	@echo "  make -C gnucap help"
+	@echo "  make -C ngspice help"
 
-.PHONY: all check gnucap ngspice clean help
+.PHONY: all check check-gnucap check-ngspice clean help

--- a/ihp-sg13g2/libs.tech/gnucap/tests/gnucap/Makefile
+++ b/ihp-sg13g2/libs.tech/gnucap/tests/gnucap/Makefile
@@ -21,11 +21,48 @@ ALL_TESTS := $(foreach f,$(ALL_TESTS), $(if $(filter $(TEST_EXCLUDE_PREFIX)%,$(n
 # Each test generates an output
 ALL_OUTS := $(foreach f, $(ALL_TESTS), $(dir $(f))check/$(notdir $(f)).out)
 
+# Pinned, because the first rule below is reset-failures and make would
+# otherwise take that as the goal: a bare `make` here would clear the
+# bookkeeping, run no test and exit 0, which is the failure this file exists to
+# stop.
+.DEFAULT_GOAL := check
+
+# Aggregate exit status.
+#
+# A test rule must not fail the build on the spot: the whole suite has to run so
+# that one invocation reports the complete PASS/FAIL set. So each test that does
+# not pass records itself here, and the aggregate targets fail afterwards. That is
+# what makes `make check` return nonzero when something regressed, so it can be
+# used as a gate rather than only read.
+# Scoped to this make invocation: two concurrent runs in the same directory would
+# otherwise share the files, and one finishing would clear the other's record,
+# which can turn a real failure into a green report.
+RUNID  := $(shell echo $$PPID)
+FAILLOG = .check-failures.$(RUNID)
+RUNLOG  = .check-ran.$(RUNID)
+
+reset-failures:
+	@rm -f $(FAILLOG) $(RUNLOG)
+
+REPORT = ran=$$(cat $(RUNLOG) 2>/dev/null | wc -l); \
+	bad=$$(cat $(FAILLOG) 2>/dev/null | wc -l); \
+	echo ""; \
+	if [ "$$bad" -gt 0 ]; then \
+	  echo "$$bad of $$ran tests did not pass:"; \
+	  sed 's/^/  /' $(FAILLOG); \
+	  rm -f $(FAILLOG) $(RUNLOG); \
+	  exit 1; \
+	fi; \
+	echo "all $$ran tests passed"; \
+	rm -f $(RUNLOG)
+
 # Default: check all tests
 check: $(ALL_OUTS)
+	@$(REPORT)
+
 # Rule: one test file *.gc generates one output file *.gc.out
 define TEST_RULE
-$(dir $(1))check/$(notdir $(1)).out: $(1)
+$(dir $(1))check/$(notdir $(1)).out: $(1) | reset-failures
 	@mkdir -p $(dir $(1))check
 	@# Run gnucap and filter output:
 	@cd "$(dir $(1))" && \
@@ -35,15 +72,18 @@ $(dir $(1))check/$(notdir $(1)).out: $(1)
 	  grep -v 'already installed' | \
 	  grep -v '^@@' \
 	  > "check/$(notdir $(1)).out" || true
+	@echo "$$(notdir $$<)" >> $(RUNLOG)
 	@if [ -f "$(dir $(1))ref/$(notdir $(1)).out" ]; then \
 	  if $(DIFF) -u "$(dir $(1))ref/$(notdir $(1)).out" "$$@" > "$$(basename $$@).diff" 2>&1; then \
 	    echo "PASS $$(notdir $$<)"; \
 	    rm -f "$$(basename $$@).diff"; \
 	  else \
 	    echo "FAIL $$(notdir $$<)"; \
+	    echo "FAIL $$(notdir $$<)" >> $(FAILLOG); \
 	  fi; \
 	else \
 	  echo "MISS $$(notdir $$<)"; \
+	  echo "MISS $$(notdir $$<)" >> $(FAILLOG); \
 	fi
 endef
 
@@ -53,11 +93,13 @@ $(foreach f, $(ALL_TESTS), $(eval $(call TEST_RULE,$(f))))
 # Rule: Make each test directory an aggregate target for its test
 define DIR_RULE
 check-$(1): $(foreach f, $(filter $(1)/%.gc, $(ALL_TESTS)), $(dir $(f))check/$(notdir $(f)).out)
+	@$$(REPORT)
 endef
 # Create one aggregate per directory in TESTDIRS using DIR_RULE
 $(foreach d,$(TESTDIRS),$(eval $(call DIR_RULE,$(d))))
 
 clean:
+	@rm -f .check-failures.* .check-ran.*
 	@for dir in $(TESTDIRS); do \
 	  rm -rf $$dir/check; \
 	done
@@ -76,5 +118,6 @@ help:
 	@echo ""
 	@echo "Total tests: $(words $(ALL_TESTS))"
 
-.PHONY: check clean $(TESTDIRS) help
+# $(TESTDIRS) are directories, not targets; the aggregates are check-<testdir>.
+.PHONY: check clean help reset-failures $(addprefix check-,$(TESTDIRS))
 

--- a/ihp-sg13g2/libs.tech/gnucap/tests/gnucap/resistor/tb_res_basic.va
+++ b/ihp-sg13g2/libs.tech/gnucap/tests/gnucap/resistor/tb_res_basic.va
@@ -12,5 +12,5 @@ module tb_res_basic();
     idc #(.dc(0.001)) Ir1(n1, gnd);
     idc #(.dc(0.001)) Ir2(n2, gnd);
     idc #(.dc(0.001)) Ir3(n3, gnd);
-    idc #(.dc(0.001)) Ir3(gnd, n4);
+    idc #(.dc(0.001)) Ir4(gnd, n4);
 endmodule

--- a/ihp-sg13g2/libs.tech/gnucap/tests/ngspice/Makefile
+++ b/ihp-sg13g2/libs.tech/gnucap/tests/ngspice/Makefile
@@ -21,24 +21,63 @@ ALL_TESTS := $(foreach f,$(ALL_TESTS), $(if $(filter $(TEST_EXCLUDE_PREFIX)%,$(n
 # Each test generates an output
 ALL_OUTS := $(foreach f, $(ALL_TESTS), $(dir $(f))check/$(notdir $(f)).out)
 
+# Pinned, because the first rule below is reset-failures and make would
+# otherwise take that as the goal: a bare `make` here would clear the
+# bookkeeping, run no test and exit 0, which is the failure this file exists to
+# stop.
+.DEFAULT_GOAL := check
+
+# Aggregate exit status.
+#
+# A test rule must not fail the build on the spot: the whole suite has to run so
+# that one invocation reports the complete PASS/FAIL set. So each test that does
+# not pass records itself here, and the aggregate targets fail afterwards. That is
+# what makes `make check` return nonzero when something regressed, so it can be
+# used as a gate rather than only read.
+# Scoped to this make invocation: two concurrent runs in the same directory would
+# otherwise share the files, and one finishing would clear the other's record,
+# which can turn a real failure into a green report.
+RUNID  := $(shell echo $$PPID)
+FAILLOG = .check-failures.$(RUNID)
+RUNLOG  = .check-ran.$(RUNID)
+
+reset-failures:
+	@rm -f $(FAILLOG) $(RUNLOG)
+
+REPORT = ran=$$(cat $(RUNLOG) 2>/dev/null | wc -l); \
+	bad=$$(cat $(FAILLOG) 2>/dev/null | wc -l); \
+	echo ""; \
+	if [ "$$bad" -gt 0 ]; then \
+	  echo "$$bad of $$ran tests did not pass:"; \
+	  sed 's/^/  /' $(FAILLOG); \
+	  rm -f $(FAILLOG) $(RUNLOG); \
+	  exit 1; \
+	fi; \
+	echo "all $$ran tests passed"; \
+	rm -f $(RUNLOG)
+
 # Default: check all tests
 check: $(ALL_OUTS)
+	@$(REPORT)
 
 # Rule: one test file *.sp generates one output file *.sp.out
 define TEST_RULE
-$(dir $(1))check/$(notdir $(1)).out: $(1)
+$(dir $(1))check/$(notdir $(1)).out: $(1) | reset-failures
 	@mkdir -p $(dir $(1))check
 	@cd "$(dir $(1))" && \
 	  $(NGSPICE) -b -o /dev/null "$(notdir $(1))" > /dev/null
+	@echo "$$(notdir $$<)" >> $(RUNLOG)
 	@if [ -f "$(dir $(1))ref/$(notdir $(1)).out" ]; then \
 	  if $(DIFF) -u "$(dir $(1))ref/$(notdir $(1)).out" "$$@" > "$$(basename $$@).diff" 2>&1; then \
 	    echo "PASS $$(notdir $$<)"; \
 	    rm -f "$$(basename $$@).diff"; \
 	  else \
 	    echo "FAIL $$(notdir $$<)"; \
+	    echo "FAIL $$(notdir $$<)" >> $(FAILLOG); \
 	  fi; \
 	else \
 	  echo "MISS $$(notdir $$<)"; \
+	  echo "MISS $$(notdir $$<)" >> $(FAILLOG); \
 	fi
 endef
 
@@ -48,11 +87,13 @@ $(foreach f, $(ALL_TESTS), $(eval $(call TEST_RULE,$(f))))
 # Rule: Make each test directory an aggregate target for its test
 define DIR_RULE
 check-$(1): $(foreach f, $(filter $(1)/%.sp, $(ALL_TESTS)), $(dir $(f))check/$(notdir $(f)).out)
+	@$$(REPORT)
 endef
 # Create one aggregate per directory in TESTDIRS using DIR_RULE
 $(foreach d, $(TESTDIRS), $(eval $(call DIR_RULE,$(d))))
 
 clean:
+	@rm -f .check-failures.* .check-ran.*
 	@for dir in $(TESTDIRS); do \
 	  rm -rf $$dir/check; \
 	done
@@ -71,4 +112,5 @@ help:
 	@echo ""
 	@echo "Total tests: $(words $(ALL_TESTS))"
 
-.PHONY: check clean $(TESTDIRS) help
+# $(TESTDIRS) are directories, not targets; the aggregates are check-<testdir>.
+.PHONY: check clean help reset-failures $(addprefix check-,$(TESTDIRS))


### PR DESCRIPTION
A handful of `libs.tech/gnucap` build and test-harness fixes, found while porting the suite to a sibling PDK where every one of them showed up again. Nothing here touches a model or a reference value; the numbers are identical before and after.

**`make check` never built anything.** `Makefile:15` reads `check: models plugins`, and neither name has a rule with a recipe. They resolve only because line 36 declares them phony, and a phony target with no recipe is a silent no-op, so `check` ran `make -C tests` and nothing else. Worth pointing out that the `.PHONY` line is the mechanism rather than a separate nit: drop it and the same Makefile fails loudly with `No rule to make target 'plugins', needed by 'check'`. The prerequisites look like they were meant to read `models-plugins gnucap-plugins`, which is what `all` already does, so `check: all` is the fix.

This is more than cosmetic on a fresh clone, where there is no `plugins/` directory at all. Every gnucap testbench opens with `load ../../../plugins/models/<model>.so` and the Monte Carlo ones also `load ../../../plugins/gnucap`, so the suite ran against plugins that were never compiled. It also made `make check` and `make -C tests check` exactly equivalent, although README.md:169 describes the first as building the plugins and README.md:176 offers the second as the way to skip that.

**The suite could not fail.** Both test Makefiles printed `FAIL` and still exited 0, so a mismatch was something you had to notice by reading the output. They now record each test that does not pass and the aggregate targets exit nonzero afterwards. The whole suite still runs to the end first, which is the reason for the two-step rather than just letting the diff fail the recipe.

`make -C tests check` also runs both halves before reporting, instead of stopping if the gnucap half fails. When something breaks, whether ngspice broke the same way is most of the diagnosis: both sides means the model or the reference data, one side means that simulator's plumbing.

The report counts what actually ran, so a single-directory run does not claim the whole suite passed, and the state it keeps is scoped to the make invocation: two concurrent runs in the same directory sharing it could have one clear the other's record, and a cleared record reads as a pass.

**Stale plugins could be validated silently.** `models/Makefile` declared no dependency on the sources each paramset reaches through `` `include ``, only on the paramset file itself, so `touch r3_cmc.va && make resistor_paramset` answered `Nothing to be done`. Combined with the `check` fix that matters: `check` now builds, and it should not build from a dependency graph that misses `r3_cmc.va`, `psp103.va`, `cap_cmomi.va` and `discipline.h`. The include graph is explicit now, with the three external model trees taken wholesale since any of their `.include` files feeds the compile and they change rarely. Carrying those dependencies means naming the generated `.cc` files as explicit targets, which on its own would stop GNU make treating them as intermediates and leave 377 MiB of generated C++ in the tree after every build, so `.INTERMEDIATE` keeps them transient.

**Smaller things in the same files:**

- `models/Makefile` built OSDI into `plugins/models` while `clean` removed it from `plugins/osdi`, so `make osdi-<model>` left a file behind that `make clean` could not reach. It now builds where `clean` looks.
- `clean` in the top Makefile ended with `rm -rf plugins/*.so`, which never matched anything: the sub-makes remove their own `.so` from `plugins/models` and `plugins/gnucap`, and nothing is ever written to `plugins/` itself.
- `help` advertised a `tests` target that does not exist, and never mentioned the real `check`. Because `.PHONY` named it, `make tests` printed `Nothing to be done for 'tests'` and exited 0, which reads as a test run that passed.
- `tests/Makefile` help offered `make -C gnucap <testdir>`; the aggregates are `check-<testdir>`, and the bare form silently does nothing. It also hardcoded the device list, which is now a pointer to `make -C gnucap help` so it cannot drift.
- README.md:96 documented `make model-plugins`; the target is `models-plugins`, so the documented command exits 2. README.md:231 pointed at `python/plot_tests.py`, which does not exist; the aggregate script is `plot_all.py`.
- `tests/gnucap/resistor/tb_res_basic.va:14-15` gave two different `idc` instances the same name `Ir3`. Renamed the second to `Ir4`. Gnucap was accepting both, so this changes nothing numerically, and the resistor family passes against the unchanged reference data before and after.
- README gained the OpenVAF step. The Ngspice testbenches load OSDI objects from `libs.tech/ngspice/osdi/`, which is a build product and gitignored, so on a fresh checkout the directory does not exist and the Ngspice half stops on its first test. Nothing said so; the Prerequisites section documented `PDK_ROOT` and `PDK` and stopped there. I hit this on a clean worktree while validating this PR, which is a reasonable proxy for a new contributor.
- `.gitignore` gained the gnucap build outputs. `*.so` was already covered, but the generated `.cc`, the `.o`, `models/*.dump.va`, `figures/` and `tests/**/check/` were not, so a run left 9 untracked paths behind. The generated C++ is transient (see `.INTERMEDIATE` above), but the plugins themselves are about 99 MB and the eight `check/` directories another 15 MB. That was easy to miss while `check` did not build; it is not now.
- Wherever there is no `plugins/` directory, `make plugins` used to exit 0 doing nothing and now fails with `No rule to make target`. That is the intended consequence of the main fix rather than a side effect, but it is a user-visible behaviour change worth calling out. The condition is the directory, not the checkout: a fresh clone is one way in, and the reworked `clean` is the other, since it now removes the empty `plugins/` tree it used to leave behind. Once the directory exists make treats it as up to date and exits 0 either way, and `make models` always did, since `models/` is tracked. Note that `make plugins` is not a documented target and never was, in this README or the old one; the name existed only as the broken `check:` prerequisite and its `.PHONY` entry, both of which this PR removes.

**Not changed, but worth knowing:** four reference files have no matching testbench, `gnucap/moslv/ref/tb_moslv_stats_mc.gc.out`, `ngspice/moslv/ref/tb_moslv_mc_stats_rf.sp.out`, `ngspice/moslv/ref/tb_moslv_nmos_stats.sp.out` and `ngspice/moshv/ref/tb_moshv_nmos_stats.sp.out`, the last of which is zero bytes. They are never read, since both Makefiles derive the reference path from the discovered testbench name rather than scanning `ref/`. Left alone here since removing checked-in reference data belongs with whoever knows why it is there.

Validation, with gnucap `resolve 2026.06.10`, gnucap-mg-vams from the same release, and ngspice-46: **94/94 PASS on both simulators**, zero FAIL, zero MISS, from a clean build through the fixed `check` path. `make check` now exits 0 because everything passed, rather than exiting 0 no matter what.

No reference file is touched by this PR, and the only content change to a testbench is the `Ir3` rename, which was checked on its own: the resistor family passes against the unchanged references both before and after it.

Two negative controls confirm the gate actually gates. Forcing a reference mismatch prints the full PASS/FAIL list and then exits nonzero. Running the gnucap half before `cpp/` is built fails and exits nonzero on exactly the tests that `load ../../../plugins/gnucap`: 4 of the 14 `.va` testbenches carry that line, which is 32 of the 94 `.gc` tests. I observed it first on the resistor family alone, where it is 4 of 7. That is the pre-existing failure mode this PR is meant to stop hiding.

The same changes are running in ihp-sg13cmos5l#74, which ports this suite to that PDK, so they have a second set of miles on them.

