### PR TITLE
CI: run each PDK's checks only when that PDK is affected

### DIFF
--- a/.github/pdk-ci.yml
+++ b/.github/pdk-ci.yml
@@ -1,0 +1,59 @@
+# ==========================================================================
+# Copyright 2026 IHP PDK Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
+# ==========================================================================
+
+# Single source of truth for which PDK CI runs on a given change.
+#
+# This repository holds more than one PDK in one tree. They are not independent:
+# ihp-sg13cmos5l reuses large parts of ihp-sg13g2 through relative symlinks (its
+# DRC/LVS rule decks, testcases, pycell library, models, ...), so a change to
+# ihp-sg13g2 can break ihp-sg13cmos5l, while nothing in ihp-sg13g2 depends on
+# ihp-sg13cmos5l. The dependency is one-directional.
+#
+# .github/scripts/affected_pdks.py reads this file and turns a set of changed
+# files into the list of PDKs whose CI must run:
+#   - a change under a PDK's own directory affects that PDK, plus every PDK that
+#     depends on it (the reverse of `depends_on`);
+#   - a change matching `shared_infra` affects every PDK;
+#   - a manual (workflow_dispatch), merge-queue (merge_group) or
+#     undetermined-diff run affects every PDK.
+#
+# To add a PDK, add one block under `pdks` with its `depends_on` and params.
+# Nothing else in the CI needs to change: the workflows read this file, and make
+# reports+succeeds (via the skip-unless macro in ihp-common/pdk.mk) on any test
+# a PDK does not carry.
+
+pdks:
+  ihp-sg13g2:
+    depends_on: []
+  ihp-sg13cmos5l:
+    depends_on: [ihp-sg13g2]          # symlinks into g2; reverse edge only
+
+# Any changed file matching one of these globs runs every PDK's CI: these files
+# define how the tests are built and run, or are shared by every PDK.
+shared_infra:
+  - Makefile
+  - "Makefile.*"
+  - "ihp-common/**"
+  - ".github/actions/**"
+  - ".github/workflows/**"
+  - ".github/scripts/**"
+  - ".github/pdk-ci.yml"
+  - versions.txt
+  - requirements.txt
+  - .flake8
+  - .rubocop.yml
+  - .gitmodules

--- a/.github/pdk-ci.yml
+++ b/.github/pdk-ci.yml
@@ -57,3 +57,22 @@ shared_infra:
   - .flake8
   - .rubocop.yml
   - .gitmodules
+
+# Which PDK-relative paths each test class cares about. A workflow passes its
+# class to the detect job, and a PDK's leg for that class runs only when a file
+# under it (or a PDK it depends on) matches one of these globs (a shared_infra
+# change still runs every class for every PDK). This keeps a DRC-only change
+# from spinning LVS and PCell. A change under a PDK dir that matches no class
+# (docs, libs.ref data) runs nothing here. Globs are relative to the PDK dir.
+test_classes:
+  drc:
+    - "libs.tech/klayout/tech/drc/**"
+  lvs:
+    - "libs.tech/klayout/tech/lvs/**"
+  pcell:
+    - "libs.tech/klayout/python/**"
+    - "libs.tech/klayout/*_tests/**"
+  lint:
+    - "libs.tech/klayout/tech/drc/**"
+    - "libs.tech/klayout/tech/lvs/**"
+    - "libs.tech/klayout/python/*_pycell_lib/**"

--- a/.github/scripts/affected_pdks.py
+++ b/.github/scripts/affected_pdks.py
@@ -46,7 +46,7 @@ import sys
 
 import yaml
 
-FORCE_ALL_EVENTS = ("workflow_dispatch", "merge_group", "schedule")
+FORCE_ALL_EVENTS = ("workflow_dispatch", "merge_group", "schedule", "push")
 
 
 def load_config(path):
@@ -72,6 +72,11 @@ def matches_shared(path, shared_globs):
     return any(fnmatch.fnmatch(path, pattern) for pattern in shared_globs)
 
 
+def matches_class(rel_path, globs):
+    """rel_path is relative to the PDK dir; globs come from test_classes."""
+    return any(fnmatch.fnmatch(rel_path, g) for g in globs)
+
+
 def dependents(pdks):
     """Reverse of `depends_on`: dep -> set of PDKs that depend on it."""
     rev = {name: set() for name in pdks}
@@ -93,10 +98,17 @@ def closure(seed, rev):
     return affected
 
 
-def compute(cfg, event, changed):
-    """Return (matrix_dict, any_bool) for the given event and changed files."""
+def compute(cfg, event, changed, test_class=None):
+    """Return (matrix_dict, any_bool) for the given event and changed files.
+
+    With test_class set, a PDK is "directly changed" only when one of its own
+    changed files matches that class's globs in cfg['test_classes']; a
+    shared_infra change still forces every PDK. With no test_class (or an
+    unknown one) any file under a PDK dir counts.
+    """
     pdks = cfg["pdks"]
     shared = cfg.get("shared_infra", [])
+    class_globs = (cfg.get("test_classes") or {}).get(test_class) if test_class else None
 
     force_all = (
         event in FORCE_ALL_EVENTS
@@ -107,8 +119,15 @@ def compute(cfg, event, changed):
     if force_all:
         affected = set(pdks)
     else:
-        direct = {name for name in pdks
-                  for f in changed if f.startswith(name + "/")}
+        direct = set()
+        for name in pdks:
+            prefix = name + "/"
+            for f in changed:
+                if not f.startswith(prefix):
+                    continue
+                if class_globs is None or matches_class(f[len(prefix):], class_globs):
+                    direct.add(name)
+                    break
         affected = closure(direct, dependents(pdks))
 
     include = [{"pdk": name} for name in sorted(affected)]
@@ -120,8 +139,9 @@ def main(argv):
     cfg = load_config(config_path)
     event = os.environ.get("EVENT", "")
     changed = parse_changed(os.environ.get("CHANGED", ""))
+    test_class = os.environ.get("CLASS", "") or None
 
-    matrix, any_affected = compute(cfg, event, changed)
+    matrix, any_affected = compute(cfg, event, changed, test_class)
 
     line_matrix = "matrix=" + json.dumps(matrix)
     line_any = "any=" + ("true" if any_affected else "false")

--- a/.github/scripts/affected_pdks.py
+++ b/.github/scripts/affected_pdks.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+# ==========================================================================
+# Copyright 2026 IHP PDK Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
+# ==========================================================================
+
+"""Turn a set of changed files into the CI matrix of affected PDKs.
+
+Reads .github/pdk-ci.yml (the single source of truth for PDKs, their
+dependencies and their per-PDK CI parameters) and prints a GitHub Actions
+matrix listing the PDKs whose CI must run for the given change.
+
+Rules (see .github/pdk-ci.yml for the rationale):
+  * A change under a PDK's own directory affects that PDK and every PDK that
+    depends on it (the reverse of `depends_on`).
+  * A change matching `shared_infra` affects every PDK.
+  * A workflow_dispatch / merge_group / schedule run, or a run whose changed
+    file set could not be determined (empty), affects every PDK.
+
+The heavy lifting (deciding which files changed) is done by the caller, which
+passes the changed file list in; this script only applies policy, so it is
+pure and unit-testable offline (see test_affected_pdks.py).
+
+Usage (in CI):
+  EVENT=<github.event_name> CHANGED='<json or newline list>' \
+      python3 .github/scripts/affected_pdks.py [path/to/pdk-ci.yml]
+Writes `matrix=<json>` and `any=<true|false>` to $GITHUB_OUTPUT (or stdout).
+"""
+
+import fnmatch
+import json
+import os
+import sys
+
+import yaml
+
+FORCE_ALL_EVENTS = ("workflow_dispatch", "merge_group", "schedule")
+
+
+def load_config(path):
+    with open(path, encoding="utf-8") as handle:
+        cfg = yaml.safe_load(handle)
+    if not cfg or "pdks" not in cfg:
+        raise ValueError("%s: missing 'pdks' section" % path)
+    cfg.setdefault("shared_infra", [])
+    return cfg
+
+
+def parse_changed(raw):
+    """Accept a JSON array (dorny list-files: json) or a whitespace/newline list."""
+    raw = (raw or "").strip()
+    if not raw:
+        return []
+    if raw[0] == "[":
+        return [str(f) for f in json.loads(raw)]
+    return [line.strip() for line in raw.replace("\n", " ").split() if line.strip()]
+
+
+def matches_shared(path, shared_globs):
+    return any(fnmatch.fnmatch(path, pattern) for pattern in shared_globs)
+
+
+def dependents(pdks):
+    """Reverse of `depends_on`: dep -> set of PDKs that depend on it."""
+    rev = {name: set() for name in pdks}
+    for name, meta in pdks.items():
+        for dep in (meta or {}).get("depends_on", []) or []:
+            rev.setdefault(dep, set()).add(name)
+    return rev
+
+
+def closure(seed, rev):
+    """seed PDKs plus everything that transitively depends on them."""
+    affected, stack = set(), list(seed)
+    while stack:
+        name = stack.pop()
+        if name in affected:
+            continue
+        affected.add(name)
+        stack.extend(rev.get(name, ()))
+    return affected
+
+
+def compute(cfg, event, changed):
+    """Return (matrix_dict, any_bool) for the given event and changed files."""
+    pdks = cfg["pdks"]
+    shared = cfg.get("shared_infra", [])
+
+    force_all = (
+        event in FORCE_ALL_EVENTS
+        or not changed
+        or any(matches_shared(f, shared) for f in changed)
+    )
+
+    if force_all:
+        affected = set(pdks)
+    else:
+        direct = {name for name in pdks
+                  for f in changed if f.startswith(name + "/")}
+        affected = closure(direct, dependents(pdks))
+
+    include = [{"pdk": name} for name in sorted(affected)]
+    return {"include": include}, bool(include)
+
+
+def main(argv):
+    config_path = argv[1] if len(argv) > 1 else ".github/pdk-ci.yml"
+    cfg = load_config(config_path)
+    event = os.environ.get("EVENT", "")
+    changed = parse_changed(os.environ.get("CHANGED", ""))
+
+    matrix, any_affected = compute(cfg, event, changed)
+
+    line_matrix = "matrix=" + json.dumps(matrix)
+    line_any = "any=" + ("true" if any_affected else "false")
+
+    out_path = os.environ.get("GITHUB_OUTPUT")
+    if out_path:
+        with open(out_path, "a", encoding="utf-8") as handle:
+            handle.write(line_matrix + "\n")
+            handle.write(line_any + "\n")
+
+    # Always echo to the log so the decision is visible in the job output.
+    print(line_matrix)
+    print(line_any)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.github/scripts/check_repo_invariants.py
+++ b/.github/scripts/check_repo_invariants.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+# ==========================================================================
+# Copyright 2026 IHP PDK Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
+# ==========================================================================
+
+"""Assert the repo-level invariants the per-PDK CI routing relies on.
+
+The routing in affected_pdks.py trusts .github/pdk-ci.yml to describe reality.
+If the map drifts from the tree, CI fails open (an unlisted PDK routes to
+nothing, all gates pass having tested nothing; a wrong-direction symlink breaks
+the dependency model). This script makes that drift fail loudly. Run from the
+repo root; exits non-zero listing every violation.
+
+  1. pdks <-> directories: every top-level ihp-* directory that carries a
+     libs.tech is declared under `pdks`, and every declared PDK exists.
+  2. symlink direction: every symlink that points from one PDK into another has
+     a matching depends_on edge (source depends on target). This catches a link
+     added in the wrong direction (e.g. ihp-sg13g2 -> ihp-sg13cmos5l), which
+     would silently invalidate the closure.
+"""
+
+import os
+import sys
+
+import yaml
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+CONFIG = os.path.join(ROOT, ".github", "pdk-ci.yml")
+SKIP_DIRS = {".git", "actions_venv", "node_modules"}
+
+
+def pdk_dirs():
+    """Top-level ihp-* directories that carry a libs.tech (i.e. real PDKs)."""
+    out = set()
+    for name in os.listdir(ROOT):
+        if name.startswith("ihp-") and os.path.isdir(os.path.join(ROOT, name, "libs.tech")):
+            out.add(name)
+    return out
+
+
+def pdk_of(rel_path):
+    """Which PDK a repo-relative path belongs to, or None."""
+    top = rel_path.split(os.sep, 1)[0]
+    return top if top in PDKS else None
+
+
+def closure(name, deps):
+    seen, stack = set(), [name]
+    while stack:
+        n = stack.pop()
+        for d in deps.get(n, []):
+            if d not in seen:
+                seen.add(d)
+                stack.append(d)
+    return seen
+
+
+def main():
+    cfg = yaml.safe_load(open(CONFIG, encoding="utf-8"))
+    declared = set(cfg.get("pdks", {}))
+    deps = {n: list((m or {}).get("depends_on", []) or []) for n, m in cfg["pdks"].items()}
+
+    global PDKS
+    PDKS = pdk_dirs()
+
+    errors = []
+
+    # 1. map <-> directories
+    for missing in sorted(PDKS - declared):
+        errors.append("PDK directory '%s' has libs.tech but is not in pdk-ci.yml `pdks` "
+                      "(its CI would never run)." % missing)
+    for extra in sorted(declared - PDKS):
+        errors.append("pdk-ci.yml declares PDK '%s' but no such directory with libs.tech exists." % extra)
+
+    # 2. symlink direction
+    for dirpath, dirnames, filenames in os.walk(ROOT):
+        dirnames[:] = [d for d in dirnames if d not in SKIP_DIRS]
+        for entry in dirnames + filenames:
+            abspath = os.path.join(dirpath, entry)
+            if not os.path.islink(abspath):
+                continue
+            rel = os.path.relpath(abspath, ROOT)
+            src = pdk_of(rel)
+            if src is None:
+                continue
+            target = os.readlink(abspath)
+            resolved = os.path.normpath(os.path.join(os.path.dirname(rel), target))
+            tgt = pdk_of(resolved)
+            if tgt and tgt != src and tgt not in closure(src, deps):
+                errors.append("symlink %s -> %s crosses %s -> %s, but pdk-ci.yml has no "
+                              "matching depends_on edge." % (rel, target, src, tgt))
+
+    if errors:
+        print("Repo invariant violations:", file=sys.stderr)
+        for e in errors:
+            print("  - " + e, file=sys.stderr)
+        return 1
+    print("Repo invariants OK: pdks=%s, cross-PDK symlinks all match depends_on."
+          % ", ".join(sorted(PDKS)))
+    return 0
+
+
+PDKS = set()
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/test_affected_pdks.py
+++ b/.github/scripts/test_affected_pdks.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+# ==========================================================================
+# Copyright 2026 IHP PDK Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
+# ==========================================================================
+
+"""Offline unit tests for affected_pdks.compute.
+
+Runs the real .github/pdk-ci.yml through every change scenario the CI must get
+right, plus an in-memory third-PDK case proving the map scales by one entry.
+No GitHub, no network, no Docker: `python3 test_affected_pdks.py` (also works
+under pytest).
+"""
+
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.abspath(os.path.join(HERE, "..", ".."))
+sys.path.insert(0, HERE)
+
+import affected_pdks as ap  # noqa: E402
+
+CONFIG = os.path.join(REPO, ".github", "pdk-ci.yml")
+
+
+def affected(cfg, event, changed):
+    matrix, any_affected = ap.compute(cfg, event, changed)
+    names = sorted(entry["pdk"] for entry in matrix["include"])
+    return names, any_affected
+
+
+def load():
+    return ap.load_config(CONFIG)
+
+
+# --- scenarios against the real map -------------------------------------
+
+def test_g2_change_pulls_in_cmos5l():
+    cfg = load()
+    names, any_a = affected(cfg, "pull_request",
+                            ["ihp-sg13g2/libs.tech/klayout/tech/drc/rule_decks/beol/5_16_metal1.drc"])
+    assert names == ["ihp-sg13cmos5l", "ihp-sg13g2"], names
+    assert any_a is True
+
+
+def test_cmos5l_own_file_stays_cmos5l():
+    cfg = load()
+    # A real, non-symlink file that only cmos5l carries.
+    names, any_a = affected(cfg, "pull_request",
+                            ["ihp-sg13cmos5l/libs.tech/klayout/tech/drc/ihp-sg13cmos5l.drc"])
+    assert names == ["ihp-sg13cmos5l"], names
+    assert any_a is True
+
+
+def test_both_pdks_changed():
+    cfg = load()
+    names, _ = affected(cfg, "pull_request", [
+        "ihp-sg13g2/libs.tech/klayout/tech/lvs/rule_decks/x.lvs",
+        "ihp-sg13cmos5l/libs.tech/klayout/tech/lvs/foo.lvs",
+    ])
+    assert names == ["ihp-sg13cmos5l", "ihp-sg13g2"], names
+
+
+def test_shared_infra_makefile_runs_all():
+    cfg = load()
+    names, any_a = affected(cfg, "pull_request", ["ihp-common/pdk.mk"])
+    assert names == ["ihp-sg13cmos5l", "ihp-sg13g2"], names
+    assert any_a is True
+
+
+def test_shared_infra_versions_runs_all():
+    cfg = load()
+    names, _ = affected(cfg, "pull_request", ["versions.txt"])
+    assert names == ["ihp-sg13cmos5l", "ihp-sg13g2"], names
+
+
+def test_shared_infra_root_makefile_and_glob():
+    cfg = load()
+    for f in ("Makefile", "Makefile.sg13cmos5l", ".github/workflows/pdk-run.yml"):
+        names, _ = affected(cfg, "pull_request", [f])
+        assert names == ["ihp-sg13cmos5l", "ihp-sg13g2"], (f, names)
+
+
+def test_workflow_dispatch_runs_all():
+    cfg = load()
+    names, any_a = affected(cfg, "workflow_dispatch", [])
+    assert names == ["ihp-sg13cmos5l", "ihp-sg13g2"], names
+    assert any_a is True
+
+
+def test_merge_group_runs_all():
+    cfg = load()
+    names, _ = affected(cfg, "merge_group",
+                        ["ihp-sg13cmos5l/libs.tech/klayout/tech/drc/ihp-sg13cmos5l.drc"])
+    assert names == ["ihp-sg13cmos5l", "ihp-sg13g2"], names
+
+
+def test_empty_changeset_falls_back_to_all():
+    cfg = load()
+    names, any_a = affected(cfg, "pull_request", [])
+    assert names == ["ihp-sg13cmos5l", "ihp-sg13g2"], names
+    assert any_a is True
+
+
+def test_non_pdk_non_shared_change_runs_nothing():
+    cfg = load()
+    names, any_a = affected(cfg, "pull_request", ["README.md", "CHANGELOG.md"])
+    assert names == [], names
+    assert any_a is False
+
+
+def test_third_pdk_scales_by_one_entry():
+    # In-memory map extension: a new PDK depending on g2 must be pulled in by a
+    # g2 change, proving the closure scales without touching the workflows.
+    cfg = load()
+    cfg["pdks"]["ihp-sg13foo"] = {"depends_on": ["ihp-sg13g2"]}
+    names, _ = affected(cfg, "pull_request",
+                        ["ihp-sg13g2/libs.tech/klayout/tech/drc/rule_decks/beol/5_16_metal1.drc"])
+    assert names == ["ihp-sg13cmos5l", "ihp-sg13foo", "ihp-sg13g2"], names
+    # A change to the new PDK alone stays contained.
+    names, _ = affected(cfg, "pull_request", ["ihp-sg13foo/libs.tech/x"])
+    assert names == ["ihp-sg13foo"], names
+
+
+def _all_tests():
+    return sorted(name for name in globals()
+                  if name.startswith("test_") and callable(globals()[name]))
+
+
+def main():
+    failures = 0
+    for name in _all_tests():
+        try:
+            globals()[name]()
+            print("PASS %s" % name)
+        except AssertionError as exc:
+            failures += 1
+            print("FAIL %s: %s" % (name, exc))
+    print("\n%d passed, %d failed" % (len(_all_tests()) - failures, failures))
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/test_affected_pdks.py
+++ b/.github/scripts/test_affected_pdks.py
@@ -36,8 +36,8 @@ import affected_pdks as ap  # noqa: E402
 CONFIG = os.path.join(REPO, ".github", "pdk-ci.yml")
 
 
-def affected(cfg, event, changed):
-    matrix, any_affected = ap.compute(cfg, event, changed)
+def affected(cfg, event, changed, test_class=None):
+    matrix, any_affected = ap.compute(cfg, event, changed, test_class)
     names = sorted(entry["pdk"] for entry in matrix["include"])
     return names, any_affected
 
@@ -133,6 +133,57 @@ def test_third_pdk_scales_by_one_entry():
     # A change to the new PDK alone stays contained.
     names, _ = affected(cfg, "pull_request", ["ihp-sg13foo/libs.tech/x"])
     assert names == ["ihp-sg13foo"], names
+
+
+# --- per-test-class scoping ---------------------------------------------
+
+DRC_G2 = "ihp-sg13g2/libs.tech/klayout/tech/drc/rule_decks/beol/5_16_metal1.drc"
+LVS_G2 = "ihp-sg13g2/libs.tech/klayout/tech/lvs/rule_decks/x.lvs"
+DRC_CMOS5L_OWN = "ihp-sg13cmos5l/libs.tech/klayout/tech/drc/ihp-sg13cmos5l.drc"
+PCELL_G2 = "ihp-sg13g2/libs.tech/klayout/python/sg13g2_pycell_lib/ihp/nmos_code.py"
+DOC_G2 = "ihp-sg13g2/libs.doc/SG13G2_os_process_spec.pdf"
+
+
+def test_class_drc_only_runs_for_drc_change():
+    cfg = load()
+    assert affected(cfg, "pull_request", [DRC_G2], "drc")[0] == ["ihp-sg13cmos5l", "ihp-sg13g2"]
+    # an LVS change must NOT trigger the drc class
+    assert affected(cfg, "pull_request", [LVS_G2], "drc") == ([], False)
+
+
+def test_class_lvs_only_runs_for_lvs_change():
+    cfg = load()
+    assert affected(cfg, "pull_request", [LVS_G2], "lvs")[0] == ["ihp-sg13cmos5l", "ihp-sg13g2"]
+    assert affected(cfg, "pull_request", [DRC_G2], "lvs") == ([], False)
+
+
+def test_class_cmos5l_own_drc_stays_cmos5l():
+    cfg = load()
+    assert affected(cfg, "pull_request", [DRC_CMOS5L_OWN], "drc")[0] == ["ihp-sg13cmos5l"]
+
+
+def test_class_pcell_matches_python_and_tests():
+    cfg = load()
+    assert affected(cfg, "pull_request", [PCELL_G2], "pcell")[0] == ["ihp-sg13cmos5l", "ihp-sg13g2"]
+    # a drc change must not trigger pcell
+    assert affected(cfg, "pull_request", [DRC_G2], "pcell") == ([], False)
+
+
+def test_class_non_test_path_runs_nothing():
+    cfg = load()
+    # a doc/data file under a PDK dir matches no class -> that class runs nothing
+    assert affected(cfg, "pull_request", [DOC_G2], "drc") == ([], False)
+
+
+def test_class_shared_infra_still_forces_all():
+    cfg = load()
+    assert affected(cfg, "pull_request", ["ihp-common/pdk.mk"], "drc")[0] == ["ihp-sg13cmos5l", "ihp-sg13g2"]
+
+
+def test_class_push_event_forces_all():
+    cfg = load()
+    names, any_a = affected(cfg, "push", [], "drc")
+    assert names == ["ihp-sg13cmos5l", "ihp-sg13g2"] and any_a is True
 
 
 def _all_tests():

--- a/.github/workflows/detect-affected-pdks.yml
+++ b/.github/workflows/detect-affected-pdks.yml
@@ -28,6 +28,12 @@ name: detect-affected-pdks
 
 on:
   workflow_call:
+    inputs:
+      test_class:
+        description: "Test class to scope by (drc|lvs|pcell|lint); empty = any PDK file."
+        required: false
+        type: string
+        default: ""
     outputs:
       matrix:
         description: "GitHub Actions matrix (JSON) of the affected PDKs."
@@ -67,6 +73,7 @@ jobs:
         env:
           EVENT: ${{ github.event_name }}
           CHANGED: ${{ steps.changes.outputs.any_files }}
+          CLASS: ${{ inputs.test_class }}
         run: |
           python3 -c 'import yaml' 2>/dev/null || python3 -m pip install --quiet pyyaml
           python3 .github/scripts/affected_pdks.py

--- a/.github/workflows/detect-affected-pdks.yml
+++ b/.github/workflows/detect-affected-pdks.yml
@@ -68,5 +68,5 @@ jobs:
           EVENT: ${{ github.event_name }}
           CHANGED: ${{ steps.changes.outputs.any_files }}
         run: |
-          python3 -m pip install --quiet pyyaml
+          python3 -c 'import yaml' 2>/dev/null || python3 -m pip install --quiet pyyaml
           python3 .github/scripts/affected_pdks.py

--- a/.github/workflows/detect-affected-pdks.yml
+++ b/.github/workflows/detect-affected-pdks.yml
@@ -1,0 +1,72 @@
+# ==========================================================================
+# Copyright 2026 IHP PDK Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
+# ==========================================================================
+
+# Reusable job that decides which PDKs a change affects, from the single source
+# of truth in .github/pdk-ci.yml. Every per-PDK workflow calls this first and
+# feeds its `matrix` output into pdk-run.yml.
+#
+# On a pull_request it resolves the changed files with dorny/paths-filter and
+# lets affected_pdks.py apply the dependency policy. On workflow_dispatch and
+# merge_group the changed-file step is skipped and the script runs every PDK
+# (a manual or merge-queue run should be exhaustive).
+
+name: detect-affected-pdks
+
+on:
+  workflow_call:
+    outputs:
+      matrix:
+        description: "GitHub Actions matrix (JSON) of the affected PDKs."
+        value: ${{ jobs.detect.outputs.matrix }}
+      any:
+        description: "'true' when at least one PDK is affected, else 'false'."
+        value: ${{ jobs.detect.outputs.any }}
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      matrix: ${{ steps.compute.outputs.matrix }}
+      any: ${{ steps.compute.outputs.any }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      # Only a pull_request has a base to diff against. For workflow_dispatch and
+      # merge_group this step is skipped, CHANGED stays empty, and the script
+      # falls back to running every PDK.
+      - name: Detect changed files
+        id: changes
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        with:
+          list-files: json
+          filters: |
+            any:
+              - '**'
+
+      - name: Compute affected PDKs
+        id: compute
+        env:
+          EVENT: ${{ github.event_name }}
+          CHANGED: ${{ steps.changes.outputs.any_files }}
+        run: |
+          python3 -m pip install --quiet pyyaml
+          python3 .github/scripts/affected_pdks.py

--- a/.github/workflows/drc_regression.yml
+++ b/.github/workflows/drc_regression.yml
@@ -42,6 +42,8 @@ permissions:
 jobs:
   detect:
     uses: ./.github/workflows/detect-affected-pdks.yml
+    with:
+      test_class: drc
 
   drc:
     needs: detect

--- a/.github/workflows/drc_regression.yml
+++ b/.github/workflows/drc_regression.yml
@@ -27,6 +27,10 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  # Runs the full matrix (all PDKs) after a merge, catching cross-PDK breakage
+  # that two separately-green PRs can introduce once both land on dev.
+  push:
+    branches: [dev]
   pull_request:
   merge_group:
   workflow_dispatch:
@@ -48,8 +52,12 @@ jobs:
       targets: "test-DRC-main test-DRC-cells"
 
   gate:
-    # The single required status check. Always runs, even when no PDK is
-    # affected (drc skipped), so a required check is never left pending.
+    # The single required status check for this workflow. Always runs, even when
+    # no PDK is affected (drc skipped), so a required check is never left
+    # pending. The name must be unique across workflows, otherwise every "gate"
+    # job would report the same check context and branch protection could not
+    # tell them apart.
+    name: DRC gate
     if: ${{ always() }}
     needs: [detect, drc]
     runs-on: ubuntu-latest

--- a/.github/workflows/drc_regression.yml
+++ b/.github/workflows/drc_regression.yml
@@ -1,4 +1,4 @@
-#==========================================================================
+# ==========================================================================
 # Copyright 2025 IHP PDK Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # SPDX-License-Identifier: Apache-2.0
-#==========================================================================
+# ==========================================================================
+
+# DRC regression, per affected PDK. `detect` decides which PDKs a change touches
+# (a change to ihp-sg13g2 also runs ihp-sg13cmos5l, which symlinks into it; a
+# change to cmos5l's own files runs cmos5l only), `drc` runs them, and the
+# always-run `gate` is the single required status check (see .github/pdk-ci.yml).
 
 name: DRC Regression Testing
 
@@ -23,122 +28,37 @@ concurrency:
 
 on:
   pull_request:
-    paths:
-      - 'ihp-*/libs.tech/klayout/tech/drc/**'
-      - '.github/actions/setup-klayout/action.yml'
-      - '.github/workflows/drc_regression.yml'
+  merge_group:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
-  drc_regression:
+  detect:
+    uses: ./.github/workflows/detect-affected-pdks.yml
+
+  drc:
+    needs: detect
+    if: ${{ needs.detect.outputs.any == 'true' }}
+    uses: ./.github/workflows/pdk-run.yml
+    with:
+      matrix: ${{ needs.detect.outputs.matrix }}
+      targets: "test-DRC-main test-DRC-cells"
+
+  gate:
+    # The single required status check. Always runs, even when no PDK is
+    # affected (drc skipped), so a required check is never left pending.
+    if: ${{ always() }}
+    needs: [detect, drc]
     runs-on: ubuntu-latest
-
-    # The path filter above gates the workflow, not the individual legs, so a
-    # change to one PDK's deck runs both. That is deliberate: the decks share
-    # rule files through symlinks, so a change to one can break the other.
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - pdk: ihp-sg13g2
-            sp_tables: '--table=nwell --table=activ --table=cont --table=via1 --table=mim'
-          - pdk: ihp-sg13cmos5l
-            sp_tables: '--table=nwell --table=activ --table=cont --table=via1'
-
     steps:
-      - name: 🧾 Checkout repo
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: 🔧 Set up KLayout
-        uses: ./.github/actions/setup-klayout
-
-      - name: 🧪 Run KLayout DRC Regression
-        run: make test-DRC-main PDK=${{ matrix.pdk }}
-
-      # The steps below smoke-test the two ways a designer reaches the deck --
-      # the binary directly, and run_drc.py -- rather than the rules themselves,
-      # which is why they all end in `|| true`. The regression above is what
-      # actually gates the pull request. The venv they source is created by
-      # setup-klayout.
-      - name: ⛰️ Run KLayout top-level DRC Deck
+      - name: Aggregate result
         run: |
-          klayout -b -r ${{ matrix.pdk }}/libs.tech/klayout/tech/drc/${{ matrix.pdk }}.drc \
-            -rd run_mode=deep \
-            -rd threads=1 \
-            -rd no_feol=false \
-            -rd no_beol=false \
-            -rd no_offgrid=false \
-            -rd no_pin=false \
-            -rd no_forbidden=false \
-            -rd input=${{ matrix.pdk }}/libs.tech/klayout/tech/drc/testing/testcases/unit/activ.gds \
-          || true
-
-      - name: ⛰️ Run KLayout top-level DRC Deck with selected tables
-        run: |
-          klayout -b -r ${{ matrix.pdk }}/libs.tech/klayout/tech/drc/${{ matrix.pdk }}.drc \
-            -rd run_mode=deep \
-            -rd threads=1 \
-            -rd tables="nwell activ cont vian passiv lbe metal1" \
-            -rd no_feol=true \
-            -rd no_beol=true \
-            -rd no_offgrid=true \
-            -rd no_pin=true \
-            -rd no_forbidden=true \
-            -rd input=${{ matrix.pdk }}/libs.tech/klayout/tech/drc/testing/testcases/unit/activ.gds \
-          || true
-
-      - name: 📜 Run KLayout "run_drc" script in sp
-        run: |
-          . actions_venv/bin/activate; python3 ${{ matrix.pdk }}/libs.tech/klayout/tech/drc/run_drc.py \
-            --mp 1 \
-            --disable_extra_rules \
-            --path ${{ matrix.pdk }}/libs.tech/klayout/tech/drc/testing/testcases/unit/activ.gds \
-          || true
-
-      - name: 📜 Run KLayout "run_drc" script in mp
-        run: |
-          . actions_venv/bin/activate; python3 ${{ matrix.pdk }}/libs.tech/klayout/tech/drc/run_drc.py \
-            --mp 2 \
-            --disable_extra_rules \
-            --path ${{ matrix.pdk }}/libs.tech/klayout/tech/drc/testing/testcases/unit/activ.gds \
-          || true
-
-      - name: 📜 Run KLayout "run_drc" script with selected tables in sp
-        run: |
-          . actions_venv/bin/activate; python3 ${{ matrix.pdk }}/libs.tech/klayout/tech/drc/run_drc.py \
-            --mp 1 \
-            ${{ matrix.sp_tables }} --no_density --disable_extra_rules \
-            --path ${{ matrix.pdk }}/libs.tech/klayout/tech/drc/testing/testcases/unit/activ.gds \
-          || true
-
-      - name: 📜 Run KLayout "run_drc" script with selected tables in mp
-        run: |
-          . actions_venv/bin/activate; python3 ${{ matrix.pdk }}/libs.tech/klayout/tech/drc/run_drc.py \
-            --mp 2 \
-            --table=nbulay --table=gatpoly --table=psd --table=vian --table=passiv --table=lbe --table=metal1 --no_density --disable_extra_rules \
-            --path ${{ matrix.pdk }}/libs.tech/klayout/tech/drc/testing/testcases/unit/activ.gds \
-          || true
-
-  drc_regression_cells:
-    runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        pdk: [ihp-sg13g2, ihp-sg13cmos5l]
-
-    steps:
-      - name: 🧾 Checkout repo
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: 🔧 Set up KLayout
-        uses: ./.github/actions/setup-klayout
-
-      # Reports and succeeds on a PDK with no run_regression_cells.py, which is
-      # CMOS5L today. It starts testing for real the moment that file lands.
-      - name: 🧪 Run DRC Regression for Cells
-        run: make test-DRC-cells PDK=${{ matrix.pdk }}
+          echo "detect=${{ needs.detect.result }} drc=${{ needs.drc.result }}"
+          if echo "${{ needs.detect.result }} ${{ needs.drc.result }}" \
+             | grep -qE "failure|cancelled"; then
+            echo "::error::DRC regression failed"; exit 1
+          fi
+          echo "DRC regression passed (or no affected PDK for this change)."

--- a/.github/workflows/functional-heavy.yml
+++ b/.github/workflows/functional-heavy.yml
@@ -1,0 +1,139 @@
+# ==========================================================================
+# Copyright 2026 IHP PDK Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
+# ==========================================================================
+
+# The heavy device/model suites, kept OUT of the per-PR checks: they need
+# simulators and Verilog-A compilation (and gnucap, whose plugin build alone
+# runs for tens of minutes). Manual (workflow_dispatch) or weekly. This is NOT
+# a required check.
+#
+# The make targets already skip (report+succeed) when a tool they need is
+# missing, so a provisioning step that fails degrades to a loud skip rather than
+# a hard failure. openvaf is pinned to the version in versions.txt.
+
+name: Functional Heavy Suites
+
+concurrency:
+  group: ${{ github.repository }}-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 3 * * 1'          # Mondays, 03:00 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  # cap_cmomi / cap_cmomf PCell DRC+LVS sweeps. KLayout only, cmos5l only.
+  cap_sweeps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: ./.github/actions/setup-klayout
+      - name: Run cap PCell sweeps (ihp-sg13cmos5l)
+        run: make test-cap-cmomi-sweep test-cap-cmomf-sweep PDK=ihp-sg13cmos5l
+
+  # cap_cmomi model consistency: needs ngspice + a Verilog-A compiler to build
+  # the OSDI the model cards reference. Runs for both PDKs.
+  cap_model:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        pdk: [ihp-sg13g2, ihp-sg13cmos5l]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: ./.github/actions/setup-klayout
+      - name: Install ngspice and tcl
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y ngspice tcl
+      - name: Install OpenVAF
+        run: |
+          VER=$(grep '^openvaf ' versions.txt | awk '{print $2}')
+          curl -fL --retry 5 --retry-all-errors \
+            -o openvaf.tar.gz \
+            "https://openva.fra1.cdn.digitaloceanspaces.com/openvaf_${VER//./_}_linux_amd64.tar.gz"
+          tar xzf openvaf.tar.gz
+          sudo install -m 0755 openvaf /usr/local/bin/openvaf
+          openvaf --version || true
+      - name: Build Verilog-A OSDI objects
+        run: |
+          . actions_venv/bin/activate
+          (cd ihp-sg13g2/libs.tech/verilog-a && ./openvaf-compile-va.sh)
+      - name: Run cap_cmomi model check (${{ matrix.pdk }})
+        run: make test-cap-cmomi-model PDK=${{ matrix.pdk }}
+
+  # gnucap device regression, cmos5l only. gnucap and gnucap-mg-vams are not
+  # packaged, so they are built from source; the build is best-effort
+  # (continue-on-error) because make test-gnucap skips loudly when they are
+  # absent rather than failing.
+  gnucap:
+    runs-on: ubuntu-latest
+    env:
+      PDK_ROOT: ${{ github.workspace }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: ./.github/actions/setup-klayout
+      - name: Install ngspice and build tools
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y ngspice tcl automake libtool bison flex gperf
+      - name: Install OpenVAF
+        run: |
+          VER=$(grep '^openvaf ' versions.txt | awk '{print $2}')
+          curl -fL --retry 5 --retry-all-errors \
+            -o openvaf.tar.gz \
+            "https://openva.fra1.cdn.digitaloceanspaces.com/openvaf_${VER//./_}_linux_amd64.tar.gz"
+          tar xzf openvaf.tar.gz
+          sudo install -m 0755 openvaf /usr/local/bin/openvaf
+      - name: Build Verilog-A OSDI objects
+        run: |
+          . actions_venv/bin/activate
+          (cd ihp-sg13g2/libs.tech/verilog-a && ./openvaf-compile-va.sh)
+      - name: Build gnucap and gnucap-mg-vams from source
+        continue-on-error: true
+        run: |
+          set -x
+          git clone --depth 1 https://codeberg.org/gnucap/gnucap
+          (cd gnucap && ./autogen.sh && ./configure && make -j"$(nproc)" && sudo make install)
+          git clone --depth 1 https://codeberg.org/gnucap/gnucap-modelgen-verilog
+          (cd gnucap-modelgen-verilog && autoreconf -i && ./configure && make -j"$(nproc)" && sudo make install)
+          sudo ldconfig
+      - name: Run gnucap regression (ihp-sg13cmos5l)
+        run: make test-gnucap PDK=ihp-sg13cmos5l
+
+  gate:
+    if: ${{ always() }}
+    needs: [cap_sweeps, cap_model, gnucap]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Aggregate result
+        run: |
+          echo "cap_sweeps=${{ needs.cap_sweeps.result }} cap_model=${{ needs.cap_model.result }} gnucap=${{ needs.gnucap.result }}"
+          if echo "${{ needs.cap_sweeps.result }} ${{ needs.cap_model.result }} ${{ needs.gnucap.result }}" \
+             | grep -qE "failure|cancelled"; then
+            echo "::error::A heavy functional suite failed"; exit 1
+          fi
+          echo "Heavy functional suites passed (or skipped when a tool was unavailable)."

--- a/.github/workflows/functional-heavy.yml
+++ b/.github/workflows/functional-heavy.yml
@@ -79,7 +79,11 @@ jobs:
       - name: Build Verilog-A OSDI objects
         run: |
           . actions_venv/bin/activate
+          # Both PDKs have their own compile script and osdi/ dir (cmos5l ships
+          # its own cap_cmomi/cap_cmomf VA; only mosvar/psp103/r3_cmc symlink g2),
+          # so build both or cmos5l's model checks resolve a missing OSDI.
           (cd ihp-sg13g2/libs.tech/verilog-a && ./openvaf-compile-va.sh)
+          (cd ihp-sg13cmos5l/libs.tech/verilog-a && ./openvaf-compile-va.sh)
       - name: Run cap_cmomi model check (${{ matrix.pdk }})
         run: make test-cap-cmomi-model PDK=${{ matrix.pdk }}
 
@@ -111,7 +115,11 @@ jobs:
       - name: Build Verilog-A OSDI objects
         run: |
           . actions_venv/bin/activate
+          # Both PDKs have their own compile script and osdi/ dir (cmos5l ships
+          # its own cap_cmomi/cap_cmomf VA; only mosvar/psp103/r3_cmc symlink g2),
+          # so build both or cmos5l's model checks resolve a missing OSDI.
           (cd ihp-sg13g2/libs.tech/verilog-a && ./openvaf-compile-va.sh)
+          (cd ihp-sg13cmos5l/libs.tech/verilog-a && ./openvaf-compile-va.sh)
       - name: Build gnucap and gnucap-mg-vams from source
         continue-on-error: true
         run: |
@@ -121,10 +129,20 @@ jobs:
           git clone --depth 1 https://codeberg.org/gnucap/gnucap-modelgen-verilog
           (cd gnucap-modelgen-verilog && autoreconf -i && ./configure && make -j"$(nproc)" && sudo make install)
           sudo ldconfig
+      - name: Report gnucap tool availability
+        run: |
+          for t in gnucap gnucap-mg-vams; do
+            if command -v "$t" >/dev/null 2>&1; then
+              echo "::notice::$t is available"
+            else
+              echo "::warning::$t was not built; make test-gnucap will skip (no regression run)"
+            fi
+          done
       - name: Run gnucap regression (ihp-sg13cmos5l)
         run: make test-gnucap PDK=ihp-sg13cmos5l
 
   gate:
+    name: Heavy suites gate
     if: ${{ always() }}
     needs: [cap_sweeps, cap_model, gnucap]
     runs-on: ubuntu-latest

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -27,6 +27,8 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  push:
+    branches: [dev]
   pull_request:
   merge_group:
   workflow_dispatch:
@@ -112,9 +114,28 @@ jobs:
           fi
           echo "OK: klayout version is consistent ($VERSIONS_TXT)"
 
+  ci_selftest:
+    # The CI routing (affected_pdks.py + pdk-ci.yml) decides what every other
+    # gate runs, so it is tested and kept honest here on every PR: unit tests for
+    # the closure, flake8 over the scripts, and the repo-invariant checks (the
+    # pdk map matches the tree, cross-PDK symlinks match depends_on). Without
+    # this, a bad edit to the routing fails open (empty matrix, green gates).
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Lint and self-test the CI scripts
+        run: |
+          python3 -m pip install --quiet pyyaml flake8
+          flake8 --config=.flake8 .github/scripts
+          python3 .github/scripts/test_affected_pdks.py
+          python3 .github/scripts/check_repo_invariants.py
+
   gate:
+    name: Lint gate
     if: ${{ always() }}
-    needs: [detect, lint_python, klayout_version_consistency]
+    needs: [detect, lint_python, klayout_version_consistency, ci_selftest]
     runs-on: ubuntu-latest
     steps:
       - name: Aggregate result

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,4 +1,4 @@
-#==========================================================================
+# ==========================================================================
 # Copyright 2024 IHP PDK Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,33 +13,43 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # SPDX-License-Identifier: Apache-2.0
-#==========================================================================
+# ==========================================================================
+
+# Python linting, per affected PDK, plus a PDK-independent klayout version
+# consistency check. `detect` picks the PDKs to lint (see .github/pdk-ci.yml);
+# the version check always runs; the always-run `gate` is the required check.
+# No KLayout needed here, so this does not use the pdk-run runner.
 
 name: Python Code Linting
 
+concurrency:
+  group: ${{ github.repository }}-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
-    paths:
-      - 'ihp-*/libs.tech/klayout/tech/drc/**'
-      - 'ihp-*/libs.tech/klayout/tech/lvs/**'
-      - 'ihp-*/libs.tech/klayout/python/*_pycell_lib/**'
-      - 'versions.txt'
-      - 'requirements.txt'
-      - '.flake8'
-      - '.github/workflows/linting.yml'
+  merge_group:
   workflow_dispatch:
 
-jobs:
-  lint_python:
-    runs-on: ubuntu-latest
+permissions:
+  contents: read
+  pull-requests: read
 
-    # One leg per PDK so a failure names the PDK it came from. The repo-wide
-    # `make lint-all` still lints every ihp-* at once for local use.
+jobs:
+  detect:
+    uses: ./.github/workflows/detect-affected-pdks.yml
+
+  lint_python:
+    needs: detect
+    if: ${{ needs.detect.outputs.any == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    # One leg per affected PDK so a failure names the PDK it came from. The
+    # repo-wide `make lint-all` still lints every ihp-* at once for local use.
     strategy:
       fail-fast: false
-      matrix:
-        pdk: [ihp-sg13g2, ihp-sg13cmos5l]
-
+      matrix: ${{ fromJSON(needs.detect.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -69,7 +79,11 @@ jobs:
           echo "OK: no forbidden characters in ${{ matrix.pdk }} PCell library"
 
   klayout_version_consistency:
+    # PDK-independent: versions.txt and requirements.txt are shared by every PDK,
+    # so this always runs and feeds the gate directly.
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Check klayout pin in requirements.txt matches versions.txt
@@ -97,3 +111,17 @@ jobs:
             exit 1
           fi
           echo "OK: klayout version is consistent ($VERSIONS_TXT)"
+
+  gate:
+    if: ${{ always() }}
+    needs: [detect, lint_python, klayout_version_consistency]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Aggregate result
+        run: |
+          echo "detect=${{ needs.detect.result }} lint=${{ needs.lint_python.result }} version=${{ needs.klayout_version_consistency.result }}"
+          if echo "${{ needs.detect.result }} ${{ needs.lint_python.result }} ${{ needs.klayout_version_consistency.result }}" \
+             | grep -qE "failure|cancelled"; then
+            echo "::error::Linting failed"; exit 1
+          fi
+          echo "Linting passed (or no affected PDK for this change)."

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -40,6 +40,8 @@ permissions:
 jobs:
   detect:
     uses: ./.github/workflows/detect-affected-pdks.yml
+    with:
+      test_class: lint
 
   lint_python:
     needs: detect

--- a/.github/workflows/lvs_regression.yml
+++ b/.github/workflows/lvs_regression.yml
@@ -39,6 +39,8 @@ permissions:
 jobs:
   detect:
     uses: ./.github/workflows/detect-affected-pdks.yml
+    with:
+      test_class: lvs
 
   lvs:
     needs: detect

--- a/.github/workflows/lvs_regression.yml
+++ b/.github/workflows/lvs_regression.yml
@@ -1,4 +1,4 @@
-#==========================================================================
+# ==========================================================================
 # Copyright 2024 IHP PDK Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # SPDX-License-Identifier: Apache-2.0
-#==========================================================================
+# ==========================================================================
+
+# LVS regression, per affected PDK. See drc_regression.yml and .github/pdk-ci.yml
+# for how `detect` decides which PDKs run and why the `gate` job is the required
+# check.
 
 name: LVS Regression Testing
 
@@ -23,58 +27,35 @@ concurrency:
 
 on:
   pull_request:
-    paths:
-      - 'ihp-*/libs.tech/klayout/tech/lvs/**'
-      - '.github/actions/setup-klayout/action.yml'
-      - '.github/workflows/lvs_regression.yml'
+  merge_group:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
-  lvs_regression:
+  detect:
+    uses: ./.github/workflows/detect-affected-pdks.yml
+
+  lvs:
+    needs: detect
+    if: ${{ needs.detect.outputs.any == 'true' }}
+    uses: ./.github/workflows/pdk-run.yml
+    with:
+      matrix: ${{ needs.detect.outputs.matrix }}
+      targets: "test-LVS-main test-LVS-SVS test-LVS-cmomi-checks test-LVS-cmomf-checks test-LVS-cells"
+
+  gate:
+    if: ${{ always() }}
+    needs: [detect, lvs]
     runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        pdk: [ihp-sg13g2, ihp-sg13cmos5l]
-
     steps:
-      - name: 🧾 Checkout repo
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: 🔧 Set up KLayout
-        uses: ./.github/actions/setup-klayout
-
-      - name: 🧪 Run KLayout LVS Regression
-        run: make test-LVS-main PDK=${{ matrix.pdk }}
-
-      - name: 🧪 Run Manual SVS Regression
-        run: make test-LVS-SVS PDK=${{ matrix.pdk }}
-
-      - name: 🧪 Run cap_cmomi LVS Checks
-        run: make test-LVS-cmomi-checks PDK=${{ matrix.pdk }}
-
-      - name: 🧪 Run cap_cmomf LVS Checks
-        run: make test-LVS-cmomf-checks PDK=${{ matrix.pdk }}
-
-  lvs_regression_cells:
-    runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        pdk: [ihp-sg13g2, ihp-sg13cmos5l]
-
-    steps:
-      - name: 🧾 Checkout repo
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: 🔧 Set up KLayout
-        uses: ./.github/actions/setup-klayout
-
-      - name: 🧪 Run LVS Regression for Cells
-        run: make test-LVS-cells PDK=${{ matrix.pdk }}
+      - name: Aggregate result
+        run: |
+          echo "detect=${{ needs.detect.result }} lvs=${{ needs.lvs.result }}"
+          if echo "${{ needs.detect.result }} ${{ needs.lvs.result }}" \
+             | grep -qE "failure|cancelled"; then
+            echo "::error::LVS regression failed"; exit 1
+          fi
+          echo "LVS regression passed (or no affected PDK for this change)."

--- a/.github/workflows/lvs_regression.yml
+++ b/.github/workflows/lvs_regression.yml
@@ -26,6 +26,8 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  push:
+    branches: [dev]
   pull_request:
   merge_group:
   workflow_dispatch:
@@ -47,6 +49,7 @@ jobs:
       targets: "test-LVS-main test-LVS-SVS test-LVS-cmomi-checks test-LVS-cmomf-checks test-LVS-cells"
 
   gate:
+    name: LVS gate
     if: ${{ always() }}
     needs: [detect, lvs]
     runs-on: ubuntu-latest

--- a/.github/workflows/pcell.yml
+++ b/.github/workflows/pcell.yml
@@ -41,6 +41,8 @@ permissions:
 jobs:
   detect:
     uses: ./.github/workflows/detect-affected-pdks.yml
+    with:
+      test_class: pcell
 
   pcell:
     needs: detect

--- a/.github/workflows/pcell.yml
+++ b/.github/workflows/pcell.yml
@@ -1,0 +1,63 @@
+# ==========================================================================
+# Copyright 2026 IHP PDK Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
+# ==========================================================================
+
+# PCell functional tests, per affected PDK. Runs the headless KLayout PCell
+# checks that live in each PDK's *_tests directory (library build, concurrent
+# load, PCell-DRC, native PCells, sprintf). Tests a PDK does not carry are
+# reported and skipped by make (skip-unless in ihp-common/pdk.mk), so the same
+# target list is safe for every PDK.
+
+name: PCell Functional Tests
+
+concurrency:
+  group: ${{ github.repository }}-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+  merge_group:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  detect:
+    uses: ./.github/workflows/detect-affected-pdks.yml
+
+  pcell:
+    needs: detect
+    if: ${{ needs.detect.outputs.any == 'true' }}
+    uses: ./.github/workflows/pdk-run.yml
+    with:
+      matrix: ${{ needs.detect.outputs.matrix }}
+      targets: "test-PCell-lib test-PCell-concurrency test-PCell-drc test-PCell-native test-PCell-sprintf"
+
+  gate:
+    if: ${{ always() }}
+    needs: [detect, pcell]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Aggregate result
+        run: |
+          echo "detect=${{ needs.detect.result }} pcell=${{ needs.pcell.result }}"
+          if echo "${{ needs.detect.result }} ${{ needs.pcell.result }}" \
+             | grep -qE "failure|cancelled"; then
+            echo "::error::PCell functional tests failed"; exit 1
+          fi
+          echo "PCell functional tests passed (or no affected PDK for this change)."

--- a/.github/workflows/pcell.yml
+++ b/.github/workflows/pcell.yml
@@ -28,6 +28,8 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  push:
+    branches: [dev]
   pull_request:
   merge_group:
   workflow_dispatch:
@@ -49,6 +51,7 @@ jobs:
       targets: "test-PCell-lib test-PCell-concurrency test-PCell-drc test-PCell-native test-PCell-sprintf"
 
   gate:
+    name: PCell gate
     if: ${{ always() }}
     needs: [detect, pcell]
     runs-on: ubuntu-latest

--- a/.github/workflows/pdk-run.yml
+++ b/.github/workflows/pdk-run.yml
@@ -56,5 +56,8 @@ jobs:
         uses: ./.github/actions/setup-klayout
 
       - name: Run make targets (${{ matrix.pdk }})
+        # -k (keep-going): run every target and still exit non-zero if any
+        # failed, so one failing target does not hide the result of the rest
+        # (e.g. a failing test-LVS-main must not skip test-LVS-cells).
         run: |
-          make ${{ inputs.targets }} PDK=${{ matrix.pdk }}
+          make -k ${{ inputs.targets }} PDK=${{ matrix.pdk }}

--- a/.github/workflows/pdk-run.yml
+++ b/.github/workflows/pdk-run.yml
@@ -1,0 +1,60 @@
+# ==========================================================================
+# Copyright 2026 IHP PDK Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
+# ==========================================================================
+
+# Reusable runner for the KLayout-based test classes (DRC, LVS, PCell). One
+# matrix leg per affected PDK; each leg sets up the pinned KLayout and runs the
+# given make targets for that PDK. `make` reports+succeeds (skip-unless in
+# ihp-common/pdk.mk) on any target a PDK does not carry, so the same target list
+# is safe for every PDK.
+#
+# Callers pass `matrix` from detect-affected-pdks.yml and only invoke this when
+# at least one PDK is affected (`any == 'true'`), so the matrix is never empty.
+
+name: pdk-run
+
+on:
+  workflow_call:
+    inputs:
+      matrix:
+        description: "JSON matrix (from detect-affected-pdks) of PDKs to run."
+        required: true
+        type: string
+      targets:
+        description: "Space-separated make targets to run for each PDK."
+        required: true
+        type: string
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(inputs.matrix) }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up KLayout
+        uses: ./.github/actions/setup-klayout
+
+      - name: Run make targets (${{ matrix.pdk }})
+        run: |
+          make ${{ inputs.targets }} PDK=${{ matrix.pdk }}

--- a/.github/workflows/sram_validation.yml
+++ b/.github/workflows/sram_validation.yml
@@ -29,6 +29,8 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  push:
+    branches: [dev]
   pull_request:
   merge_group:
   workflow_dispatch:
@@ -56,6 +58,13 @@ jobs:
               - 'ihp-sg13g2/libs.ref/sg13g2_sram/**'
               - 'ihp-sg13g2/libs.qa/sram/**'
               - '.github/workflows/sram_validation.yml'
+              # `make test-SRAM` builds the venv and runs through the shared
+              # Makefiles, so a change to any of these can change the result.
+              - 'Makefile'
+              - 'Makefile.*'
+              - 'ihp-common/**'
+              - 'requirements.txt'
+              - 'versions.txt'
 
   validate_sram:
     needs: changes
@@ -73,6 +82,7 @@ jobs:
         run: make test-SRAM PDK=ihp-sg13g2
 
   gate:
+    name: SRAM gate
     if: ${{ always() }}
     needs: [changes, validate_sram]
     runs-on: ubuntu-latest

--- a/.github/workflows/sram_validation.yml
+++ b/.github/workflows/sram_validation.yml
@@ -1,4 +1,4 @@
-#==========================================================================
+# ==========================================================================
 # Copyright 2026 IHP PDK Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,33 +13,75 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # SPDX-License-Identifier: Apache-2.0
-#==========================================================================
+# ==========================================================================
 
 # AI provenance: Generated with OpenAI Codex (GPT-5).
 
+# SRAM validation. Only ihp-sg13g2 ships an SRAM, so this is g2-only and does not
+# use the per-PDK matrix. It runs on every PR (so the required `gate` check is
+# never left pending), decides internally whether the SRAM sources changed, and
+# validates through `make test-SRAM` for a single, make-driven entry point.
+
 name: SRAM validation
+
+concurrency:
+  group: ${{ github.repository }}-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 on:
   pull_request:
-    paths:
-      - 'ihp-sg13g2/libs.ref/sg13g2_sram/**'
-      - 'ihp-sg13g2/libs.qa/sram/**'
-      - '.github/workflows/sram_validation.yml'
+  merge_group:
   workflow_dispatch:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
-  validate_sram:
+  changes:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      sram: ${{ steps.filter.outputs.sram }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: filter
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        with:
+          filters: |
+            sram:
+              - 'ihp-sg13g2/libs.ref/sg13g2_sram/**'
+              - 'ihp-sg13g2/libs.qa/sram/**'
+              - '.github/workflows/sram_validation.yml'
+
+  validate_sram:
+    needs: changes
+    if: ${{ needs.changes.outputs.sram == 'true' || github.event_name != 'pull_request' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Install validation tools
         run: |
           sudo apt-get update
           sudo apt-get install --yes iverilog
-          python3 -m pip install gdstk
       - name: Validate SRAM views and Verilog models
+        run: make test-SRAM PDK=ihp-sg13g2
+
+  gate:
+    if: ${{ always() }}
+    needs: [changes, validate_sram]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Aggregate result
         run: |
-          python3 ihp-sg13g2/libs.qa/sram/validate_sram.py
+          echo "changes=${{ needs.changes.result }} validate_sram=${{ needs.validate_sram.result }}"
+          if echo "${{ needs.changes.result }} ${{ needs.validate_sram.result }}" \
+             | grep -qE "failure|cancelled"; then
+            echo "::error::SRAM validation failed"; exit 1
+          fi
+          echo "SRAM validation passed (or SRAM sources unchanged)."

--- a/.github/workflows/symlink_check.yml
+++ b/.github/workflows/symlink_check.yml
@@ -25,6 +25,8 @@ concurrency:
 # so moving or renaming a file anywhere in the repository can break one. The
 # check takes seconds, so it runs on every pull request.
 on:
+  push:
+    branches: [dev]
   pull_request:
   merge_group:
   workflow_dispatch:

--- a/.github/workflows/symlink_check.yml
+++ b/.github/workflows/symlink_check.yml
@@ -26,6 +26,7 @@ concurrency:
 # check takes seconds, so it runs on every pull request.
 on:
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -176,6 +176,8 @@ cython_debug/
 *.lvsdb
 unit_tests_*
 cap_cmomi_consistency_run/
+cap_cmomi_sweep_run/
+cap_cmomf_sweep_run/
 drc_run_*
 drc_cells_*
 lvs_run_*

--- a/ihp-common/pdk.mk
+++ b/ihp-common/pdk.mk
@@ -36,9 +36,11 @@ VENV := $(TOP_DIR)/actions_venv/bin/activate
 # Paths are relative to the PDK directory. Make runs in the repository root,
 # so every use below is either prefixed with $(PDK_DIR) or reached after the
 # `cd $(PDK_DIR)` that skip-unless performs.
-DRC_TESTS  := libs.tech/klayout/tech/drc/testing
-LVS_TESTS  := libs.tech/klayout/tech/lvs/testing
-SRAM_TESTS := libs.qa/sram
+DRC_TESTS   := libs.tech/klayout/tech/drc/testing
+LVS_TESTS   := libs.tech/klayout/tech/lvs/testing
+SRAM_TESTS  := libs.qa/sram
+# sg13g2 -> sg13g2_tests, sg13cmos5l -> sg13cmos5l_tests
+PCELL_TESTS := libs.tech/klayout/$(PDK:ihp-%=%)_tests
 
 LVS_MAKE = $(MAKE) --no-print-directory -C $(PDK_DIR)/$(LVS_TESTS)
 
@@ -151,6 +153,54 @@ test-SRAM: env
 	  echo "Validating $(PDK_NAME) SRAM views and Verilog models"; \
 	  python3 $(SRAM_TESTS)/validate_sram.py)
 
+#=================================
+# ------ PCELL FUNCTIONAL ---------
+#=================================
+
+# Functional PCell checks living in each PDK's <pdk>_tests directory. Every
+# target skips (report+succeed) on a PDK that does not carry that test file, so
+# the same target list is safe for every PDK in CI. The KLayout-driven ones run
+# headless (klayout -zz -r) with a fresh KLAYOUT_HOME so a salt-installed IHP PDK
+# in the user's ~/.klayout cannot shadow the technology under test, and from a
+# throwaway working directory because pycell_test.py writes an SG13_dev.gds next
+# to the CWD.
+
+.ONESHELL:
+test-PCell-lib: env
+	$(call skip-unless,$(PCELL_TESTS)/pycell_test.py,\
+	  echo "Building the $(PDK_NAME) PCell library"; \
+	  cd "$$(mktemp -d)"; \
+	  KLAYOUT_HOME="$$(mktemp -d)" KLAYOUT_PATH=$(PDK_DIR)/libs.tech/klayout \
+	    klayout -zz -r $(PDK_DIR)/$(PCELL_TESTS)/pycell_test.py)
+
+.ONESHELL:
+test-PCell-concurrency: env
+	$(call skip-unless,$(PCELL_TESTS)/pycell_concurrency_test.py,\
+	  echo "Running the $(PDK_NAME) PCell concurrency test"; \
+	  python3 $(PDK_DIR)/$(PCELL_TESTS)/pycell_concurrency_test.py)
+
+.ONESHELL:
+test-PCell-drc: env
+	$(call skip-unless,$(PCELL_TESTS)/pycell_drc_test.py,\
+	  echo "Running the $(PDK_NAME) PCell DRC test"; \
+	  cd "$$(mktemp -d)"; \
+	  KLAYOUT_HOME="$$(mktemp -d)" KLAYOUT_PATH=$(PDK_DIR)/libs.tech/klayout \
+	    klayout -zz -r $(PDK_DIR)/$(PCELL_TESTS)/pycell_drc_test.py)
+
+.ONESHELL:
+test-PCell-native: env
+	$(call skip-unless,$(PCELL_TESTS)/native_pcell_test.py,\
+	  echo "Running the $(PDK_NAME) native PCell test"; \
+	  cd "$$(mktemp -d)"; \
+	  KLAYOUT_HOME="$$(mktemp -d)" KLAYOUT_PATH=$(PDK_DIR)/libs.tech/klayout \
+	    klayout -zz -r $(PDK_DIR)/$(PCELL_TESTS)/native_pcell_test.py)
+
+.ONESHELL:
+test-PCell-sprintf: env
+	$(call skip-unless,$(PCELL_TESTS)/sprintf_test.py,\
+	  echo "Running the $(PDK_NAME) sprintf regression"; \
+	  python3 $(PDK_DIR)/$(PCELL_TESTS)/sprintf_test.py)
+
 #==========================
 # --------- HELP ----------
 #==========================
@@ -171,6 +221,13 @@ help::
 	@echo "... test-LVS-cells             (Run LVS for all standard cells                )"
 	@echo "... test-LVS-switch            (Run simple LVS switching test                 )"
 	@echo "... test-SRAM                  (Validate SRAM views and Verilog models        )"
+	@echo "... test-PCell-lib             (Build the PCell library headless              )"
+	@echo "... test-PCell-concurrency     (Load the PCell library from many processes    )"
+	@echo "... test-PCell-drc             (DRC-clean every PCell                         )"
+	@echo "... test-PCell-native          (Check the native (non-python) PCells          )"
+	@echo "... test-PCell-sprintf         (sprintf helper regression                     )"
 
 .PHONY: lint lint_python test-DRC-main test-DRC-cells test-LVS-main \
-        test-LVS-cells test-LVS-switch test-SRAM help
+        test-LVS-cells test-LVS-switch test-SRAM \
+        test-PCell-lib test-PCell-concurrency test-PCell-drc \
+        test-PCell-native test-PCell-sprintf help

--- a/ihp-sg13cmos5l/libs.tech/klayout/sg13cmos5l_tests/cap_cmomf_sweep.py
+++ b/ihp-sg13cmos5l/libs.tech/klayout/sg13cmos5l_tests/cap_cmomf_sweep.py
@@ -73,10 +73,14 @@ EPSILON = 0.001
 
 # Rules that fire on any bare device cell because the surroundings are absent:
 # an isolated capacitor has no Activ, no GatPoly and no TopMetal1 anywhere, so
-# the global density rules have nothing to measure. Anything outside this set
-# is a real violation of the device itself.
+# the global density rules have nothing to measure -- both their minimum (Mn.j)
+# and maximum (Mn.k) sides. Which side a config trips depends on its bounding
+# box and the KLayout version, so tolerate the whole family. Anything outside
+# this set is a real violation of the device itself.
 DRC_EXPECTED_VIOLATIONS = {
-    "AFil.g", "GFil.g", "TM1.c", "M1.j", "M2.j", "M3.j", "M4.j",
+    "AFil.g", "GFil.g", "TM1.c",
+    "M1.j", "M2.j", "M3.j", "M4.j",
+    "M1.k", "M2.k", "M3.k", "M4.k",
 }
 
 # name -> pcell params. The metal stack drives the top-layer finger

--- a/ihp-sg13cmos5l/libs.tech/klayout/sg13cmos5l_tests/cap_cmomi_sweep.py
+++ b/ihp-sg13cmos5l/libs.tech/klayout/sg13cmos5l_tests/cap_cmomi_sweep.py
@@ -48,10 +48,15 @@ TECH_NAME = "sg13cmos5l"
 
 # Rules that fire on any bare device cell because the surroundings are absent:
 # an isolated capacitor has no Activ, no GatPoly and no TopMetal1 anywhere, so
-# the global density rules have nothing to measure. Anything outside this set
-# is a real violation of the device itself.
+# the global density rules have nothing to measure -- both their minimum (Mn.j)
+# and maximum (Mn.k) sides. Which side a config trips depends on its bounding
+# box and the KLayout version (e.g. same_min pushes M3/M4 over the maximum),
+# so tolerate the whole family. Anything outside this set is a real violation
+# of the device itself.
 DRC_EXPECTED_VIOLATIONS = {
-    "AFil.g", "GFil.g", "TM1.c", "M1.j", "M2.j", "M3.j", "M4.j",
+    "AFil.g", "GFil.g", "TM1.c",
+    "M1.j", "M2.j", "M3.j", "M4.j",
+    "M1.k", "M2.k", "M3.k", "M4.k",
 }
 
 # name -> pcell params. 'two_terminal' marks feeds that must extract as a cap.

--- a/ihp-sg13g2/libs.tech/klayout/sg13g2_tests/native_pcell_test.py
+++ b/ihp-sg13g2/libs.tech/klayout/sg13g2_tests/native_pcell_test.py
@@ -73,8 +73,10 @@ def add_via_testcases(layout: pya.Layout,
 
     region = pya.Region()
 
-    from sg13g2_pycell_lib.sg13_tech_info import TechInfo
-    via_names = [via.name for via in TechInfo.instance().vias]
+    from cni.tech import Tech
+    from sg13g2_pycell_lib.sg13_tech_info import TechInfoFactory
+    tech_info = TechInfoFactory.tech_info_for_tech(Tech.get("SG13_dev"))
+    via_names = [via.name for via in tech_info.vias]
     for via in via_names:
         for nx, ny in ((1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (1, 2), (4, 2), (5, 2), (1, 4), (2, 4), (2, 5)):
             inst = add_cell_and_instance(

--- a/ihp-sg13g2/libs.tech/klayout/sg13g2_tests/pycell_drc_test.py
+++ b/ihp-sg13g2/libs.tech/klayout/sg13g2_tests/pycell_drc_test.py
@@ -73,10 +73,12 @@ def add_via_stack_testcases(layout: pya.Layout,
 
     region = pya.Region()
 
-    from sg13g2_pycell_lib.sg13_tech_info import TechInfo
-    
+    from cni.tech import Tech
+    from sg13g2_pycell_lib.sg13_tech_info import TechInfoFactory
+    tech_info = TechInfoFactory.tech_info_for_tech(Tech.get("SG13_dev"))
+
     # add single vias
-    for via in TechInfo.instance().vias:
+    for via in tech_info.vias:
         for (vn_nx, vn_ny), (vt1_nx, vt1_ny), (vt2_nx, vt1_ny) \
          in (((1,1), (1,1), (1,1)), \
              ((2,2), (1,1), (1,1)), \


### PR DESCRIPTION
The repo now holds two PDKs, ihp-sg13g2 and ihp-sg13cmos5l. cmos5l reuses g2's files through symlinks, so a g2 change can affect cmos5l, but a cmos5l change never affects g2. Today the workflows run both PDKs on any change, and changes to the shared build files (pdk.mk, Makefile, versions.txt) trigger nothing. This PR fixes both.

What runs now:
- a change under ihp-sg13g2 runs g2 and cmos5l
- a change to a cmos5l-only file runs cmos5l
- a change to a shared file runs every PDK

How it works: one map file, `.github/pdk-ci.yml`, lists each PDK and what it depends on. A small, unit-tested script turns the changed files into the list of PDKs to run, and the DRC, LVS and lint workflows read that list. Each workflow ends in one always-run "gate" job. Adding a third PDK is one entry in the map.

Also new: the KLayout PCell tests now run in CI (library build, concurrent load, PCell-DRC, native PCells, sprintf), and a separate manual/weekly workflow runs the heavy suites (cap sweeps, cap_cmomi model, gnucap).

Two old test bugs were fixed along the way: the PCell DRC and native tests called a removed API, and the cap sweeps did not accept the maximum metal-density rules.

Branch protection (needs a repo admin, after merge): mark the per-workflow "gate" jobs as the required checks (DRC, LVS, lint, PCell), not the per-PDK jobs under them. Each "gate" job always runs and reports a single pass or fail for its whole workflow, so it still reports when a change skips a PDK. A per-PDK job does not run when its PDK is not affected, and a required check that never runs would block every PR.

Closes #1158, #1204.

Provides the CI base that these issues build on: #1203 (RTL-to-GDS workflow), #1189 (qucs-s integration), #1205 (magic bondpad LEF test), and part of #1171, #1182, #1183, #1185 and #1206.

Follow-ups surfaced while building this CI (tracked separately, not fixed here):
- #1210: the sealring PCell fails to coerce its default length "6.0u".
- #1211: the PCell tests can report success even when the run failed; they become real gates once #1210 is fixed and the tests fail on ERROR.
- #1212: the cmos5l DRC regression counts rules that were never tested as a pass; harden together with #1184.
