### PR TITLE
sg13g2_tests: bind `pycell_test.py` layout to the sg13g2 technology

### DIFF
--- a/ihp-sg13g2/libs.tech/klayout/sg13g2_tests/pycell_test.py
+++ b/ihp-sg13g2/libs.tech/klayout/sg13g2_tests/pycell_test.py
@@ -26,6 +26,9 @@
 # KLAYOUT_PATH=$(pwd)/.. klayout ihp-pycells.gds -e
 
 layout = pya.Layout()
+# The SG13_dev library is bound to the sg13g2 technology; the layout must
+# use the same technology for the library lookup to succeed (KLayout >= 0.28)
+layout.technology_name = "sg13g2"
 pcellNmos = layout.create_cell("nmos", "SG13_dev", { "l": 0.350e-6, "w": 6e-6, "ng": 3 })
 pcellPmos = layout.create_cell("pmos", "SG13_dev", { "l": 0.350e-6, "w": 6e-6, "ng": 3 })
 pcellCmim = layout.create_cell("cmim", "SG13_dev", {})


### PR DESCRIPTION
`pycell_test.py` creates its layout with a plain `pya.Layout()`. Since the `SG13_dev` pycell library is registered bound to the `sg13g2` technology (`self.technology = SG13_Tech.TECH_NAME` in `sg13g2_pycell_lib/__init__.py`), a layout without a technology cannot see the library on KLayout >= 0.28: every `layout.create_cell(...)` silently returns `nil`, and the test crashes at the first `top.insert(...)` with
```
ERROR: RuntimeError: Internal error: gsiDeclDbCell.cc:159 cell != 0 was not true in DCellInstArray.__init__
```
## Fix

Bind the layout to the technology before creating cells:

```python
layout = pya.Layout()
layout.technology_name = "sg13g2"
```

The same fix was applied to the CMOS5L PDK test in IHP-GmbH/ihp-sg13cmos5l#95 (there with `technology_name = "sg13cmos5l"`).

## Verification

Ran in IIC-OSIC-TOOLS (KLayout 0.30): without the fix the test crashes as above; with the fix it runs through all devices and writes `SG13_dev.gds`.

Note: with the test now actually running, the Tcl callback machinery logs a pre-existing, unrelated error for two cells (`ValueError: could not convert string to float: '6.0u'` in `coerce_parameters`, pycell4klayout-api `dlo.py:366`). Fixed in https://github.com/IHP-GmbH/pycell4klayout-api/pull/10.

