### PR TITLE
psp103: give the edge part of flicker noise a unique name

### DIFF
--- a/ihp-sg13g2/libs.tech/verilog-a/psp103/Changelog
+++ b/ihp-sg13g2/libs.tech/verilog-a/psp103/Changelog
@@ -1,3 +1,7 @@
+Change name of flicker noise contribution edge transistor from "flicker" to "flickeredge"
+to distinguish between bottom and edge part. psp103_module.include line 1954
+This is inline with User’s Manual- NXP / CEA-Leti v. 103.8.2
+
 Xyce/ADMS adaptions:
 Use IHP specific code for AD, AS, PD, PS calculation.
 Remove $mfactor from OP output variables calculation

--- a/ihp-sg13g2/libs.tech/verilog-a/psp103/PSP103_module.include
+++ b/ihp-sg13g2/libs.tech/verilog-a/psp103/PSP103_module.include
@@ -1951,7 +1951,7 @@ analog begin
             I(GP,DI)     <+  white_noise(MULT_i * shot_igd, "igd");
             I(BS,SI)     <+  white_noise(MULT_i * jnoise_s, "ibs");
             I(BD,DI)     <+  white_noise(MULT_i * jnoise_d, "ibd");
-            I(DI,SI)     <+  flicker_noise(sigVds * MULT_i * Sfledge, EFEDGE_i, "flicker");
+            I(DI,SI)     <+  flicker_noise(sigVds * MULT_i * Sfledge, EFEDGE_i, "flickeredge");
             I(DI,SI)     <+  white_noise(MULT_i * sqidedge * sqidedge, "ididedge");
 
         end // noise


### PR DESCRIPTION
A unique name was given for the edge part of the ids flicker noise contribution. 

This small PR will solve the problem of #805. There is still a bug in ngspice osdi noise interface in summing up the different noise contributions which will be solved in next release 48.
