### PR TITLE
ngspice: fix sg13_hv_svaricap hot-temperature transient failure (dsubw TLEVC)

### DIFF
--- a/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_svaricaphv_mod.lib
+++ b/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_svaricaphv_mod.lib
@@ -79,7 +79,7 @@ nmvcap2 G2 bi2 W0 sg13_hv_svaricap l = l w = w m = 'Nx*Ny' dta = trise
 rww   W  W0 r = '((((rwell0+(rwellvw*(v(2, 4))))+((rwellw+(rwellwvw*(v(2, 4))))*w))+(((rwellnx+(rwellnxvw*(v(2, 4))))*w)/(Nx*Ny)))*Nx)*Ny'
 dsubw W1  W dsubw off area = '(((Nx*0.38u)+(Nx*l))+1.11u)*(Ny*(w+0.97u))' pj = '2*((((Nx*0.38u)+(Nx*l))+1.11u)+(Ny*(w+0.97u)))'
 rsubw W1 bn r = '(rsubw0/(sqrt(pow(Nx, rsubwexp))))/(w+rsubwf)'
-.model dsubw d is = 2.45E-17 jsw = 5.959E-10 n = 4 ns = 1.029 cjo = 1.444E-15 vj = 0.1 m = 0.1052 cjp = 1.117E-09 php = 0.457 mjsw = 0.2595 fc = 0.95 cta = 1E-06
+.model dsubw d is = 2.45E-17 jsw = 5.959E-10 n = 4 ns = 1.029 cjo = 1.444E-15 vj = 0.1 m = 0.1052 cjp = 1.117E-09 php = 0.457 mjsw = 0.2595 fc = 0.95 cta = 1E-06 tlevc = 1
 
 * --------- Coupling G1 G2 capacitance with serial resistor ---------
 ck_g12 G1 G2a c = '(((ck0+(ckw*w))+((ckwnx*w)/(Nx*Ny)))*Nx)*Ny'

--- a/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_svaricaphv_mod_mismatch.lib
+++ b/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_svaricaphv_mod_mismatch.lib
@@ -83,7 +83,7 @@ nmvcap2 G2 bi2 W0 sg13_hv_svaricap m = 'Nx*Ny' dta = trise
 rww   W  W0 r = '((((rwell0+(rwellvw*(v(2, 4))))+((rwellw+(rwellwvw*(v(2, 4))))*w))+(((rwellnx+(rwellnxvw*(v(2, 4))))*w)/(Nx*Ny)))*Nx)*Ny'
 dsubw W1  W dsubw off area = '(((Nx*0.38u)+(Nx*l))+1.11u)*(Ny*(w+0.97u))' pj = '2*((((Nx*0.38u)+(Nx*l))+1.11u)+(Ny*(w+0.97u)))'
 rsubw W1 bn r = '(rsubw0/(sqrt(pow(Nx, rsubwexp))))/(w+rsubwf)'
-.model dsubw d is = 2.45E-17 jsw = 5.959E-10 n = 4 ns = 1.029 cjo = 1.444E-15 vj = 0.1 m = 0.1052 cjp = 1.117E-09 php = 0.457 mjsw = 0.2595 fc = 0.95 cta = 1E-06
+.model dsubw d is = 2.45E-17 jsw = 5.959E-10 n = 4 ns = 1.029 cjo = 1.444E-15 vj = 0.1 m = 0.1052 cjp = 1.117E-09 php = 0.457 mjsw = 0.2595 fc = 0.95 cta = 1E-06 tlevc = 1
 
 * --------- Coupling G1 G2 capacitance with serial resistor ---------
 ck_g12 G1 G2a c = '(((ck0+(ckw*w))+((ckwnx*w)/(Nx*Ny)))*Nx)*Ny'


### PR DESCRIPTION
Fixes #1098 (sg13_hv_svaricap hot-temperature transient failure).

**What**: adds `tlevc = 1` to the `dsubw` substrate-diode model cards in `sg13g2_svaricaphv_mod.lib` and `sg13g2_svaricaphv_mod_mismatch.lib` (one token per file, no other changes).

**Why**: the cards specify `vj = 0.1` and `cta = 1e-6` but leave `TLEVC` at ngspice's default 0. The default diode temperature equation drives a junction potential this small through zero at 52.46980 °C; beyond that, the transient depletion-charge expression evaluates `log(1 - vd/VJ(T))` with a negative argument for any positive well-to-substrate bias, and every transient containing the device aborts at its first timepoint ("Timestep too small ... trouble with ...dsubw"). The equation predicts the measured pass/fail edges to five significant figures: temperature edge 52.46980 °C, and at 60 °C a control-bias edge of 29.7394 mV (= computed |VJ(60 °C)|).

`TLEVC=1` keeps the specified junction potential positive (`TPB` defaults to 0) and activates the already-present `cta` coefficient — selecting a defined temperature mode rather than adding an arbitrary numerical floor.

**Validation** (ngspice-46, one-device transient testcase from the linked issue):

| Check | Unpatched | Patched |
|---|---|---|
| 60 °C / 0.3 V transient, 20 ns | fails at first timepoint | completes |
| 85 °C / 0.9 V transient, 20 ns | fails at first timepoint | completes |
| 125 °C / 0.3 V transient, 20 ns | fails at first timepoint | completes |
| 27 °C small-signal C–V, 6 gate biases (−3…+3 V) | — | byte-identical to unpatched (0 F difference at 17-digit precision) |

The 27 °C invariance is expected: both temperature modes reduce to the specified `vj`/`cjo` at the reference temperature, so nominal-temperature results are untouched. Away from 27 °C the fix intentionally changes the `dsubw` depletion-capacitance temperature law from the (previously non-evaluable) default mode to the linear `cta` law — please confirm this matches the intended device characterization.

No Verilog-A / OSDI change is involved; `mosvar.va` is not the failing element.
