### PR TITLE
fixed missing substrate terminal on `cap_rfcmim` extraction in Magic

### DIFF
--- a/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-extract.tech
+++ b/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-extract.tech
@@ -1165,7 +1165,7 @@ variants (),(hrhc),(lrhc),(hrlc),(lrlc)
 
  # Capacitors
  device csubcircuit cap_cmim *mimcap m5 w=w l=l
- device csubcircuit cap_rfcmim *mimcap m5 +pblock w=w l=l
+ device csubcircuit cap_rfcmim *mimcap m5 space/w +pblock w=w l=l
  # Varactor:  Note that the SVaractor is a complex device incorporating
  # multiple varactor fingers.  This will normally be handled from a
  # generated cell using a "device" property.  In case varactor structures


### PR DESCRIPTION
Fixes #1008

## Problem

Magic extracts `cap_rfcmim` with only two terminals:

```
X0 TOP BOT cap_rfcmim l=7u w=7u
```

but the model is a three-terminal subcircuit:

```
.subckt cap_rfcmim PLUS MINUS bn
```

The missing bulk pin breaks ngspice simulation of extracted netlists and makes Magic + Netgen LVS fail on any cell containing an RF C-MIM.

## Cause

In `ihp-sg13g2-extract.tech` the device line declares no substrate types. Magic's syntax is `device csubcircuit name dev-types terminal-types [sub-types|None sub-node] [options]`, so the substrate connection has to be declared explicitly. Magic behaves as told, this is a technology file gap.

## Fix

```diff
- device csubcircuit cap_rfcmim *mimcap m5 +pblock w=w l=l
+ device csubcircuit cap_rfcmim *mimcap m5 space/w +pblock w=w l=l
```

`space/w` lets Magic resolve the bulk to the connected substrate node, which is the ptap guard ring the RF C-MIM pcell draws. Under the capacitor itself the well plane is `pblock`, so a plain `pwell` search would find nothing. The `+pblock` identifier layer stays last before the parameters, as required. The line lives in the `variants (),(hrhc),(lrhc),(hrlc),(lrlc)` block, so default extraction and all four PEX corners are covered.

## Verification

Magic 8.3.681 in iic-osic-tools, using the cells from https://github.com/iic-jku/open-pdks-regression-tests

Extraction of `sg13_rf_cmim` changes from `X0 C0 C1 cap_rfcmim` to `X0 C0 C1 CX cap_rfcmim`, where `CX` is the guard ring net. In `sg13_combined` the bulk resolves to `VSS`.

Magic + Netgen LVS results:

| cell | before | after |
| --- | --- | --- |
| sg13_cmim | pass | pass, extracted netlist unchanged |
| sg13_rf_cmim | fail | pass |
| sg13_combined | fail | pass |
| sg13_combined_cmim_ontop | fail | pass |

Plain `cap_cmim` is not affected. Its device record declares no substrate types, and the `+pblock` identifier layer still selects the correct model for a non-RF MiM cap.

## Not included

The separate `ngspice(lvs)` extract style uses `device capacitor` for `cap_rfcmim`, and that device class cannot emit a substrate node at all. It still extracts as `C0 C0 C1 cap_rfcmim w=10u l=10u`. Making that style consistent would mean switching it to `csubcircuit`, which changes the element from C to X in that style, so it is left for a separate discussion.
