### PR TITLE
fix(magic/npn): swap width/length parameters for extraction

### DIFF
--- a/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-extract.tech
+++ b/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-extract.tech
@@ -1152,13 +1152,15 @@ variants (),(hrhc),(lrhc),(hrlc),(lrlc)
 	pwell,space/w error l=l w=w a1=as p1=ps a2=ad p2=pd
 
  # Bipolars
- device msubcircuit npn13g2 npn gec *ndiff space/w error w1=we l1=le
+ # NOTE: Width/Length for the HBTs are swapped when compared to MOSFETs
+ # hence Width(BJT) maps to length, and Length(BJT) maps to width.
+ device msubcircuit npn13g2 npn gec *ndiff space/w error w1=le l1=we
 
  # 2nd layout type of low-voltage HBT bipolar
- device msubcircuit npn13g2l npn nec *ndiff space/w error w1=we l1=le
+ device msubcircuit npn13g2l npn nec *ndiff space/w error w1=le l1=we
 
  # High voltage NPN bipolar
- device msubcircuit npn13g2v npn hvnec *ndiff space/w error w1=we l1=le
+ device msubcircuit npn13g2v npn hvnec *ndiff space/w error w1=le l1=we
 
  # Lateral PNP bipolar
  device msubcircuit pnpMPA pnp *pdiff pwell,space/w a1=a p1=p
@@ -1228,13 +1230,13 @@ variants (lvs)
  # device mosfet scr1
 
  # Bipolars
- device bjt npn13g2 npn gec *ndiff space/w error w1=we l1=le
+ device bjt npn13g2 npn gec *ndiff space/w error w1=le l1=we
 
  # 2nd layout type of low-voltage HBT bipolar
- device bjt npn13g2l npn nec *ndiff space/w error w1=we l1=le
+ device bjt npn13g2l npn nec *ndiff space/w error w1=le l1=we
 
  # High voltage NPN bipolar
- device bjt npn13g2v npn hvnec *ndiff space/w error w1=we l1=le
+ device bjt npn13g2v npn hvnec *ndiff space/w error w1=le l1=we
 
  # pnpMPA PNP bipolar
  device bjt pnpMPA pnp *pdiff pwell,space/w a1=a p1=p


### PR DESCRIPTION
`msubcircuit` uses the same convention as a MOSFET for measuring the width/length, however the NPNs use the opposite order.
Hence we need to set `we` to the "length of the terminal" and `le` to the "width of the terminal". 

Note: This also changes the order of `we/le` to align with NGSpice/KLayout netlist(s).

Fixes: #1010 

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR

## Comparison

As a  sanity check I instantiated the following devices in KLayout:

- `npn13G2`
    - Default parameters
- `npn13G2L`
    - Le = [1.0u, 2.5u] in steps of 0.5u
    - Otherwise default
- `npn13G2V`
    - Le = [1.0u, 5.0u] in steps of 0.5u
    - Otherwise default
    
### Currently (without this PR)

**npn13g2**

```
# PCell parameters: npn13G2, we=0.07u, le=0.9u

## KLayout LVS extracted netlist
Q$1 \$98 \$99 \$100 \$1 npn13G2 we=70n le=900n Nx=1 m=1

## Magic Ext.
X13 a_n253_310# w_n271_n380# a_n75_24# w_n978_n5356# npn13g2 le=70n we=0.9u
```
--> Mismatch between `le` and `we`

**npn13g2l**

```
# PCell parameters: npn13G2l, we=0.07u, le=[1.0u, 2.5u] in increments of 0.5u

## KLayout LVS
2$2 \$69 \$70 \$94 \$1 npn13G2l we=70n le=1000n Nx=1 m=1
3$3 \$71 \$72 \$95 \$1 npn13G2l we=70n le=1500n Nx=1 m=1
4$4 \$73 \$74 \$96 \$1 npn13G2l we=70n le=2000n Nx=1 m=1
5$5 \$75 \$76 \$97 \$1 npn13G2l we=70n le=2500n Nx=1 m=1

## Magic Ext. (Ordered by dimension)

X6 a_n377_n1959# w_n245_n1959# a_n104_n1903# w_n978_n5356# npn13g2l le=70n we=1u
X8 a_2061_n1959# w_2193_n1959# a_2334_n1903# w_n978_n5356# npn13g2l le=70n we=1.5u
X0 a_4814_n1959# w_4946_n1959# a_5087_n1903# w_n978_n5356# npn13g2l le=70n we=2u
X2 a_7246_n1959# w_7378_n1959# a_7519_n1903# w_n978_n5356# npn13g2l le=70n we=2.5u
```
--> `we` changes, and not the expected `le` --> mismatch between `le/we` at all levels.

**npn13g2v**

```
# PCell parameters: npn13G2l, we=0.12u, le=[1.0u, 5.0u] in increments of 0.5u

## KLayout LVS
6$6 \$20 \$21 \$47 \$1 npn13G2v we=120n le=1000n Nx=1 m=1
7$7 \$22 \$23 \$48 \$1 npn13G2v we=120n le=1500n Nx=1 m=1
8$8 \$24 \$25 \$49 \$1 npn13G2v we=120n le=2000n Nx=1 m=1
9$9 \$26 \$27 \$50 \$1 npn13G2v we=120n le=2500n Nx=1 m=1
10$10 \$28 \$29 \$51 \$1 npn13G2v we=120n le=3000n Nx=1 m=1
11$11 \$30 \$31 \$52 \$1 npn13G2v we=120n le=3500n Nx=1 m=1
12$12 \$32 \$33 \$53 \$1 npn13G2v we=120n le=4000n Nx=1 m=1
13$13 \$34 \$35 \$54 \$1 npn13G2v we=120n le=4500n Nx=1 m=1
14$14 \$36 \$37 \$55 \$1 npn13G2v we=120n le=5000n Nx=1 m=1

## Magic Ext. (Ordered by dimension)
X10 a_n452_n4806# w_n371_n4806# a_n230_n4750# w_n978_n5356# npn13g2v le=0.12u we=1u
X9 a_2174_n4806# w_2255_n4806# a_2396_n4750# w_n978_n5356# npn13g2v le=0.12u we=1.5u
X3 a_4791_n4806# w_4872_n4806# a_5013_n4750# w_n978_n5356# npn13g2v le=0.12u we=2u
X11 a_6970_n4806# w_7051_n4806# a_7192_n4750# w_n978_n5356# npn13g2v le=0.12u we=2.5u
X4 a_9324_n4806# w_9405_n4806# a_9546_n4750# w_n978_n5356# npn13g2v le=0.12u we=3u
X1 a_11589_n4806# w_11670_n4806# a_11811_n4750# w_n978_n5356# npn13g2v le=0.12u we=3.5u
X5 a_13558_n4806# w_13639_n4806# a_13780_n4750# w_n978_n5356# npn13g2v le=0.12u we=4u
X7 a_16152_n4806# w_16233_n4806# a_16374_n4750# w_n978_n5356# npn13g2v le=0.12u we=4.5u
X12 a_18702_n4806# w_18783_n4806# a_18924_n4750# w_n978_n5356# npn13g2v le=0.12u we=5u
```
--> `we` changes, and not the expected `le` --> mismatch between `le/we` at all levels.

### This PR

**npn13g2**

```
# PCell parameters: npn13G2, we=0.07u, le=0.9u

## KLayout LVS extracted netlist
Q$1 \$98 \$99 \$100 \$1 npn13G2 we=70n le=900n Nx=1 m=1

## Magic Ext.
X13 a_n253_310# w_n271_n380# a_n75_24# w_n978_n5356# npn13g2 we=70n le=0.9u
```
--> Matches

**npn13g2l**

```
# PCell parameters: npn13G2l, we=0.07u, le=[1.0u, 2.5u] in increments of 0.5u

## KLayout LVS
2$2 \$69 \$70 \$94 \$1 npn13G2l we=70n le=1000n Nx=1 m=1
3$3 \$71 \$72 \$95 \$1 npn13G2l we=70n le=1500n Nx=1 m=1
4$4 \$73 \$74 \$96 \$1 npn13G2l we=70n le=2000n Nx=1 m=1
5$5 \$75 \$76 \$97 \$1 npn13G2l we=70n le=2500n Nx=1 m=1

## Magic Ext. (Ordered by dimension)

X6 a_n377_n1959# w_n245_n1959# a_n104_n1903# w_n978_n5356# npn13g2l we=70n le=1u
X8 a_2061_n1959# w_2193_n1959# a_2334_n1903# w_n978_n5356# npn13g2l we=70n le=1.5u
X0 a_4814_n1959# w_4946_n1959# a_5087_n1903# w_n978_n5356# npn13g2l we=70n le=2u
X2 a_7246_n1959# w_7378_n1959# a_7519_n1903# w_n978_n5356# npn13g2l we=70n le=2.5u

```
--> Matches

**npn13g2v**

```
# PCell parameters: npn13G2l, we=0.12u, le=[1.0u, 5.0u] in increments of 0.5u

## KLayout LVS
6$6 \$20 \$21 \$47 \$1 npn13G2v we=120n le=1000n Nx=1 m=1
7$7 \$22 \$23 \$48 \$1 npn13G2v we=120n le=1500n Nx=1 m=1
8$8 \$24 \$25 \$49 \$1 npn13G2v we=120n le=2000n Nx=1 m=1
9$9 \$26 \$27 \$50 \$1 npn13G2v we=120n le=2500n Nx=1 m=1
10$10 \$28 \$29 \$51 \$1 npn13G2v we=120n le=3000n Nx=1 m=1
11$11 \$30 \$31 \$52 \$1 npn13G2v we=120n le=3500n Nx=1 m=1
12$12 \$32 \$33 \$53 \$1 npn13G2v we=120n le=4000n Nx=1 m=1
13$13 \$34 \$35 \$54 \$1 npn13G2v we=120n le=4500n Nx=1 m=1
14$14 \$36 \$37 \$55 \$1 npn13G2v we=120n le=5000n Nx=1 m=1

## Magic Ext. (Ordered by dimension)

X10 a_n452_n4806# w_n371_n4806# a_n230_n4750# w_n978_n5356# npn13g2v we=0.12u le=1u
X9 a_2174_n4806# w_2255_n4806# a_2396_n4750# w_n978_n5356# npn13g2v we=0.12u le=1.5u
X3 a_4791_n4806# w_4872_n4806# a_5013_n4750# w_n978_n5356# npn13g2v we=0.12u le=2u
X11 a_6970_n4806# w_7051_n4806# a_7192_n4750# w_n978_n5356# npn13g2v we=0.12u le=2.5u
X4 a_9324_n4806# w_9405_n4806# a_9546_n4750# w_n978_n5356# npn13g2v we=0.12u le=3u
X1 a_11589_n4806# w_11670_n4806# a_11811_n4750# w_n978_n5356# npn13g2v we=0.12u le=3.5u
X5 a_13558_n4806# w_13639_n4806# a_13780_n4750# w_n978_n5356# npn13g2v we=0.12u le=4u
X7 a_16152_n4806# w_16233_n4806# a_16374_n4750# w_n978_n5356# npn13g2v we=0.12u le=4.5u
X12 a_18702_n4806# w_18783_n4806# a_18924_n4750# w_n978_n5356# npn13g2v we=0.12u le=5u
```
--> Matches