### PR TITLE
Update Sealring Generator (2)

### DIFF
--- a/ihp-sg13g2/libs.tech/klayout/tech/scripts/sealring.py
+++ b/ihp-sg13g2/libs.tech/klayout/tech/scripts/sealring.py
@@ -2,7 +2,9 @@
 Klayout's batch mode. For example:
 
 klayout -n sg13g2 -zz -r sealring.py \
-        -rd width=1300.0 -rd height=1300.0 -rd output=macros/sealring.gds.gz
+        -rd width=1300.0 -rd length=1300.0 -rd output=macros/sealring.gds.gz
+
+The former 'height' argument is still accepted as a deprecated alias for 'length'.
 
 """
 # pylint: disable=import-error
@@ -15,14 +17,14 @@ import klayout.db
 LIB = 'SG13_dev'
 PCELL = 'sealring'
 
-def generate_sealring(width: float, heigth: float, input: str | None, output: str, offset_x: float, offset_y: float):
+def generate_sealring(length: float, width: float, input: str | None, output: str, offset_x: float, offset_y: float):
     """Function to create a new layout, add the sealring PCell to sealring_top
     and save it somewhere on the filesystem.
 
-    :param width: Width (X-Axis) of the sealring.
+    :param length: Length (X-Axis) of the sealring.
+    :type length: float
+    :param width: Width (Y-Axis) of the sealring.
     :type width: float
-    :param height: Heigth (Y-Axis) of the sealring.
-    :type heigth: float
     :param output: Path and name of the file where the sealring should be written to.
     :type output: str
     :param offset_x: Translation in X direction in µm.
@@ -48,21 +50,21 @@ def generate_sealring(width: float, heigth: float, input: str | None, output: st
             "- Running KLayout with a version that supports Python PCells and properly loads them\n"
             "- Verifying that 'SG13_dev' appears in the Library Browser under PCells"
         )
-    
+
     pcell_decl = lib.layout().pcell_declaration(PCELL)
 
-    # Remove space around the sealring from width/height arguments.
+    # Remove space around the sealring from width/length arguments.
     params = pcell_decl.params_as_hash(pcell_decl.get_parameters())
     edge_box = float(re.sub('[a-zA-Z]+', '', params['edgeBox'].default))
     width = float(width) - edge_box * 2
-    heigth = float(heigth) - edge_box * 2
+    length = float(length) - edge_box * 2
 
     if input:
         top_cell = layout.top_cell()
     else:
         top_cell = layout.cell(layout.add_cell("sealring_top"))
 
-    pcell = layout.add_pcell_variant(lib, pcell_decl.id(), {'w': f'{width}u', 'l': f'{heigth}u'})
+    pcell = layout.add_pcell_variant(lib, pcell_decl.id(), {'w': f'{width}u', 'l': f'{length}u'})
     layout.cell(pcell)
 
     # Convert offset from µm to dbu
@@ -92,10 +94,17 @@ except NameError:
     sys.exit(1)
 
 try:
-    height
+    length
 except NameError:
-    print("Missing height argument. Please define '-rd height=<height>'")
-    sys.exit(1)
+    try:
+        # Deprecated fallback for the former 'height' argument.
+        height
+    except NameError:
+        print("Missing length argument. Please define '-rd length=<length>'")
+        sys.exit(1)
+    print("Warning: The 'height' argument is deprecated and will be removed in a "
+         "future release. Please use '-rd length=<length>' instead.")
+    length = height
 
 try:
     output
@@ -121,4 +130,4 @@ try:
 except NameError:
     input = None
 
-generate_sealring(width, height, input, output, offset_x, offset_y)  # pylint: disable=undefined-variable
+generate_sealring(length, width, input, output, offset_x, offset_y)  # pylint: disable=undefined-variable

--- a/ihp-sg13g2/libs.tech/klayout/tech/scripts/sealring.py
+++ b/ihp-sg13g2/libs.tech/klayout/tech/scripts/sealring.py
@@ -31,8 +31,8 @@ import klayout.db
 LIB = 'SG13_dev'
 PCELL = 'sealring'
 
-def generate_sealring(length: float, width: float, input: str | None, output: str, offset_x: float,
-                      offset_y: float):
+def generate_sealring(length: float, width: float, input_file: str | None, output: str,
+                      offset_x: float, offset_y: float):
     """Function to create a new layout, add the sealring PCell to sealring_top
     and save it somewhere on the filesystem.
 
@@ -40,9 +40,9 @@ def generate_sealring(length: float, width: float, input: str | None, output: st
     :type length: float
     :param width: Width (Y-Axis) of the sealring.
     :type width: float
-    :param input: Path and name of an existing layout the sealring should be added to.
-                  If omitted, a new layout with a 'sealring_top' cell is created.
-    :type input: str | None
+    :param input_file: Path and name of an existing layout the sealring should be added to.
+                       If omitted, a new layout with a 'sealring_top' cell is created.
+    :type input_file: str | None
     :param output: Path and name of the file where the sealring should be written to.
     :type output: str
     :param offset_x: Translation in X direction in µm.
@@ -54,8 +54,8 @@ def generate_sealring(length: float, width: float, input: str | None, output: st
     layout = klayout.db.Layout(True)
     layout.dbu = 0.001
 
-    if input:
-        layout.read(input)
+    if input_file:
+        layout.read(input_file)
 
     lib = pya.Library.library_by_name(LIB, 'sg13g2')
     if lib is None:
@@ -77,7 +77,7 @@ def generate_sealring(length: float, width: float, input: str | None, output: st
     width = float(width) - edge_box * 2
     length = float(length) - edge_box * 2
 
-    if input:
+    if input_file:
         top_cell = layout.top_cell()
     else:
         top_cell = layout.cell(layout.add_cell("sealring_top"))
@@ -133,13 +133,9 @@ try:
 except NameError:
     offset_y = 0.0
 
-try:
-    input
-    # Ignore built-in input function
-    if callable(input):
-        input = None
-except NameError:
-    input = None
+# The optional '-rd input=<path-to-layout>' argument shadows the built-in input
+# function, so copy it into a dedicated variable and don't use it any further.
+input_file = None if callable(input) else input
 
-generate_sealring(length=length, width=width, input=input, output=output, offset_x=offset_x,
-                  offset_y=offset_y)  # pylint: disable=undefined-variable
+generate_sealring(length=length, width=width, input_file=input_file, output=output,
+                  offset_x=offset_x, offset_y=offset_y)  # pylint: disable=undefined-variable

--- a/ihp-sg13g2/libs.tech/klayout/tech/scripts/sealring.py
+++ b/ihp-sg13g2/libs.tech/klayout/tech/scripts/sealring.py
@@ -18,7 +18,7 @@
 Klayout's batch mode. For example:
 
 klayout -n sg13g2 -zz -r sealring.py \
-        -rd width=1300.0 -rd height=1300.0 -rd output=macros/sealring.gds.gz
+        -rd width=1300.0 -rd length=1300.0 -rd output=macros/sealring.gds.gz
 
 """
 # pylint: disable=import-error
@@ -31,14 +31,18 @@ import klayout.db
 LIB = 'SG13_dev'
 PCELL = 'sealring'
 
-def generate_sealring(width: float, heigth: float, input: str | None, output: str, offset_x: float, offset_y: float):
+def generate_sealring(length: float, width: float, input: str | None, output: str, offset_x: float,
+                      offset_y: float):
     """Function to create a new layout, add the sealring PCell to sealring_top
     and save it somewhere on the filesystem.
 
-    :param width: Width (X-Axis) of the sealring.
+    :param length: Length (X-Axis) of the sealring.
+    :type length: float
+    :param width: Width (Y-Axis) of the sealring.
     :type width: float
-    :param height: Heigth (Y-Axis) of the sealring.
-    :type heigth: float
+    :param input: Path and name of an existing layout the sealring should be added to.
+                  If omitted, a new layout with a 'sealring_top' cell is created.
+    :type input: str | None
     :param output: Path and name of the file where the sealring should be written to.
     :type output: str
     :param offset_x: Translation in X direction in µm.
@@ -64,21 +68,21 @@ def generate_sealring(width: float, heigth: float, input: str | None, output: st
             "- Running KLayout with a version that supports Python PCells and properly loads them\n"
             "- Verifying that 'SG13_dev' appears in the Library Browser under PCells"
         )
-    
+
     pcell_decl = lib.layout().pcell_declaration(PCELL)
 
-    # Remove space around the sealring from width/height arguments.
+    # Remove space around the sealring from width/length arguments.
     params = pcell_decl.params_as_hash(pcell_decl.get_parameters())
     edge_box = float(re.sub('[a-zA-Z]+', '', params['edgeBox'].default))
     width = float(width) - edge_box * 2
-    heigth = float(heigth) - edge_box * 2
+    length = float(length) - edge_box * 2
 
     if input:
         top_cell = layout.top_cell()
     else:
         top_cell = layout.cell(layout.add_cell("sealring_top"))
 
-    pcell = layout.add_pcell_variant(lib, pcell_decl.id(), {'w': f'{width}u', 'l': f'{heigth}u'})
+    pcell = layout.add_pcell_variant(lib, pcell_decl.id(), {'w': f'{width}u', 'l': f'{length}u'})
     layout.cell(pcell)
 
     # Convert offset from µm to dbu
@@ -108,9 +112,9 @@ except NameError:
     sys.exit(1)
 
 try:
-    height
+    length
 except NameError:
-    print("Missing height argument. Please define '-rd height=<height>'")
+    print("Missing length argument. Please define '-rd length=<length>'")
     sys.exit(1)
 
 try:
@@ -137,4 +141,5 @@ try:
 except NameError:
     input = None
 
-generate_sealring(width, height, input, output, offset_x, offset_y)  # pylint: disable=undefined-variable
+generate_sealring(length=length, width=width, input=input, output=output, offset_x=offset_x,
+                  offset_y=offset_y)  # pylint: disable=undefined-variable


### PR DESCRIPTION
- Change the `height` argument to `length` to match the P-Cell
- Add `height` as deprecated fallback to not break any existing flows
- Fix script  internal documentation and swap length and width to match P-Cell axis description

See previous PR: https://github.com/IHP-GmbH/IHP-Open-PDK/pull/1016
