### PR TITLE
xschem: run the parallel-simulation scripts through Tcl's `exec`

### DIFF
--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/inv_mc_tb.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/inv_mc_tb.sch
@@ -220,7 +220,7 @@ write_data [save_params] $netlist_dir/[file rootname [file tail [xschem get curr
 
 # run netlist and simulation
 xschem netlist
-python3 $\{PDK_ROOT\}/$\{PDK\}/libs.tech/xschem/sg13g2_tests/ngspice_parallel_mc.py [file tail [xschem get current_name]]
+exec >&@stdout python3 $\{PDK_ROOT\}/$\{PDK\}/libs.tech/xschem/sg13g2_tests/ngspice_parallel_mc.py [file tail [xschem get current_name]]
 "}
 C {sg13g2_pr/cap_cmim.sym} 370 -350 1 0 {name=C1
 model=cap_cmim

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/inv_sweep_tb.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/inv_sweep_tb.sch
@@ -254,5 +254,5 @@ write_data [save_params] $netlist_dir/[file rootname [file tail [xschem get curr
 
 # run netlist and simulation
 xschem netlist
-python3 $\{PDK_ROOT\}/$\{PDK\}/libs.tech/xschem/sg13g2_tests/ngspice_parallel_sweep.py [file tail [xschem get current_name]]
+exec >&@stdout python3 $\{PDK_ROOT\}/$\{PDK\}/libs.tech/xschem/sg13g2_tests/ngspice_parallel_sweep.py [file tail [xschem get current_name]]
 "}

--- a/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/isolbox_sweep_tb.sch
+++ b/ihp-sg13g2/libs.tech/xschem/sg13g2_tests/isolbox_sweep_tb.sch
@@ -118,7 +118,7 @@ write_data [save_params] $netlist_dir/[file rootname [file tail [xschem get curr
 
 # run netlist and simulation
 xschem netlist
-python3 $\{PDK_ROOT\}/$\{PDK\}/libs.tech/xschem/sg13g2_tests/ngspice_parallel_sweep.py [file tail [xschem get current_name]]
+exec >&@stdout python3 $\{PDK_ROOT\}/$\{PDK\}/libs.tech/xschem/sg13g2_tests/ngspice_parallel_sweep.py [file tail [xschem get current_name]]
 "}
 C {devices/gnd.sym} 110 -160 0 0 {name=l6 lab=GND}
 C {devices/code_shown.sym} 90 -400 0 0 {name=MODEL only_toplevel=true


### PR DESCRIPTION
## Problem

The **SimulatePARALLEL** launchers in `inv_mc_tb.sch`, `inv_sweep_tb.sch` and
`isolbox_sweep_tb.sch` end their `tclcommand` block with

```tcl
python3 ${PDK_ROOT}/${PDK}/libs.tech/xschem/sg13g2_tests/ngspice_parallel_mc.py [file tail [xschem get current_name]]
```

`python3` is not a Tcl command, so clicking the launcher aborts with

```
invalid command name "python3"
```

This is the same defect as the `mkdir -p $netlist_dir` fixed in
[`96fe2b70`](https://github.com/IHP-GmbH/IHP-Open-PDK/commit/96fe2b707)
("Update xschem-menu — from mkdir -p to file mkdir"). These three lines sit in
the very same launchers, a few lines below the `file mkdir` that was corrected,
and were missed.

## Why it only fails sometimes

Worth spelling out, since the launchers do work for some users.

When xschem stays attached to the terminal it was started from it goes through
`Tk_Main()` (see `cli_opt_detach` in xschem's `src/main.c`), and `Tcl_MainEx()`
sets `tcl_interactive` to 1 whenever stdin is a tty. With `tcl_interactive` set,
Tcl's `unknown` handler falls back to **auto-executing external programs**
(`uplevel 1 exec >&@stdout <@stdin $args`), so the bare `python3 ...` silently
works.

Started any other way — from a desktop entry, a file manager, a launcher tool,
or `xschem &` — xschem detaches, never goes through `Tcl_Main()`,
`tcl_interactive` stays 0, auto-exec is off, and the launcher dies.

Measured with the shipped PDK, same binary, same schematic:

| xschem started | `tcl_interactive` | result |
|---|---|---|
| terminal foreground (stdin is a tty) | 1 | works (auto-exec) |
| detached / stdin not a tty | 0 | `invalid command name "python3"` |

## Fix

`exec >&@stdout` is precisely what the auto-exec fallback does: run the program
with its output going to xschem's stdout. Plain `exec` would instead capture
stdout and turn anything the child writes to **stderr** into a Tcl error, which
the ngspice runs would trip over — so the redirection is not cosmetic.

Three one-line changes, one per schematic.

## Verification

With `tcl_interactive` 0, running the launcher line verbatim through xschem
(`-x -q --rcfile` on the SG13G2 PDK):

- before: `invalid command name "python3"` — python is never started
- after: python starts and runs; with no prior `xschem netlist` it reports its
  own `Error: Netlist file ./simulations/inv_mc_tb.spice not found`, i.e. the
  Tcl-level failure is gone and the script itself is reached

🤖 Generated with [Claude Code](https://claude.com/claude-code)