### PR TITLE
fix moscap callback issue

### DIFF
--- a/ihp-sg13g2/libs.tech/klayout/python/sg13g2_pycell_lib/callbacks/callbacks.json
+++ b/ihp-sg13g2/libs.tech/klayout/python/sg13g2_pycell_lib/callbacks/callbacks.json
@@ -36,12 +36,12 @@
                 "callbacks": [
                     {
                         "callback": "CbMoscap_wl",
-                        "pcellParameters": ["w", "l"]
+                        "pcellParameters": ["w", "l"],
+                        "usePcellParameterAsArgument": "true"
                     }
                 ]
             },
             {
-                "devices": ["cmim"],
                 "devices": ["cmim", "rfcmim"],
                 "callbacks": [
                     {


### PR DESCRIPTION
Fixes #1083 

- added `usePcellParameterAsArgument` for moscap
- removed extra `cmim `declaration
