### PR TITLE
Bring svaricap nwell-psub diode vj parameter in size to allow 125degC…

### DIFF
--- a/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_svaricaphv_mod.lib
+++ b/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_svaricaphv_mod.lib
@@ -79,7 +79,7 @@ nmvcap2 G2 bi2 W0 sg13_hv_svaricap l = l w = w m = 'Nx*Ny' dta = trise
 rww   W  W0 r = '((((rwell0+(rwellvw*(v(2, 4))))+((rwellw+(rwellwvw*(v(2, 4))))*w))+(((rwellnx+(rwellnxvw*(v(2, 4))))*w)/(Nx*Ny)))*Nx)*Ny'
 dsubw W1  W dsubw off area = '(((Nx*0.38u)+(Nx*l))+1.11u)*(Ny*(w+0.97u))' pj = '2*((((Nx*0.38u)+(Nx*l))+1.11u)+(Ny*(w+0.97u)))'
 rsubw W1 bn r = '(rsubw0/(sqrt(pow(Nx, rsubwexp))))/(w+rsubwf)'
-.model dsubw d is = 2.45E-17 jsw = 5.959E-10 n = 4 ns = 1.029 cjo = 1.444E-15 vj = 0.1 m = 0.1052 cjp = 1.117E-09 php = 0.457 mjsw = 0.2595 fc = 0.95 cta = 1E-06
+.model dsubw d is = 2.45E-17 jsw = 5.959E-10 n = 4 ns = 1.029 cjo = 1.444E-15 vj = 0.3357 m = 0.1052 cjp = 1.117E-09 php = 0.457 mjsw = 0.2595 fc = 0.95 cta = 1E-06
 
 * --------- Coupling G1 G2 capacitance with serial resistor ---------
 ck_g12 G1 G2a c = '(((ck0+(ckw*w))+((ckwnx*w)/(Nx*Ny)))*Nx)*Ny'

--- a/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_svaricaphv_mod_mismatch.lib
+++ b/ihp-sg13g2/libs.tech/ngspice/models/sg13g2_svaricaphv_mod_mismatch.lib
@@ -83,7 +83,7 @@ nmvcap2 G2 bi2 W0 sg13_hv_svaricap m = 'Nx*Ny' dta = trise
 rww   W  W0 r = '((((rwell0+(rwellvw*(v(2, 4))))+((rwellw+(rwellwvw*(v(2, 4))))*w))+(((rwellnx+(rwellnxvw*(v(2, 4))))*w)/(Nx*Ny)))*Nx)*Ny'
 dsubw W1  W dsubw off area = '(((Nx*0.38u)+(Nx*l))+1.11u)*(Ny*(w+0.97u))' pj = '2*((((Nx*0.38u)+(Nx*l))+1.11u)+(Ny*(w+0.97u)))'
 rsubw W1 bn r = '(rsubw0/(sqrt(pow(Nx, rsubwexp))))/(w+rsubwf)'
-.model dsubw d is = 2.45E-17 jsw = 5.959E-10 n = 4 ns = 1.029 cjo = 1.444E-15 vj = 0.1 m = 0.1052 cjp = 1.117E-09 php = 0.457 mjsw = 0.2595 fc = 0.95 cta = 1E-06
+.model dsubw d is = 2.45E-17 jsw = 5.959E-10 n = 4 ns = 1.029 cjo = 1.444E-15 vj = 0.3357 m = 0.1052 cjp = 1.117E-09 php = 0.457 mjsw = 0.2595 fc = 0.95 cta = 1E-06
 
 * --------- Coupling G1 G2 capacitance with serial resistor ---------
 ck_g12 G1 G2a c = '(((ck0+(ckw*w))+((ckwnx*w)/(Nx*Ny)))*Nx)*Ny'


### PR DESCRIPTION
This PR fixes the problem shown #1098. It sets only the model parameter vj of the nwell-psub diode to a more reasonable value. BTW, it is same value as used in other models which are using same junction, e.g. isolbox.
This fix allows transient simulation up to the max. specified range 125°C. See my comments in #1099 