### PR TITLE
Align poly resistor rhigh corner and global statistical parameter to process specification

### DIFF
--- a/ihp-sg13g2/libs.tech/ngspice/models/cornerRES.lib
+++ b/ihp-sg13g2/libs.tech/ngspice/models/cornerRES.lib
@@ -29,9 +29,9 @@
   .param dw_rsil   = 0.0
   .param dl_rppd   = 0.0
   .param dw_rppd   = 0.0
-  .param dw_rsil_par  =  0.01e-6
-  .param dw_rppd_par  =  0.006e-6
-  .param dw_rhigh_par = -0.04e-6
+  .param dw_rsil_par  =  0.0
+  .param dw_rppd_par  =  0.0
+  .param dw_rhigh_par =  0.0
 
 .include resistors_mod.lib
 .ENDL res_typ
@@ -50,9 +50,9 @@
   .param dw_rsil   = 0.0
   .param dl_rppd   = 0.0
   .param dw_rppd   = 0.0
-  .param dw_rsil_par  =  0.01e-6
-  .param dw_rppd_par  =  0.006e-6
-  .param dw_rhigh_par = -0.04e-6
+  .param dw_rsil_par  =  0.0
+  .param dw_rppd_par  =  0.0
+  .param dw_rhigh_par =  0.0
   .param nsig_rsil_rsh=0  ; global number of standard deviations for rsh
   .param nsig_rsil_w=0    ; global number of standard deviations for w
   .param nsig_rsil_l=0    ; global number of standard deviations for l
@@ -80,9 +80,9 @@
   .param rsh_rhigh = 1360
   .param rsh_rppd  = 260.0
   .param rsh_rsil  = 7.0
-  .param dw_rsil_par  =  0.01e-6
-  .param dw_rppd_par  =  0.006e-6
-  .param dw_rhigh_par = -0.04e-6
+  .param dw_rsil_par  =  0.0
+  .param dw_rppd_par  =  0.0
+  .param dw_rhigh_par =  0.0
 
 .include resistors_stat.lib
 .include resistors_mod.lib
@@ -90,7 +90,7 @@
 
 * Best Case
 .LIB res_bcs
-  .param rsh_rhigh = 1020
+  .param rsh_rhigh = 1160
   .param rsh_rppd  = 234.0
   .param rsh_rsil  = 6.02
   .param drsh_rhigh = 0.0
@@ -102,16 +102,16 @@
   .param dw_rsil   = 0.0
   .param dl_rppd   = 0.0
   .param dw_rppd   = 0.0
-  .param dw_rsil_par  = 0.04e-6
-  .param dw_rppd_par  = 0.036e-6
-  .param dw_rhigh_par = 0.0
+  .param dw_rsil_par  = 0.03e-6
+  .param dw_rppd_par  = 0.03e-6
+  .param dw_rhigh_par = 0.04e-6
 
 .include resistors_mod.lib
 .ENDL res_bcs
 
 * Best Case with mismatch modeling
 .LIB res_bcs_mismatch
-  .param rsh_rhigh = 1020
+  .param rsh_rhigh = 1160
   .param rsh_rppd  = 234.0
   .param rsh_rsil  = 6.02
   .param drsh_rhigh = 0.0
@@ -123,9 +123,9 @@
   .param dw_rsil   = 0.0
   .param dl_rppd   = 0.0
   .param dw_rppd   = 0.0
-  .param dw_rsil_par  = 0.04e-6
-  .param dw_rppd_par  = 0.036e-6
-  .param dw_rhigh_par = 0.0
+  .param dw_rsil_par  = 0.03e-6
+  .param dw_rppd_par  = 0.03e-6
+  .param dw_rhigh_par = 0.04e-6
   .param nsig_rsil_rsh=0  ; global number of standard deviations for rsh
   .param nsig_rsil_w=0    ; global number of standard deviations for w
   .param nsig_rsil_l=0    ; global number of standard deviations for l
@@ -150,7 +150,7 @@
 
 * Worst Case
 .LIB res_wcs
-  .param rsh_rhigh = 1700
+  .param rsh_rhigh = 1560
   .param rsh_rppd  = 286.0
   .param rsh_rsil  = 7.98
   .param drsh_rhigh = 0.0
@@ -162,16 +162,16 @@
   .param dw_rsil   = 0.0
   .param dl_rppd   = 0.0
   .param dw_rppd   = 0.0
-  .param dw_rsil_par  = -0.02e-6
-  .param dw_rppd_par  = -0.024e-6
-  .param dw_rhigh_par = -0.08e-6
+  .param dw_rsil_par  = -0.03e-6
+  .param dw_rppd_par  = -0.03e-6
+  .param dw_rhigh_par = -0.04e-6
 
 .include resistors_mod.lib
 .ENDL res_wcs
 
 * Worst Case with mismatch modeling
 .LIB res_wcs_mismatch
-  .param rsh_rhigh = 1700
+  .param rsh_rhigh = 1560
   .param rsh_rppd  = 286.0
   .param rsh_rsil  = 7.98
   .param drsh_rhigh = 0.0
@@ -183,9 +183,9 @@
   .param dw_rsil   = 0.0
   .param dl_rppd   = 0.0
   .param dw_rppd   = 0.0
-  .param dw_rsil_par  = -0.02e-6
-  .param dw_rppd_par  = -0.024e-6
-  .param dw_rhigh_par = -0.08e-6
+  .param dw_rsil_par  = -0.03e-6
+  .param dw_rppd_par  = -0.03e-6
+  .param dw_rhigh_par = -0.04e-6
   .param nsig_rsil_rsh=0  ; global number of standard deviations for rsh
   .param nsig_rsil_w=0    ; global number of standard deviations for w
   .param nsig_rsil_l=0    ; global number of standard deviations for l
@@ -213,9 +213,9 @@
   .param rsh_rhigh = 1360
   .param rsh_rppd  = 260.0
   .param rsh_rsil  = 7.0
-  .param dw_rsil_par  =  0.01e-6
-  .param dw_rppd_par  =  0.006e-6
-  .param dw_rhigh_par = -0.04e-6
+  .param dw_rsil_par  =  0.0
+  .param dw_rppd_par  =  0.0
+  .param dw_rhigh_par =  0.0
   .param nsig_rsil_rsh='agauss(0, 1, 1)'  ; global number of standard deviations for rsh
   .param nsig_rsil_w='agauss(0, 1, 1)'    ; global number of standard deviations for w
   .param nsig_rsil_l='agauss(0, 1, 1)'    ; global number of standard deviations for l

--- a/ihp-sg13g2/libs.tech/ngspice/models/resistors_stat.lib
+++ b/ihp-sg13g2/libs.tech/ngspice/models/resistors_stat.lib
@@ -21,10 +21,10 @@
 * ngspice global statistical parameters
 .param drsh_rsil  = 4.67 ; % of 1 Sigma
 .param drsh_rppd  = 3.3  ; % of 1 Sigma
-.param drsh_rhigh = 8.33 ; % of 1 Sigma
+.param drsh_rhigh = 5.1  ; % of 1 Sigma
 .param dl_rsil   = 0.01  ; um of 1 Sigma
 .param dw_rsil   = 0.01  ; um of 1 Sigma
 .param dl_rppd   = 0.01  ; um of 1 Sigma
 .param dw_rppd   = 0.01  ; um of 1 Sigma
-.param dl_rhigh  = 0.015 ; um of 1 Sigma
-.param dw_rhigh  = 0.015 ; um of 1 Sigma
+.param dl_rhigh  = 0.02  ; um of 1 Sigma
+.param dw_rhigh  = 0.02  ; um of 1 Sigma


### PR DESCRIPTION
This PR is an update of the ngspice library for the poly resistors. It should solve the issues #1062 and #1063.

The Update contains:

- Double application of dW is removed for all three poly resistors
- Min / Target / Max values for rhigh are now 1160 / 1360 / 1560 as in document libs.doc/doc/SG13CMOS5L_os_process_spec.pdf
- Global 1 Sigma values are adapted accordingly

This document gives an overview about the actual status of corner, global and local variations for all 3 poly resistors:
[res_update_070826.pdf](https://github.com/user-attachments/files/30823901/res_update_070826.pdf)
