### PR TITLE
fixed qucs-s stdcell link to relative

### DIFF
--- a/ihp-sg13g2/libs.tech/qucs-s/symbols_stdcell
+++ b/ihp-sg13g2/libs.tech/qucs-s/symbols_stdcell
@@ -1,1 +1,1 @@
-/home/rahman/temp/IHP-Open-PDK/ihp-sg13g2/libs.ref/sg13g2_stdcell/sym/qucs-s
+../../libs.ref/sg13g2_stdcell/sym/qucs-s


### PR DESCRIPTION
HOTFIX: absolute symbolic link for qucs-s stdcell symbols: make it relative.
