### PR TITLE
drc(testing): pair regression markers with the rule that wrote them

### DIFF
--- a/ihp-sg13g2/libs.tech/klayout/tech/drc/testing/run_regression.py
+++ b/ihp-sg13g2/libs.tech/klayout/tech/drc/testing/run_regression.py
@@ -450,7 +450,7 @@ def run_test_case(
         if len(pattern_results) > 0:
             # db to gds conversion
             marker_output, runset_analysis = convert_results_db_to_gds(
-                pattern_results[0], rules_tested
+                pattern_results[0], rules_tested, layout_path
             )
 
             # Generating merged testcase for violated rules
@@ -833,7 +833,72 @@ def draw_polygons(polygon_data, cell, lay_num, lay_dt, path_width):
         logging.error(f"# Unknown type: {tag} ignored")
 
 
-def convert_results_db_to_gds(results_database: str, rules_tested: list):
+def check_golden_marker_coverage(golden_layout, rule_data_type_map: list):
+    """
+    Warns when a golden fixture was generated against a different rule set.
+
+    A rule is identified by its position in the marker datatype, and that
+    position is assigned by first appearance among the rules that actually
+    violate. Nothing in the fixture records which rule owns which datatype, so
+    a golden whose datatypes do not match the ones this run reads was generated
+    against a deck that has since changed.
+
+    This only catches a change in the set of datatypes. A deck that swaps one
+    rule for another in the same position, or reorders two of them, leaves the
+    set identical and is invisible here; keeping a fixture honest still needs it
+    regenerated whenever the deck's rule set moves.
+
+    Parameters
+    ----------
+    golden_layout : str or Path
+        Path to the golden testcase the run was performed on.
+    rule_data_type_map : list of str
+        Rules that violated in this run, in the order they were assigned
+        datatypes.
+    """
+    if golden_layout is None or not Path(golden_layout).is_file():
+        return
+
+    golden = klayout.db.Layout()
+    golden.read(str(golden_layout))
+    golden_dts = {
+        golden.get_info(li).datatype
+        for li in golden.layer_indexes()
+        if golden.get_info(li).layer == GOLDEN_LAY_NUM
+    }
+
+    # The analysis runset reads exactly datatypes 1..N, so comparing the two sets
+    # rather than their sizes also catches a 0-based or non-contiguous fixture.
+    expected = set(range(1, len(rule_data_type_map) + 1))
+    if golden_dts == expected:
+        return
+
+    unread = sorted(golden_dts - expected)
+    missing = sorted(expected - golden_dts)
+    detail = []
+    if unread:
+        detail.append(
+            f"datatypes {unread} sit outside the range this run reads, so those markers are never compared"
+        )
+    if missing:
+        detail.append(
+            f"datatypes {missing} are read but absent from the fixture, so every violation of the rule in "
+            "each of those positions lands in viol_not_golden whether or not it is a real failure"
+        )
+    logging.warning(
+        f"{Path(golden_layout).name} carries markers on layer {GOLDEN_LAY_NUM} for datatypes "
+        f"{sorted(golden_dts)}, while this run produced {len(rule_data_type_map)} violating rules "
+        f"({', '.join(rule_data_type_map)}) and reads datatypes {sorted(expected)}: "
+        f"{'; '.join(detail)}. A rule is identified only by its position, so this check "
+        "cannot see a fixture whose rules were reordered or substituted without changing the count, and "
+        "a matching count is not on its own evidence that the pairing is right. Regenerate the fixture "
+        "with gen_golden.py."
+    )
+
+
+def convert_results_db_to_gds(
+    results_database: str, rules_tested: list, golden_layout=None
+):
     """
     Parses a KLayout .lyrdb result file and generates:
     - A GDSII file with polygons drawn for violated rules.
@@ -845,6 +910,9 @@ def convert_results_db_to_gds(results_database: str, rules_tested: list):
         Path to the KLayout results .lyrdb file.
     rules_tested : list of str
         List of rule names expected to be tested in this run.
+    golden_layout : str or Path, optional
+        Golden testcase the run was performed on, used to check that its
+        markers can still be paired with this run.
 
     Returns
     -------
@@ -922,23 +990,29 @@ full_chip = extent.sized(0.0)
 
     lib.write_gds(output_gds_path)
 
-    # Generate marker inputs and analysis
-    sorted_rules = sorted(rule_data_type_map)
-    rule_layer_map = {rule: idx + 1 for idx, rule in enumerate(sorted_rules)}
-    all_rules = set(sorted_rules) | set(rules_tested)
+    # Generate marker inputs and analysis.
+    # The datatype that identifies a rule is assigned above by first appearance
+    # in the results database, so it has to be read back the same way. Sorting
+    # here instead would pair each marker with whichever rule name happens to
+    # sort into that position.
+    rule_layer_map = {rule: idx + 1 for idx, rule in enumerate(rule_data_type_map)}
+    check_golden_marker_coverage(golden_layout, rule_data_type_map)
+    all_rules = set(rule_data_type_map) | set(rules_tested)
 
     for rule in all_rules:
         lay_dt = rule_layer_map.get(rule)
-        if lay_dt:
-            golden_marker = f"rule_{rule.replace('.', '_')}_golden"
-            viol_marker = f"rule_{rule.replace('.', '_')}_viol"
-            analysis_rules.append(
-                f"{golden_marker} = input({GOLDEN_LAY_NUM}, {lay_dt})\n"
-            )
-            analysis_rules.append(f"{viol_marker} = input({VIOL_LAY_NUM}, {lay_dt})\n")
+        if lay_dt is None:
+            # The rule is expected by the testcase but produced no violations in
+            # this run, so it has no marker layer to compare against.
+            continue
+
+        golden_marker = f"rule_{rule.replace('.', '_')}_golden"
+        viol_marker = f"rule_{rule.replace('.', '_')}_viol"
+        analysis_rules.append(f"{golden_marker} = input({GOLDEN_LAY_NUM}, {lay_dt})\n")
+        analysis_rules.append(f"{viol_marker} = input({VIOL_LAY_NUM}, {lay_dt})\n")
 
         # Output checks if not both golden and tested
-        if not (rule in sorted_rules and rule in rules_tested):
+        if not (rule in rule_data_type_map and rule in rules_tested):
             for tag, src, ref in [
                 ("viol_not_golden", viol_marker, golden_marker),
                 ("golden_not_viol", golden_marker, viol_marker),


### PR DESCRIPTION
Closes #1079.

The DRC regression encodes the rule that owns a marker as a GDS datatype, and it writes that datatype with one ordering and reads it back with another. `convert_results_db_to_gds` assigns it by first appearance in the results database, which is deck order, and then rebuilt the map with `sorted()` to generate the analysis runset. The two agree only when deck order happens to be alphabetical.

It reproduces on `dev` today, no local changes needed:

```
$ python3 libs.tech/klayout/tech/drc/testing/run_regression.py --table_name=activfiller
```

First-appearance order in the results database, which is what the markers were drawn with:

```
1 AFil.c1   2 AFil.c   3 AFil.d   4 AFil.e   5 AFil.j
```

Generated `*_analysis.drc` before this change, which is what the counts are attributed to:

```
rule_AFil_c_viol  = input(333, 1)
rule_AFil_c1_viol = input(333, 2)
```

AFil.c1's markers are read as AFil.c and the two rows are swapped. It is harmless there only because both are 0/0. Any failure that goes through this path names a rule that may be entirely clean while the real difference belongs to another one. It surfaced in ihp-sg13cmos5l, where the deck diverges more from the fixtures: `AFil.j` reports fp=6/fn=2 in the slot `AFil.e` vacated, and four antenna rows name rules that are clean while the actual deltas belong to the `TopMetal1`/`TopVia1` rules that replaced the Metal5/Via4 ones there. The mechanism is in the shared harness, not in that PDK.

The map is now built once and used for both. Two related things fall out of it.

When a rule appears in the testcase coverage but produced no violations it has no datatype, and the loop fell through to the output checks with `golden_marker` and `viol_marker` still holding the previous iteration's rule, so the checks would have been emitted against another rule's layers. That branch is now skipped. It never actually triggered: `get_unit_test_coverage` reads rule names from text labels on layer 11/222, `build_tests_dataframe` selects only `unit_golden/` plus `unit/density`, and none of the 41 fixtures there carries any such label, so `rules_tested` is empty everywhere and every rule in `all_rules` had a datatype. Worth removing anyway since it is the same positional assumption.

The deeper half is that nothing ties datatype *i* in a golden generated months ago to datatype *i* in today's run. First-appearance order depends on which rules actually violate, so a rule leaving the deck shifts every datatype behind it. `check_golden_marker_coverage` compares the datatypes a fixture carries against the ones the analysis runset actually reads, which are 1..N for the N rules that violated. Comparing the sets rather than their sizes covers both directions: markers the run will never look at, and datatypes it reads that the fixture does not carry, where every violation of the rule in that position is counted as a false positive. It also catches a 0-based or non-contiguous fixture, which a size comparison misses.

What it cannot see is a fixture whose rules were substituted or reordered without changing the count, and the warning says so rather than implying a matching count means the pairing is right. That case is real: in ihp-sg13cmos5l the antenna fixture encoded 23 rules and the run produced 23, guard silent, while four of them had been replaced by different rules in the same positions.

On `dev` it fires exactly once:

```
WARNING | nwell_golden.gds carries markers on layer 222 for datatypes [1, 2, 3, 4, 5, 6, 7,
8, 9], while this run produced 4 violating rules (NW.b, NW.b1, NW.f1, NW.f1.digibnd) and reads
datatypes [1, 2, 3, 4]: datatypes [5, 6, 7, 8, 9] sit outside the range this run reads, so those
markers are never compared. A rule is identified only by its position, so this check cannot see
a fixture whose rules were reordered or substituted without changing the count, and a matching
count is not on its own evidence that the pairing is right. Regenerate the fixture with
gen_golden.py.
```

That one is benign, and worth stating so the warning is not read as a new failure. `5_1_nwell.drc` emits exactly those four rules in that order, and the marker areas on datatypes 1 through 4 (0.0613, 20.0126, 0.0213 and 0.0170 um2) match what regenerating the fixture produces, so the surviving rules kept their positions and the five orphaned datatypes are simply never read. Regenerating `nwell_golden.gds` would clear it, but that is a fixture change and does not belong in this PR, so merging this puts a standing warning on every otherwise green run until that fixture is regenerated.

`make test-DRC-main` before and after: 262 rules passed, 0 failed, identical. `flake8` clean on the changed file (the three findings in `run_regression_cells.py` are pre-existing on `dev`).

A note on what this does not do. A sidecar mapping rule names to datatypes next to each golden would remove the positional encoding entirely, and it is the right end state. It turned out more invasive than it looks: `clean_run_dir` deletes everything in the run directory that does not match `*_golden.gds`, and `_move_and_rename_golden_files` rewrites the golden's name, so both would need to learn about the companion file, and every existing fixture would need regenerating or a fallback path to stay readable. Left for a follow-up so the correctness fix here stays reviewable on its own.

