### PR TITLE
librelane: point PAD_SPICE_MODELS at sg13g2_io.spice

### DIFF
--- a/ihp-sg13g2/libs.ref/sg13g2_io/doc/README.md
+++ b/ihp-sg13g2/libs.ref/sg13g2_io/doc/README.md
@@ -5,7 +5,7 @@ This is the sg13g2_io library. The following files are included in this library:
   * `InputPerformance.html`: simulation results for input bandwidth and duty ratio.
   * `DriveStrengthSim.html`: simulation of drive strength of the output drivers.
 * `gds/sg13g2_io.gds`: GDS view of the IO cells
-* `spice/sg13g2_io.spi`: spice netlists of the IO cells
+* `spice/sg13g2_io.spice`: spice netlists of the IO cells
 * `lef/sg13g2_io.lef`: LEF view of the IO cells
 * `lib/sg13g2_io_dummy.lib`: dummy liberty view of the IO cells.  
   This file only contains enough information to get the OpenROAD flow going; no timing

--- a/ihp-sg13g2/libs.tech/librelane/config.tcl
+++ b/ihp-sg13g2/libs.tech/librelane/config.tcl
@@ -77,7 +77,7 @@ set ::env(CELL_CDLS) "$::env(PDK_ROOT)/$::env(PDK)/libs.ref/$::env(STD_CELL_LIBR
 set ::env(PAD_LEFS) "$::env(PDK_ROOT)/$::env(PDK)/libs.ref/sg13g2_io/lef/sg13g2_io.lef"
 set ::env(PAD_GDS) "$::env(PDK_ROOT)/$::env(PDK)/libs.ref/sg13g2_io/gds/sg13g2_io.gds"
 set ::env(PAD_VERILOG_MODELS) "$::env(PDK_ROOT)/$::env(PDK)/libs.ref/sg13g2_io/verilog/sg13g2_io.v"
-set ::env(PAD_SPICE_MODELS) "$::env(PDK_ROOT)/$::env(PDK)/libs.ref/sg13g2_io/spice/sg13g2_io.spi"
+set ::env(PAD_SPICE_MODELS) "$::env(PDK_ROOT)/$::env(PDK)/libs.ref/sg13g2_io/spice/sg13g2_io.spice"
 set ::env(PAD_CDLS) "$::env(PDK_ROOT)/$::env(PDK)/libs.ref/sg13g2_io/cdl/sg13g2_io.cdl"
 
 ## magic setup


### PR DESCRIPTION
Fixes #1094.

No LibreLane flow currently starts on `dev`. `libs.tech/librelane/config.tcl` still points `PAD_SPICE_MODELS` at `libs.ref/sg13g2_io/spice/sg13g2_io.spi`, which `1a29eb49` removed when `877a33db` added `sg13g2_io.spice` in its place. LibreLane validates PDK paths before it loads any design configuration, so it quits before running a single step, whatever the design or flow.

One character on that line, plus the same name in the I/O README, which describes the file and had the old extension too.

Checked on `2787d209` with librelane 3.0.0.dev47: before, a bare flip-flop design fails at PDK config load; after, a full Chip flow on a 1600x1600 padded die runs to the end and signs off with zero KLayout DRC violations, with seal ring, filler and density all executing.