### PR TITLE
IHP LVS rule deck: Honor PURGE conditional in rfmos_model_mapping.lvs

### DIFF
--- a/ihp-sg13g2/libs.tech/klayout/tech/lvs/rule_decks/rfmos_model_mapping.lvs
+++ b/ihp-sg13g2/libs.tech/klayout/tech/lvs/rule_decks/rfmos_model_mapping.lvs
@@ -115,11 +115,6 @@ apply_rfmos_model_mapping = lambda do |target_netlist, label|
 
     devices_to_remove.each { |device| circuit.remove_device(device) }
   end
-
-  if PURGE
-    target_netlist.purge_devices
-    target_netlist.purge
-  end
 end
 
 # Apply mapping on layout side before align/compare.

--- a/ihp-sg13g2/libs.tech/klayout/tech/lvs/rule_decks/rfmos_model_mapping.lvs
+++ b/ihp-sg13g2/libs.tech/klayout/tech/lvs/rule_decks/rfmos_model_mapping.lvs
@@ -116,8 +116,10 @@ apply_rfmos_model_mapping = lambda do |target_netlist, label|
     devices_to_remove.each { |device| circuit.remove_device(device) }
   end
 
-  target_netlist.purge_devices
-  target_netlist.purge
+  if PURGE
+    target_netlist.purge_devices
+    target_netlist.purge
+  end
 end
 
 # Apply mapping on layout side before align/compare.

--- a/ihp-sg13g2/libs.tech/klayout/tech/lvs/run_lvs.py
+++ b/ihp-sg13g2/libs.tech/klayout/tech/lvs/run_lvs.py
@@ -1,3 +1,5 @@
+#! /usr/bin/env python3
+
 # ==========================================================================
 # Copyright 2024 IHP PDK Authors
 #
@@ -531,6 +533,7 @@ def generate_klayout_switches(
         "disable_tap_extraction": "true" if args.disable_tap_extraction else "false",
         "purge": "true" if args.purge else "false",
         "purge_nets": "true" if args.purge_nets else "false",
+        "purge_devices": "true" if args.purge_devices else "false",
         "topcell": get_run_top_cell_name(args, layout_path),
         "input": os.path.abspath(layout_path),
         "schematic": os.path.abspath(netlist_path) if netlist_path else None,
@@ -779,7 +782,7 @@ if __name__ == "__main__":
                [--no_net_names] [--spice_comments] [--net_only] [--no_simplify]
                [--no_series_res] [--no_parallel_res] [--combine_devices] [--top_lvl_pins]
                [--disable_tap_extraction]
-               [--purge] [--purge_nets] [--ignore_top_ports_mismatch]
+               [--purge] [--purge_nets] [--purge_devices] [--ignore_top_ports_mismatch]
                [--implicit_nets=<nets>]
     """
 
@@ -838,6 +841,8 @@ if __name__ == "__main__":
     parser.add_argument("--top_lvl_pins", action="store_true", help="Create top-level pins in netlists.")
     parser.add_argument("--purge", action="store_true", help="Purge unused nets/devices.")
     parser.add_argument("--purge_nets", action="store_true", help="Purge floating nets.")
+    parser.add_argument("--purge_devices", action="store_true", help="Purge unused devices.")
+    
     parser.add_argument(
         "--implicit_nets",
         type=str,

--- a/ihp-sg13g2/libs.tech/klayout/tech/lvs/run_lvs.py
+++ b/ihp-sg13g2/libs.tech/klayout/tech/lvs/run_lvs.py
@@ -842,7 +842,7 @@ if __name__ == "__main__":
     parser.add_argument("--purge", action="store_true", help="Purge unused nets/devices.")
     parser.add_argument("--purge_nets", action="store_true", help="Purge floating nets.")
     parser.add_argument("--purge_devices", action="store_true", help="Purge unused devices.")
-    
+
     parser.add_argument(
         "--implicit_nets",
         type=str,

--- a/ihp-sg13g2/libs.tech/klayout/tech/lvs/sg13g2.lvs
+++ b/ihp-sg13g2/libs.tech/klayout/tech/lvs/sg13g2.lvs
@@ -163,6 +163,9 @@ PURGE_NETS = bool_check?($purge_nets)
 
 logger.info("Selected PURGE_NETS option: #{PURGE_NETS}")
 
+# PURGE_DEVICES
+PURGE_DEVICES = bool_check?($purge_devices)
+
 # SIMPLIFY
 SIMPLIFY = !bool_check?($no_simplify)
 
@@ -462,6 +465,9 @@ apply_netlist_options = lambda do |target_netlist, label|
 
   log_option_action.call(label, 'purge_nets', PURGE_NETS)
   target_netlist.purge_nets if PURGE_NETS
+
+  log_option_action.call(label, 'purge_devices', PURGE_DEVICES)
+  target_netlist.purge_devices if PURGE_DEVICES
 end
 
 if NET_ONLY


### PR DESCRIPTION
Currently, `purge`/`purge_devices` is done unconditionally in `rfmos_model_mapping.lvs`, so the arguments are not honored:
```
  --purge               Purge unused nets/devices.
  --purge_nets          Purge floating nets.
```

This also broke the `klayout-pex` PEX-LVS, which is based on this rule deck:
https://github.com/iic-jku/klayout-pex/issues/158