### PR TITLE
Corrects an error in the magic tech files "cifinput" section that inc…

### DIFF
--- a/ihp-sg13cmos5l/libs.tech/magic/ihp-sg13cmos5l-cifin.tech
+++ b/ihp-sg13cmos5l/libs.tech/magic/ihp-sg13cmos5l-cifin.tech
@@ -867,11 +867,11 @@ style  sg13cmos5l variants ()
  # Handle contacts found by copyup
 
  templayer ndiccopy CONT
- and LI
+ and MET1
  and DIODE
  and DIFF
  and-not NWELL,nwelcheck
- and NSD
+ and-not PSD
  and-not THKOX,hvcheck
 
  layer ndic ndiccopy

--- a/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-cifin.tech
+++ b/ihp-sg13g2/libs.tech/magic/ihp-sg13g2-cifin.tech
@@ -1108,11 +1108,11 @@ style  sg13g2 variants ()
  # Handle contacts found by copyup
 
  templayer ndiccopy CONT
- and LI
+ and MET1
  and DIODE
  and DIFF
  and-not NWELL,nwelcheck
- and NSD
+ and-not PSD
  and-not THKOX,hvcheck
 
  layer ndic ndiccopy


### PR DESCRIPTION
Corrects an error in the magic tech files "cifinput" section that incorrectly reads a dantenna contact, causing the layout in magic to be missing the contact on the metal1 plane (in some situations;  how common this is is unknown).  The error is nearly impossible to detect visually, and can cause a `dantenna` device to become disconnected from the metal1 above it in the extracted netlist when extracting in magic.  This primarily affects the `dantenna` connection in the secondary ESD in the analog I/O pad cell, resulting in incorrect LVS of the cell.  This update fixes the problem in both the sg13g2 and sg13cmos5l PDKs.

Fixes #1137

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR
