### PR TITLE
libs.tech: klayout: tech: scripts: sealring: Make height available

### DIFF
--- a/ihp-sg13g2/libs.tech/klayout/tech/scripts/sealring.py
+++ b/ihp-sg13g2/libs.tech/klayout/tech/scripts/sealring.py
@@ -114,8 +114,12 @@ except NameError:
 try:
     length
 except NameError:
-    print("Missing length argument. Please define '-rd length=<length>'")
-    sys.exit(1)
+    try:
+        length = height
+        print("The 'height' argument is deprecated. Please define '-rd length=<length>' instead.")
+    except NameError:
+        print("Missing length argument. Please define '-rd length=<length>'")
+        sys.exit(1)
 
 try:
     output


### PR DESCRIPTION
The parameter "height" should still be available and set the new variable "length". Thus, existing scripts don't break and the height->length change is not a breaking change in upcoming releases.
    
Fixes c4cd27c8 ("libs.tech: klayout: tech: scripts: sealring: Rename height to length")